### PR TITLE
Cache `Controller`'s child objects into a reflector

### DIFF
--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -125,10 +125,11 @@ async fn main() -> Result<()> {
         }
     });
 
-    Controller::new(cmgs, ListParams::default())
-        .owns(cms, ListParams::default())
-        .reconcile_all_on(reload_rx.map(|_| ()))
-        .shutdown_on_signal()
+    let mut controller = Controller::new(cmgs, ListParams::default());
+    controller.owns(cms, ListParams::default());
+    controller.reconcile_all_on(reload_rx.map(|_| ()));
+    controller.shutdown_on_signal();
+    controller
         .run(reconcile, error_policy, Context::new(Data { client }))
         .for_each(|res| async move {
             match res {


### PR DESCRIPTION
## Motivation

Often, controllers will need to read the objects that they monitor, not just the "main" object. Currently, you can either `Api::get` the child objects, or set up your own reflector and use `applier`. The former is wasteful (since we already have the information from the watches), and the latter has some pretty significant ergonomics downsides.

## Solution

I changed `Controller::owns` and `Controller::watches` to now set up and maintain secondary reflectors, and made them return the `Store`s.

I also ended up changing the rest of `Controller` to use `&mut` references rather than chaining, for consistency. This is a pretty major breaking change, so I'd like to see what people think about the change before updating the docs.