### PR TITLE
Add kube-test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "kube-core",
   "kube-derive",
   "kube-runtime",
+  "kube-test",
 
   # internal
   "tests",

--- a/kube-test/Cargo.toml
+++ b/kube-test/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "kube-test"
+description = "Testing utilities for kube"
+version = "0.57.0"
+authors = ["kazk <kazk.dev@gmail.com>"]
+edition = "2018"
+license = "Apache-2.0"
+repository = "https://github.com/clux/kube-rs"
+readme = "../README.md"
+keywords = ["kubernetes", "kube", "test"]
+categories = ["testing"]
+
+[dependencies]
+kube = { path = "../kube", version = "^0.57.0", default-features = false, features = ["client"] }
+futures = "0.3.8"
+tokio = { version = "1.0.1", features = ["time"] }
+serde = "1.0.118"
+serde_yaml = "0.8.17"
+thiserror = "1.0.23"
+tracing = { version = "0.1.25", features = ["log"] }
+xid = "1.0.0"
+
+[dependencies.k8s-openapi]
+version = "0.12.0"
+default-features = false
+features = []
+
+[dev-dependencies.k8s-openapi]
+version = "0.12.0"
+default-features = false
+features = ["v1_20"]

--- a/kube-test/src/k3d.rs
+++ b/kube-test/src/k3d.rs
@@ -1,0 +1,222 @@
+//! Test helper to create a temporary k3d cluster.
+use std::{convert::TryFrom, process::Command};
+
+use kube::{config::Kubeconfig, Client, Config};
+
+/// Struct to manage a temporary k3d cluster.
+#[derive(Debug, Default)]
+pub struct TestEnv {
+    // The name of the temporary cluster.
+    name: String,
+    // Kubeconfig of the temporary cluster.
+    kubeconfig: Kubeconfig,
+}
+
+impl TestEnv {
+    /// Builder for configuring the test environemnt.
+    pub fn builder() -> TestEnvBuilder {
+        Default::default()
+    }
+
+    /// Create the default minimal test environment.
+    pub fn new() -> Self {
+        Self::builder().build()
+    }
+
+    fn delete(&mut self) {
+        tracing::info!("Deleting k3d cluster {}...", &self.name);
+        let status = Command::new("k3d")
+            .args(&["cluster", "delete", &self.name])
+            .status()
+            .expect("k3d cluster delete failed");
+        assert!(
+            status.success(),
+            "k3d cluster delete failed. cluster {} may still exist",
+            self.name
+        );
+    }
+
+    /// Create a new `Client` configured for the temporary server.
+    pub async fn client(&self) -> Client {
+        assert_eq!(
+            self.kubeconfig.clusters.len(),
+            1,
+            "kubeconfig only contains the temporary cluster"
+        );
+        assert_eq!(
+            self.kubeconfig
+                .clusters
+                .get(0)
+                .unwrap()
+                .name
+                .as_str()
+                .strip_prefix("k3d-")
+                .unwrap(),
+            self.name,
+            "kubeconfig only contains the temporary cluster"
+        );
+
+        let config = Config::from_custom_kubeconfig(self.kubeconfig.clone(), &Default::default())
+            .await
+            .expect("valid kubeconfig");
+        Client::try_from(config).expect("client")
+    }
+}
+
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        self.delete();
+    }
+}
+
+/// Builder for [`TestEnv`] to customize the environment.
+#[derive(Debug)]
+pub struct TestEnvBuilder {
+    /// The number of servers. Default: 1
+    servers: usize,
+    /// The number of agents. Default: 0
+    agents: usize,
+    /// Inject the Host IP as `host.k3d.internal` into the containers and CoreDNS.
+    /// Default: false
+    host_ip_injection: bool,
+    /// Create an image volume for importing images.
+    /// Default: false
+    create_image_volume: bool,
+    /// Create a `LoadBalancer` in front of the server nodes.
+    /// Default: false
+    create_load_balancer: bool,
+    /// Set `--verbose` flag. Default: false
+    verbose: bool,
+    /// Specify k3s version to use in format `v1.20.6`. Default: None.
+    version: Option<String>,
+}
+
+impl Default for TestEnvBuilder {
+    fn default() -> Self {
+        Self {
+            servers: 1,
+            agents: 0,
+            host_ip_injection: false,
+            create_image_volume: false,
+            create_load_balancer: false,
+            verbose: false,
+            version: None,
+        }
+    }
+}
+
+impl TestEnvBuilder {
+    /// Set the number of servers in the temporary cluster.
+    pub fn servers(&mut self, servers: usize) -> &mut Self {
+        self.servers = servers;
+        self
+    }
+
+    /// Set the number of agents in the temporary cluster.
+    pub fn agents(&mut self, agents: usize) -> &mut Self {
+        self.agents = agents;
+        self
+    }
+
+    /// Enable host ip injection.
+    pub fn inject_host_ip(&mut self) -> &mut Self {
+        self.host_ip_injection = true;
+        self
+    }
+
+    /// Create image volume.
+    pub fn with_image_volume(&mut self) -> &mut Self {
+        self.create_image_volume = true;
+        self
+    }
+
+    /// Create load balancer.
+    pub fn with_load_balancer(&mut self) -> &mut Self {
+        self.create_load_balancer = true;
+        self
+    }
+
+    /// Set `verbose` flag.
+    pub fn verbose(&mut self) -> &mut Self {
+        self.verbose = true;
+        self
+    }
+
+    /// Set the k3s version to use. The version should be in the form `v1.20.6`.
+    pub fn k3s_version<T: Into<String>>(&mut self, version: T) -> &mut Self {
+        self.version = Some(version.into());
+        self
+    }
+
+    /// Create the test environment.
+    pub fn build(&self) -> TestEnv {
+        let name = xid::new().to_string();
+        let servers = format!("--servers={}", self.servers);
+        let agents = format!("--agents={}", self.agents);
+        let mut args = vec![
+            "cluster",
+            "create",
+            &name,
+            "--wait",
+            // Don't change `~/.kube/config`
+            "--kubeconfig-update-default=false",
+            "--kubeconfig-switch-context=false",
+            // Disable to avoid having to create the default service account in each test.
+            // > we're keeping this disabled because if enabled, default SA is
+            // > missing which would force all tests to create one
+            // > in normal apiserver operation this SA is created by controller, but that is
+            // > not run in integration environment
+            // > https://git.io/JZKFC
+            "--k3s-server-arg",
+            "--kube-apiserver-arg=disable-admission-plugins=ServiceAccount",
+            // Disable components and features
+            "--k3s-server-arg",
+            "--disable=servicelb",
+            "--k3s-server-arg",
+            "--disable=traefik",
+            "--k3s-server-arg",
+            "--disable=metrics-server",
+            "--k3s-server-arg",
+            "--disable-cloud-controller",
+            "--no-rollback",
+            &servers,
+            &agents,
+        ];
+        if self.verbose {
+            args.push("--verbose");
+        }
+        if !self.host_ip_injection {
+            args.push("--no-hostip");
+        }
+        if !self.create_image_volume {
+            args.push("--no-image-volume");
+        }
+        if !self.create_load_balancer {
+            args.push("--no-lb");
+        }
+
+        let mut args = args.into_iter().map(Into::into).collect::<Vec<_>>();
+        if let Some(version) = &self.version {
+            args.push(format!("--image=rancher/k3s:{}-k3s1", version));
+        }
+
+        let status = Command::new("k3d")
+            .args(&args)
+            .status()
+            .expect("k3d cluster create");
+        assert!(status.success(), "failed to create k3d cluster");
+
+        // Output the cluster's kubeconfig to stdout and store it.
+        let stdout = Command::new("k3d")
+            .args(&["kubeconfig", "get", &name])
+            .output()
+            .expect("k3d kubeconfig get failed")
+            .stdout;
+        let stdout = std::str::from_utf8(&stdout).expect("valid string");
+
+        TestEnv {
+            name,
+            kubeconfig: serde_yaml::from_str(stdout).expect("valid kubeconfig"),
+        }
+    }
+}

--- a/kube-test/src/lib.rs
+++ b/kube-test/src/lib.rs
@@ -1,0 +1,129 @@
+//! Test helper for kube.
+use std::time::Duration;
+
+use futures::{StreamExt, TryStreamExt};
+use k8s_openapi::{
+    api::core::v1::ServiceAccount,
+    apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+};
+use kube::{
+    api::{ListParams, WatchEvent},
+    Api, Client, CustomResourceExt, Resource,
+};
+use thiserror::Error;
+use tokio::time;
+
+pub mod k3d;
+
+/// Test helper errors.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("timed out waiting for cluster readiness")]
+    ClusterNotReady,
+    #[error("failed to create CRD")]
+    CreateCustomResourceDefinition(#[source] kube::Error),
+    #[error("failed to watch CRD")]
+    WatchCustomResourceDefinition(#[source] kube::Error),
+    #[error("failed to resolve CRD watch event")]
+    ResolveCustomResourceDefinitionWatchEvent(#[source] kube::Error),
+    #[error("timed out waiting for CRD Established condition")]
+    CustomResourceDefinitionNotEstablished,
+}
+
+/// Wait until the cluster is actually usable by making sure the default SA exists.
+pub async fn cluster_ready(client: Client, timeout: u64) -> Result<(), Error> {
+    time::timeout(Duration::from_secs(timeout), async move {
+        tracing::info!("cluster: waiting for readiness");
+        let mut interval = time::interval(Duration::from_secs(1));
+        let sas: Api<ServiceAccount> = Api::default_namespaced(client);
+        loop {
+            interval.tick().await;
+            if sas.get("default").await.is_ok() {
+                break;
+            }
+        }
+        tracing::info!("cluster: ready");
+    })
+    .await
+    .map_err(|_| Error::ClusterNotReady)
+}
+
+/// Create CRD `K` and wait for `Established` condition.
+pub async fn create_crd<K>(client: Client, timeout_secs: u32) -> Result<CustomResourceDefinition, Error>
+where
+    K: Resource<DynamicType = ()> + CustomResourceExt,
+{
+    tracing::info!("CRD: adding and waiting for Established condition");
+    tracing::debug!("CRD: creating");
+    let crds = Api::<CustomResourceDefinition>::all(client);
+    crds.create(&Default::default(), &<K as CustomResourceExt>::crd())
+        .await
+        .map_err(Error::CreateCustomResourceDefinition)?;
+    tracing::debug!("CRD: created");
+
+    let lp = ListParams::default()
+        .fields(&format!(
+            "metadata.name={}.{}",
+            <K as Resource>::plural(&()),
+            <K as Resource>::group(&())
+        ))
+        .timeout(timeout_secs);
+    let mut stream = crds
+        .watch(&lp, "0")
+        .await
+        .map_err(Error::WatchCustomResourceDefinition)?
+        .boxed_local();
+
+    while let Some(status) = stream
+        .try_next()
+        .await
+        .map_err(Error::ResolveCustomResourceDefinitionWatchEvent)?
+    {
+        match status {
+            WatchEvent::Added(crd) => {
+                tracing::debug!("CRD: added");
+                tracing::trace!(
+                    "CRD: conditions {:?}",
+                    crd.status
+                        .as_ref()
+                        .map(|s| AsRef::<Vec<_>>::as_ref(&s.conditions))
+                );
+            }
+
+            WatchEvent::Modified(crd) => {
+                tracing::debug!("CRD: modified");
+                tracing::trace!(
+                    "CRD: conditions {:?}",
+                    crd.status
+                        .as_ref()
+                        .map(|s| AsRef::<Vec<_>>::as_ref(&s.conditions))
+                );
+                let established = crd
+                    .status
+                    .as_ref()
+                    .map(|s| {
+                        s.conditions
+                            .iter()
+                            .any(|c| c.type_ == "Established" && c.status == "True")
+                    })
+                    .unwrap_or(false);
+                if established {
+                    tracing::info!("CRD: condition met");
+                    return Ok(crd);
+                }
+            }
+
+            WatchEvent::Deleted(_) => unreachable!("should never get deleted here"),
+
+            WatchEvent::Bookmark(_) => {
+                tracing::debug!("CRD: bookmark");
+            }
+
+            WatchEvent::Error(err) => {
+                tracing::error!("CRD: {}", err);
+            }
+        }
+    }
+
+    Err(Error::CustomResourceDefinitionNotEstablished)
+}


### PR DESCRIPTION
Testing utilities for kube. Includes `TestEnv` to create a temporary k3d cluster per test.

Closes #382


### TODO

- [ ] docs
- [ ] add some tests after #563
- [ ] support more options (e.g., local registry)
- [ ] support `kubectl(args)` method to run arbitrary command? Need to use `k3d kubeconfig write $name` (to write `~/.k3d/kubeconfig-$name.yaml`) or `k3d kubeconfig get $name > /tmp/k3d-kubeconfig-$name.yml`, and run commands with `KUBECONFIG=/path/to/kubeconfig`. `k3d kubeconfig write $name` is probably better because the file should get deleted with the cluster.