### PR TITLE
Meta no longer clones - fixes #233

### DIFF
--- a/examples/configmap_reflector.rs
+++ b/examples/configmap_reflector.rs
@@ -12,11 +12,8 @@ fn spawn_periodic_reader(reader: Store<ConfigMap>) {
         loop {
             // Periodically read our state
             tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
-            let cms: Vec<_> = reader
-                .state()
-                .iter()
-                .map(|obj| Meta::name(obj).to_string())
-                .collect();
+            let state = reader.state();
+            let cms: Vec<_> = state.iter().map(Meta::name).collect();
             info!("Current configmaps: {:?}", cms);
         }
     });

--- a/examples/configmap_reflector.rs
+++ b/examples/configmap_reflector.rs
@@ -12,7 +12,11 @@ fn spawn_periodic_reader(reader: Store<ConfigMap>) {
         loop {
             // Periodically read our state
             tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
-            let cms: Vec<_> = reader.state().iter().map(|obj| Meta::name(obj).clone()).collect();
+            let cms: Vec<_> = reader
+                .state()
+                .iter()
+                .map(|obj| Meta::name(obj).to_string())
+                .collect();
             info!("Current configmaps: {:?}", cms);
         }
     });

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
             info!(
                 "Deleting {}: ({:?})",
                 Meta::name(&o),
-                o.status.unwrap().conditions.unwrap().last()
+                o.status.as_ref().unwrap().conditions.as_ref().unwrap().last()
             );
         })
         .map_right(|s| {
@@ -68,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
     let patch_params = PatchParams::default();
     match crds.create(&pp, &foocrd).await {
         Ok(o) => {
-            info!("Created {} ({:?})", Meta::name(&o), o.status.unwrap());
+            info!("Created {} ({:?})", Meta::name(&o), o.status.as_ref().unwrap());
             debug!("Created CRD: {:?}", o.spec);
         }
         Err(kube::Error::Api(ae)) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
@@ -215,7 +215,7 @@ async fn main() -> anyhow::Result<()> {
             info!(
                 "Deleting {} CRD definition: {:?}",
                 Meta::name(&o),
-                o.status.unwrap().conditions.unwrap().last()
+                o.status.as_ref().unwrap().conditions.as_ref().unwrap().last()
             );
         }
         Right(status) => {

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -32,7 +32,11 @@ async fn main() -> anyhow::Result<()> {
         loop {
             // Periodically read our state
             tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
-            let crds = reader.state().iter().map(Meta::name).collect::<Vec<_>>();
+            let crds = reader
+                .state()
+                .iter()
+                .map(|o| Meta::name(o).clone())
+                .collect::<Vec<_>>();
             info!("Current crds: {:?}", crds);
         }
     });

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -35,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
             let crds = reader
                 .state()
                 .iter()
-                .map(|o| Meta::name(o).clone())
+                .map(|o| Meta::name(o).to_string())
                 .collect::<Vec<_>>();
             info!("Current crds: {:?}", crds);
         }

--- a/examples/deployment_reflector.rs
+++ b/examples/deployment_reflector.rs
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move {
         loop {
             // Periodically read our state
-            let deploys: Vec<_> = reader.state().iter().map(Meta::name).collect();
+            let deploys: Vec<_> = reader.state().iter().map(|o| Meta::name(o).clone()).collect();
             info!("Current deploys: {:?}", deploys);
             tokio::time::delay_for(std::time::Duration::from_secs(30)).await;
         }

--- a/examples/deployment_reflector.rs
+++ b/examples/deployment_reflector.rs
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move {
         loop {
             // Periodically read our state
-            let deploys: Vec<_> = reader.state().iter().map(|o| Meta::name(o).clone()).collect();
+            let deploys: Vec<_> = reader.state().iter().map(|o| Meta::name(o).to_string()).collect();
             info!("Current deploys: {:?}", deploys);
             tokio::time::delay_for(std::time::Duration::from_secs(30)).await;
         }

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -25,7 +25,11 @@ async fn main() -> anyhow::Result<()> {
     // Periodically read our state in the background
     tokio::spawn(async move {
         loop {
-            let nodes = reader.state().iter().map(Meta::name).collect::<Vec<_>>();
+            let nodes = reader
+                .state()
+                .iter()
+                .map(|o| Meta::name(o).clone())
+                .collect::<Vec<_>>();
             info!("Current {} nodes: {:?}", nodes.len(), nodes);
             tokio::time::delay_for(std::time::Duration::from_secs(10)).await;
         }

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
             let nodes = reader
                 .state()
                 .iter()
-                .map(|o| Meta::name(o).clone())
+                .map(|o| Meta::name(o).to_string())
                 .collect::<Vec<_>>();
             info!("Current {} nodes: {:?}", nodes.len(), nodes);
             tokio::time::delay_for(std::time::Duration::from_secs(10)).await;

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
 
 // A simple node problem detector
 async fn check_for_node_failures(events: &Api<Event>, o: Node) -> anyhow::Result<()> {
-    let name = Meta::name(&o).clone();
+    let name = Meta::name(&o).to_string();
     // Nodes often modify a lot - only print broken nodes
     if let Some(true) = o.spec.unwrap().unschedulable {
         let failed = o

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
 
 // A simple node problem detector
 async fn check_for_node_failures(events: &Api<Event>, o: Node) -> anyhow::Result<()> {
-    let name = Meta::name(&o);
+    let name = Meta::name(&o).clone();
     // Nodes often modify a lot - only print broken nodes
     if let Some(true) = o.spec.unwrap().unschedulable {
         let failed = o

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -22,6 +22,6 @@ pub mod utils;
 pub mod watcher;
 
 pub use controller::{applier, Controller};
-pub use reflector::reflector;
+pub use reflector::{reflector, Store};
 pub use scheduler::scheduler;
 pub use watcher::watcher;

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -61,7 +61,7 @@ impl<K: Resource> ObjectRef<K> {
         Self {
             kind: (),
             name: obj.name().to_string(),
-            namespace: obj.namespace().clone(),
+            namespace: obj.namespace().map(String::from),
         }
     }
 

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -60,8 +60,8 @@ impl<K: Resource> ObjectRef<K> {
     {
         Self {
             kind: (),
-            name: obj.name(),
-            namespace: obj.namespace(),
+            name: obj.name().to_string(),
+            namespace: obj.namespace().clone(),
         }
     }
 

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -129,14 +129,14 @@ async fn step_trampolined<K: Meta + Clone + DeserializeOwned + Send + 'static>(
             mut stream,
         } => match stream.next().await {
             Some(Ok(WatchEvent::Added(obj))) | Some(Ok(WatchEvent::Modified(obj))) => {
-                let resource_version = obj.resource_ver().unwrap();
+                let resource_version = obj.resource_ver().clone().unwrap();
                 (Some(Ok(Event::Applied(obj))), State::Watching {
                     resource_version,
                     stream,
                 })
             }
             Some(Ok(WatchEvent::Deleted(obj))) => {
-                let resource_version = obj.resource_ver().unwrap();
+                let resource_version = obj.resource_ver().clone().unwrap();
                 (Some(Ok(Event::Deleted(obj))), State::Watching {
                     resource_version,
                     stream,

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -129,14 +129,14 @@ async fn step_trampolined<K: Meta + Clone + DeserializeOwned + Send + 'static>(
             mut stream,
         } => match stream.next().await {
             Some(Ok(WatchEvent::Added(obj))) | Some(Ok(WatchEvent::Modified(obj))) => {
-                let resource_version = obj.resource_ver().clone().unwrap();
+                let resource_version = obj.resource_ver().unwrap().to_string();
                 (Some(Ok(Event::Applied(obj))), State::Watching {
                     resource_version,
                     stream,
                 })
             }
             Some(Ok(WatchEvent::Deleted(obj))) => {
-                let resource_version = obj.resource_ver().clone().unwrap();
+                let resource_version = obj.resource_ver().unwrap().to_string();
                 (Some(Ok(Event::Deleted(obj))), State::Watching {
                     resource_version,
                     stream,

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -11,17 +11,15 @@ use serde::{Deserialize, Serialize};
 /// And these optional properties:
 /// - .metadata.namespace
 /// - .metadata.resource_version
-///
-/// This avoids a bunch of the unnecessary unwrap mechanics for apps
 pub trait Meta: Metadata {
     /// Metadata that all persisted resources must have
     fn meta(&self) -> &ObjectMeta;
     /// The name of the resource
-    fn name(&self) -> String;
+    fn name(&self) -> &String;
     /// The namespace the resource is in
-    fn namespace(&self) -> Option<String>;
+    fn namespace(&self) -> &Option<String>;
     /// Tthe resource version
-    fn resource_ver(&self) -> Option<String>;
+    fn resource_ver(&self) -> &Option<String>;
 }
 
 /// Implement accessor trait for any ObjectMeta-using Kubernetes Resource
@@ -33,16 +31,16 @@ where
         self.metadata()
     }
 
-    fn name(&self) -> String {
-        self.meta().name.clone().expect("kind has metadata.name")
+    fn name(&self) -> &String {
+        self.meta().name.as_ref().expect("kind has metadata.name")
     }
 
-    fn resource_ver(&self) -> Option<String> {
-        self.meta().resource_version.clone()
+    fn resource_ver(&self) -> &Option<String> {
+        &self.meta().resource_version
     }
 
-    fn namespace(&self) -> Option<String> {
-        self.meta().namespace.clone()
+    fn namespace(&self) -> &Option<String> {
+        &self.meta().namespace
     }
 }
 

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -36,11 +36,11 @@ where
     }
 
     fn resource_ver(&self) -> Option<&str> {
-        self.meta().resource_version.as_ref().map(|rv| rv.as_ref())
+        self.meta().resource_version.as_deref()
     }
 
     fn namespace(&self) -> Option<&str> {
-        self.meta().namespace.as_ref().map(|ns| ns.as_ref())
+        self.meta().namespace.as_deref()
     }
 }
 

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -15,11 +15,11 @@ pub trait Meta: Metadata {
     /// Metadata that all persisted resources must have
     fn meta(&self) -> &ObjectMeta;
     /// The name of the resource
-    fn name(&self) -> &String;
+    fn name(&self) -> &str;
     /// The namespace the resource is in
-    fn namespace(&self) -> &Option<String>;
+    fn namespace(&self) -> Option<&str>;
     /// Tthe resource version
-    fn resource_ver(&self) -> &Option<String>;
+    fn resource_ver(&self) -> Option<&str>;
 }
 
 /// Implement accessor trait for any ObjectMeta-using Kubernetes Resource
@@ -31,16 +31,16 @@ where
         self.metadata()
     }
 
-    fn name(&self) -> &String {
+    fn name(&self) -> &str {
         self.meta().name.as_ref().expect("kind has metadata.name")
     }
 
-    fn resource_ver(&self) -> &Option<String> {
-        &self.meta().resource_version
+    fn resource_ver(&self) -> Option<&str> {
+        self.meta().resource_version.as_ref().map(|rv| rv.as_ref())
     }
 
-    fn namespace(&self) -> &Option<String> {
-        &self.meta().namespace
+    fn namespace(&self) -> Option<&str> {
+        self.meta().namespace.as_ref().map(|ns| ns.as_ref())
     }
 }
 

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -133,7 +133,7 @@ where
                     Ok(WatchEvent::Added(o)) | Ok(WatchEvent::Modified(o)) | Ok(WatchEvent::Deleted(o)) => {
                         // always store the last seen resourceVersion
                         if let Some(nv) = Meta::resource_ver(o) {
-                            *version.lock().await = nv.clone();
+                            *version.lock().await = nv.to_string();
                         }
                     }
                     Ok(WatchEvent::Bookmark(bm)) => {

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -252,8 +252,8 @@ impl ToString for ObjectId {
 impl ObjectId {
     fn key_for<K: Meta>(o: &K) -> Self {
         ObjectId {
-            name: Meta::name(o),
-            namespace: Meta::namespace(o),
+            name: Meta::name(o).to_string(),
+            namespace: Meta::namespace(o).clone(),
         }
     }
 }

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -117,7 +117,7 @@ where
                     // always store the last seen resourceVersion
                     if let Some(nv) = Meta::resource_ver(o) {
                         trace!("Updating reflector version for {} to {}", kind, nv);
-                        state.version = nv.clone();
+                        state.version = nv.to_string();
                     }
                 }
                 WatchEvent::Bookmark(bm) => {
@@ -253,7 +253,7 @@ impl ObjectId {
     fn key_for<K: Meta>(o: &K) -> Self {
         ObjectId {
             name: Meta::name(o).to_string(),
-            namespace: Meta::namespace(o).clone(),
+            namespace: Meta::namespace(o).map(String::from),
         }
     }
 }


### PR DESCRIPTION
As this is now causing more congestion on shared references (as seen in the examples), it makes it awkward when used with option heavy k8s_openapi.

If k8s_openapi implements https://github.com/Arnavion/k8s-openapi/issues/72 then this will feel a lot less awkward and should almost certainly be merged then.

At any rate, wanted to see how this felt. Going to leave this one open for discussion for a bit.