### PR TITLE
Add auth delegation utilities

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -194,3 +194,7 @@ path = "custom_client_trace.rs"
 [[example]]
 name = "secret_syncer"
 path = "secret_syncer.rs"
+
+[[example]]
+name = "auth_delegation"
+path = "auth_delegation.rs"

--- a/examples/auth_delegation.rs
+++ b/examples/auth_delegation.rs
@@ -1,0 +1,142 @@
+use anyhow::Context;
+use k8s_openapi::api::{
+    authentication::v1::{TokenRequest, TokenRequestSpec},
+    authorization::v1::{NonResourceAttributes, ResourceAttributes},
+    core::v1::{ConfigMap, Pod, ServiceAccount},
+};
+use kube::{
+    core::Request,
+    discovery::verbs,
+    util::auth::{
+        AccessStatus, AuthClient, NonResourceAttributesBuilder, ResourceAttributesBuilder,
+        SubjectAccessReviewBuilder, TokenValidity,
+    },
+    Resource,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let client = kube::Client::try_default().await?;
+    let token = get_token(&client).await?;
+    let client = AuthClient::new(client);
+    let attrs = ResourceAttributesBuilder::new()
+        .set_from_resource::<Pod>(&())
+        .verb(verbs::CREATE)
+        .all_objects()
+        .build();
+    check_has_access("create pods", &token, Attrs::Resource(attrs), &client).await?;
+    let attrs = ResourceAttributesBuilder::new()
+        .set_from_resource::<ConfigMap>(&())
+        .verb(verbs::GET)
+        .object_name("kube-root-ca.crt")
+        .namespace("default")
+        .build();
+    check_has_access(
+        "discover apiserver TLS sertificate trust chain",
+        &token,
+        Attrs::Resource(attrs),
+        &client,
+    )
+    .await?;
+    let attrs = NonResourceAttributesBuilder::new()
+        .verb("GET")
+        .path("/metrics")
+        .build();
+    check_has_access(
+        "get apiserver metrics",
+        &token,
+        Attrs::NonResource(attrs),
+        &client,
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn get_token(client: &kube::Client) -> anyhow::Result<String> {
+    if let Ok(t) = std::env::var("TOKEN") {
+        println!("Using token from the TOKEN environment variable");
+        return Ok(t);
+    }
+    if let (Ok(ns), Ok(sa)) = (std::env::var("NAMESPACE"), std::env::var("SERVICE_ACCOUNT")) {
+        let audience = std::env::var("AUDIENCE").ok();
+        println!(
+            "Requesting token for service account {} in namespace {}, intended for audience {:?}",
+            ns, sa, audience
+        );
+        let token_request_data = TokenRequest {
+            spec: TokenRequestSpec {
+                audiences: audience.into_iter().collect(),
+                expiration_seconds: Some(600),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let token_request_data = serde_json::to_vec(&token_request_data)?;
+
+        let token_request = Request {
+            url_path: ServiceAccount::url_path(&(), Some(&ns)),
+        };
+        let token_request =
+            token_request.create_subresource("token", &sa, &Default::default(), token_request_data)?;
+        let token_request: TokenRequest = client.request(token_request).await?;
+        let token = token_request
+            .status
+            .map(|st| st.token)
+            .context("token not returned")?;
+        return Ok(token);
+    }
+    anyhow::bail!("Token not specified");
+}
+
+enum Attrs {
+    Resource(ResourceAttributes),
+    NonResource(NonResourceAttributes),
+}
+
+async fn check_has_access(
+    description: &str,
+    token: &str,
+    attrs: Attrs,
+    client: &AuthClient,
+) -> anyhow::Result<()> {
+    let user_info = match client.validate_token(token, &[]).await? {
+        TokenValidity::Valid { user, .. } => user,
+        TokenValidity::Invalid { reason } => {
+            println!("Token is not valid: {:?}", reason);
+            return Ok(());
+        }
+        TokenValidity::Fail => {
+            println!("Internal error");
+            return Ok(());
+        }
+    };
+
+    let mut spec_builder = SubjectAccessReviewBuilder::new();
+    spec_builder.set_from_user_info(user_info);
+
+    let spec = match attrs {
+        Attrs::Resource(res) => spec_builder.resource(res),
+        Attrs::NonResource(nr) => spec_builder.non_resource(nr),
+    };
+
+    let status = client.check_access(spec).await?;
+
+    print!("{}: ", description);
+    match status {
+        AccessStatus::Allow => {
+            println!("allowed");
+        }
+        AccessStatus::Deny { reason } => {
+            println!("denied: {:?}", reason);
+        }
+        AccessStatus::NoOpinion => {
+            println!("neither allowed nor denied (no opinion)");
+        }
+        AccessStatus::Fail => {
+            println!("internal error");
+        }
+    }
+
+    Ok(())
+}

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -97,6 +97,7 @@ cfg_client! {
     pub mod api;
     pub mod discovery;
     pub mod client;
+    pub mod util;
 
     #[doc(inline)]
     pub use api::Api;

--- a/kube-client/src/util/auth.rs
+++ b/kube-client/src/util/auth.rs
@@ -1,0 +1,306 @@
+//! Simple client for `authentication.kubernetes.io` and `authorization.kubernetes.io` groups
+//! See [`AuthClient`] for usage.
+
+use std::collections::BTreeMap;
+
+use crate::{api::Api, client::Client, Result};
+use k8s_openapi::api::authentication::v1::{TokenReview, TokenReviewSpec, UserInfo};
+use k8s_openapi::api::authorization::v1::{
+    NonResourceAttributes, ResourceAttributes, SubjectAccessReview, SubjectAccessReviewSpec,
+};
+use kube_core::Resource;
+
+/// `AuthClient` can be used to delegate authentication and/or authorization
+/// to Kubernetes API server (same way Kubelet or extension API servers may do it).
+/// # Permissions
+/// `system:auth-delegator` role is enough for all methods to work.
+#[derive(Clone)]
+pub struct AuthClient {
+    token_reviews: Api<TokenReview>,
+    subject_access_reviews: Api<SubjectAccessReview>,
+}
+
+/// Describes whether token passed all necessary. See [`AuthClient::validate_token`] for details.
+#[derive(Debug, Clone)]
+pub enum TokenValidity {
+    /// Token passed all checks.
+    Valid {
+        /// User information. This information can be trusted because
+        /// it comes from server.
+        user: UserInfo,
+        /// Audiences token is authorized against. This is subset of audiences provided
+        /// on input.
+        audiences: Vec<String>,
+    },
+    /// Token failed some checks and should not be trusted.
+    Invalid {
+        /// Contains optional error message.
+        reason: Option<String>,
+    },
+    /// Internal error (i.e. validation failed, but it is not caused by token)
+    Fail,
+}
+
+/// Describes whether operation is authorized. See [`AuthClient::check_access`] for details.
+#[derive(Debug, Clone)]
+pub enum AccessStatus {
+    /// Operation is authorized.
+    Allow,
+    /// Operation is not authorized.
+    Deny {
+        /// Contains optional error message.
+        reason: Option<String>,
+    },
+    /// Authorizer has no opinion.
+    /// May be treated e.g. as implicit `Deny`.
+    NoOpinion,
+    /// Internal error
+    Fail,
+}
+
+impl AuthClient {
+    /// Creates new `AuthClient` which will use given `client` for making kubernetes API requests.
+    pub fn new(client: Client) -> Self {
+        AuthClient {
+            token_reviews: Api::all(client.clone()),
+            subject_access_reviews: Api::all(client),
+        }
+    }
+    /// Verifies that token is valid and was issued for at least one of provided audiences.
+    /// If `audiences` is empty this function will verify that token can be used with cluster API.
+    pub async fn validate_token(&self, token: &str, expected_audiences: &[&str]) -> Result<TokenValidity> {
+        let token_review_request = TokenReview {
+            spec: TokenReviewSpec {
+                audiences: Some(expected_audiences.iter().map(ToString::to_string).collect()),
+                token: Some(token.to_string()),
+            },
+            ..Default::default()
+        };
+        let token_review = self
+            .token_reviews
+            .create(&Default::default(), &token_review_request)
+            .await?;
+        let status = match token_review.status {
+            Some(s) => s,
+            None => return Ok(TokenValidity::Fail),
+        };
+        if status.authenticated != Some(true) {
+            return Ok(TokenValidity::Invalid { reason: status.error });
+        }
+        // API references recommends additionally validate audiences
+        let audiences = status.audiences.as_deref().unwrap_or_default();
+        if !expected_audiences.is_empty()
+            && !audiences.iter().any(|a| expected_audiences.contains(&a.as_str()))
+        {
+            return Ok(TokenValidity::Invalid {
+                reason: Some("invalid token audiences".to_string()),
+            });
+        }
+        let user = match status.user {
+            Some(u) => u,
+            None => return Ok(TokenValidity::Fail),
+        };
+        Ok(TokenValidity::Valid {
+            user,
+            audiences: audiences.to_vec(),
+        })
+    }
+
+    /// Verifies that user can do operation.
+    pub async fn check_access(&self, spec: SubjectAccessReviewSpec) -> Result<AccessStatus> {
+        let review_request = SubjectAccessReview {
+            spec,
+            ..Default::default()
+        };
+        let review = self
+            .subject_access_reviews
+            .create(&Default::default(), &review_request)
+            .await?;
+        let status = match review.status {
+            Some(s) => s,
+            None => return Ok(AccessStatus::Fail),
+        };
+        if status.allowed {
+            return Ok(AccessStatus::Allow);
+        }
+        if status.denied == Some(true) {
+            return Ok(AccessStatus::Deny {
+                reason: status.reason,
+            });
+        }
+        Ok(AccessStatus::NoOpinion)
+    }
+}
+
+/// Helper for creating `SubjectAccessReview`.
+/// At first you should specify user information, and then
+/// call `resource` or `non_resource` methods, which return specialized
+/// builders.
+pub struct SubjectAccessReviewBuilder(SubjectAccessReviewSpec);
+
+impl SubjectAccessReviewBuilder {
+    /// Creates new builder.
+    pub fn new() -> Self {
+        SubjectAccessReviewBuilder(SubjectAccessReviewSpec::default())
+    }
+
+    /// Set user who makes the request.
+    pub fn user(&mut self, user: &str) {
+        self.0.user = Some(user.to_string());
+    }
+    /// Set uid of the user who makes the request.
+    pub fn user_uid(&mut self, uid: &str) {
+        self.0.uid = Some(uid.to_string());
+    }
+
+    /// Set groups of the user who makes the request.
+    /// Any existing value will be overwitten.
+    pub fn groups(&mut self, groups: &[&str]) {
+        self.0.groups = Some(groups.iter().map(ToString::to_string).collect());
+    }
+
+    /// Sets extras of the user who makes the request.
+    /// Any existing value will be overwitten.
+    pub fn extras(&mut self, extras: BTreeMap<String, Vec<String>>) {
+        self.0.extra = Some(extras);
+    }
+    /// Appends extra value. If an extra with the same `name` is already present, `value` is appended.
+    pub fn add_extra(&mut self, name: &str, value: &str) {
+        let extras = self.0.extra.get_or_insert_with(Default::default);
+        let values = extras.entry(name.to_string()).or_default();
+        values.push(value.to_string());
+    }
+    /// Sets all values from the given `UserInfo` value.
+    pub fn set_from_user_info(&mut self, info: UserInfo) {
+        self.0.uid = info.uid;
+        self.0.user = info.username;
+        self.0.groups = info.groups;
+        self.0.extra = info.extra;
+    }
+
+    /// Finalizes builder with given resource attributes and returns SubjectAccessReview spec.
+    pub fn resource(mut self, attrs: ResourceAttributes) -> SubjectAccessReviewSpec {
+        self.0.resource_attributes = Some(attrs);
+        self.0
+    }
+
+    /// Finalizes builder with given non-resource attributes and returns SubjectAccessReview spec.
+    pub fn non_resource(mut self, attrs: NonResourceAttributes) -> SubjectAccessReviewSpec {
+        self.0.non_resource_attributes = Some(attrs);
+        self.0
+    }
+}
+
+/// See [`SubjectAccessReviewBuilder`].
+#[derive(Clone)]
+pub struct ResourceAttributesBuilder(ResourceAttributes);
+
+impl ResourceAttributesBuilder {
+    /// Creates empty builder
+    pub fn new() -> Self {
+        ResourceAttributesBuilder(Default::default())
+    }
+    /// Check access for the given api group
+    pub fn api_group(mut self, group: &str) -> Self {
+        self.0.group = Some(group.to_string());
+        self
+    }
+    /// Check access for all api groups
+    pub fn all_api_groups(self) -> Self {
+        self.api_group("*")
+    }
+
+    /// Check access for the given version
+    pub fn version(mut self, version: &str) -> Self {
+        self.0.version = Some(version.to_string());
+        self
+    }
+    /// Check access for all versions
+    pub fn all_versions(self) -> Self {
+        self.version("*")
+    }
+
+    /// Check access for the given resource.
+    pub fn resource_name(mut self, name: &str) -> Self {
+        self.0.resource = Some(name.to_string());
+        self
+    }
+    /// Check access for all resources.
+    pub fn all_resources(self) -> Self {
+        self.resource_name("*")
+    }
+    /// Sets api group, version and resource name
+    pub fn set_from_resource<K: Resource>(self, dt: &K::DynamicType) -> Self {
+        self.api_group(&K::group(dt))
+            .version(&K::version(dt))
+            .resource_name(&K::plural(dt))
+    }
+
+    /// Check access for the given verb.
+    /// This function accepts Kubernetes operation verbs, such as `get` or `create`.
+    pub fn verb(mut self, verb: &str) -> Self {
+        self.0.verb = Some(verb.to_string());
+        self
+    }
+
+    /// Check access for all operation verbs.
+    pub fn all_verbs(self) -> Self {
+        self.verb("*")
+    }
+
+    /// Check access for the given subresource (instead of the whole resource).
+    pub fn subresource(mut self, sr: &str) -> Self {
+        self.0.subresource = Some(sr.to_string());
+        self
+    }
+
+    /// Check access for the object with given name.
+    pub fn object_name(mut self, name: &str) -> Self {
+        self.0.name = Some(name.to_string());
+        self
+    }
+    /// Check access for all objects.
+    pub fn all_objects(self) -> Self {
+        self.object_name("")
+    }
+    /// Check access for the given namespace.
+    pub fn namespace(mut self, ns: &str) -> Self {
+        self.0.namespace = Some(ns.to_string());
+        self
+    }
+    /// Check access for all namespaces (for namespace-scoped resources)
+    /// or in global scope (for non-namespace-scoped resources).
+    pub fn global(self) -> Self {
+        self.namespace("")
+    }
+
+    /// Finalizes builder and returns resource attributes.
+    pub fn build(self) -> ResourceAttributes {
+        self.0
+    }
+}
+
+/// See [`SubjectAccessReviewBuilder`].
+#[derive(Clone)]
+pub struct NonResourceAttributesBuilder(NonResourceAttributes);
+
+impl NonResourceAttributesBuilder {
+    /// Creates empty builder
+    pub fn new() -> Self {
+        NonResourceAttributesBuilder(Default::default())
+    }
+    /// HTTP request path
+    pub fn path(mut self, path: &str) -> Self {
+        self.0.path = Some(path.to_string());
+        self
+    }
+    /// HTTP request verb, such as `GET` or `POST`.
+    pub fn verb(mut self, verb: &str) -> Self {
+        self.0.verb = Some(verb.to_string());
+        self
+    }
+    /// Finalizes builder and returns non-resource attributes.
+    pub fn build(self) -> NonResourceAttributes {
+        self.0
+    }
+}

--- a/kube-client/src/util/auth.rs
+++ b/kube-client/src/util/auth.rs
@@ -68,6 +68,14 @@ impl AuthClient {
     }
     /// Verifies that token is valid and was issued for at least one of provided audiences.
     /// If `audiences` is empty this function will verify that token can be used with cluster API.
+    /// ```no_run
+    /// # async fn _(client: &AuthClient, token: &str) -> Result<(), Box<dyn std::error::Error>> {
+    /// let res = client.validate_token(token, &["my-server"]).await?;
+    /// if matches!(res, TokenValidity::Valid) {
+    ///     println!("token is valid");
+    /// }
+    /// # }
+    /// ```
     pub async fn validate_token(&self, token: &str, expected_audiences: &[&str]) -> Result<TokenValidity> {
         let token_review_request = TokenReview {
             spec: TokenReviewSpec {
@@ -107,6 +115,24 @@ impl AuthClient {
     }
 
     /// Verifies that user can do operation.
+    /// ```no_run
+    /// # use  k8s_openapi::api::core::v1::Pod;
+    /// # async fn _(client: &AuthClient, user_info: UserInfo) -> Result<(), Box<dyn std::error::Error>> {
+    /// let attrs = ResourceAttributesBuilder::new()
+    ///     .set_from_resource::<Pod>()
+    ///     .all_verbs()
+    ///     .all_objects()
+    ///     .build();
+    /// let spec = SubjectAccessReviewBuilder::new()
+    ///     .set_from_user_info(user_info)
+    ///     .resource(attrs)
+    ///     .build();
+    /// let res = client.check_access(spec).await?;
+    /// if matches!(res, AccessStatus::Allow) {
+    ///     println!("access granted");
+    /// }
+    /// # }
+    /// ```
     pub async fn check_access(&self, spec: SubjectAccessReviewSpec) -> Result<AccessStatus> {
         let review_request = SubjectAccessReview {
             spec,

--- a/kube-client/src/util/mod.rs
+++ b/kube-client/src/util/mod.rs
@@ -1,0 +1,3 @@
+//! High-level utilities for certain Kubernetes APIs
+
+pub mod auth;

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -248,6 +248,24 @@ impl Request {
         let req = http::Request::put(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
         req.body(data).map_err(Error::BuildRequest)
     }
+
+    /// Create an instance of the subresource
+    pub fn create_subresource(
+        &self,
+        subresource_name: &str,
+        name: &str,
+        pp: &PostParams,
+        data: Vec<u8>,
+    ) -> Result<http::Request<Vec<u8>>, Error> {
+        let target = format!("{}/{}/{}?", self.url_path, name, subresource_name);
+        let mut qp = form_urlencoded::Serializer::new(target);
+        if pp.dry_run {
+            qp.append_pair("dryRun", "All");
+        }
+        let urlstr = qp.finish();
+        let req = http::Request::post(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
+        req.body(data).map_err(Error::BuildRequest)
+    }
 }
 
 /// Extensive tests for Request of k8s_openapi::Resource structs

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -141,6 +141,7 @@ cfg_client! {
     pub use kube_client::api;
     pub use kube_client::discovery;
     pub use kube_client::client;
+    pub use kube_client::util;
 
     #[doc(inline)]
     pub use api::Api;


### PR DESCRIPTION
## Motivation

Applications usually perform some authentication & authorization, and for kubernetes-native apps it makes sense to leverage apiserver for that, e.g. this is [recommended](https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/#extension-apiserver-authorizes-the-request) for the extension API servers.
<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

This PR adds simple high-level client together with `SubjectAccessReview` builders.

Additionally, while I was writing an example, I realized that currently it is not possible to create subresources, so I added a method for this in a separate commit.
