### PR TITLE
Fix example job_api

### DIFF
--- a/examples/job_api.rs
+++ b/examples/job_api.rs
@@ -64,7 +64,7 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
             WatchEvent::Deleted(s) => info!("Deleted {}", s.name()),
-            WatchEvent::Error(s) => error!("{}", s),
+            WatchEvent::Error(s) => error!("{:?}", s),
             _ => {}
         }
     }


### PR DESCRIPTION
Just loaded the project and found there is an tiny error on `job_api.rs`. `ErrorResponse` doesn't implement `Display`, so we cannot use `{}` on it.

This just turns to leverage its `Debug` trait, although we can implement `Display` for it.