### PR TITLE
Add low-level distributed lock

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -206,3 +206,7 @@ path = "custom_client_trace.rs"
 [[example]]
 name = "secret_syncer"
 path = "secret_syncer.rs"
+
+[[example]]
+name = "raw_election"
+path = "raw_election.rs"

--- a/examples/raw_election.rs
+++ b/examples/raw_election.rs
@@ -1,0 +1,64 @@
+use std::time::Duration;
+
+use k8s_openapi::{api::coordination::v1::Lease, chrono::Utc};
+use kube::runtime::lock::raw::{LockSettings, RawLock};
+
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let kube = kube::Client::try_default().await?;
+
+    let lease = std::env::var("LEASE").unwrap_or_else(|_| "kube-election-example".to_string());
+    let namespace = std::env::var("LEASE_NS").ok();
+    let instance = std::env::var("INSTANCE").unwrap_or_else(|_| std::process::id().to_string());
+    let lease_duration_secs = std::env::var("LEASE_DURATION")
+        .unwrap_or_else(|_| "5".to_string())
+        .parse()
+        .unwrap();
+
+    let leases = if let Some(ns) = &namespace {
+        kube::Api::<Lease>::namespaced(kube, ns)
+    } else {
+        kube::Api::<Lease>::default_namespaced(kube)
+    };
+
+    let settings = LockSettings {
+        lease_name: lease.clone(),
+        identity: instance.clone(),
+        expiration_timeout_secs: lease_duration_secs,
+    };
+
+    let mut lock = RawLock::new(leases, settings);
+    tracing::info!(?namespace, ?lease, ?instance, "Starting loop");
+    let retirement_threshold = 10;
+    let mut budget = retirement_threshold;
+    loop {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let now = Utc::now();
+        let res = lock.try_acquire(now).await?;
+        if res {
+            tracing::info!(?instance, term = lock.term(), "I am the leader");
+            budget -= 1;
+            if budget == 0 {
+                tracing::info!(?instance, "retiring");
+                budget = retirement_threshold;
+                let retire_res = lock.try_release().await?;
+                if retire_res {
+                    tracing::info!(?instance, "retired");
+                    tokio::time::sleep(Duration::from_secs(8)).await;
+                } else {
+                    tracing::info!(?instance, "failed to retire");
+                }
+            }
+        } else {
+            tracing::info!(
+                ?instance,
+                leader = lock.owner(),
+                term = lock.term(),
+                "I am the follower"
+            );
+        }
+    }
+}

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -22,6 +22,7 @@ k8s_openapi::k8s_if_ge_1_19! {
     pub mod events;
 }
 pub mod finalizer;
+pub mod lock;
 pub mod reflector;
 pub mod scheduler;
 pub mod utils;

--- a/kube-runtime/src/lock.rs
+++ b/kube-runtime/src/lock.rs
@@ -1,0 +1,27 @@
+//! Leader election support.
+//! # Primitives
+//! TODO.
+//! # Requirements and guarantees
+//! In general, one may talk about two properties of distributed locking protocol:
+//! 1. Safety (should not be confused with safety in rust). Protocol is safe if it provides
+//! strict "at most once guarantee", i.e. situation when several instances execute critical section is impossible.
+//! 2. Liveness. Protocol has liveness if it tolerates partial failures without human intervention.
+//!
+//! It is impossible for generic locking protocol to have both propertise,
+//! and `kube`-supplied locks implemented in this module choose liveness over safety.
+//! Therefore your code must tolerate situation when critical section is entered concurrently.
+//!
+//! To minimize chances that this situation will occur:
+//! - Use distinct `identity`-es for different instances.
+//! - Stop your leader-only components right after being notified about lost leadership, in timely fashion.
+//! - Do not violate runtime compatibility policy (documented below)
+//! - Do not delete or edit `Lease` object used by locks internally.
+//! - Ensure that cluster has no clock skew (i.e. at any moment difference between time on any two nodes is negligible compared
+//! to expiration timeout).
+//! - Ensure that task which renews lock does not starve (if it does not get executed, it won't have chance to observe that lock has expired).
+//! # Runtime compatiblity policy
+//! Sometimes underlying protocol may be changed in such a way that actors compiled with newer kube version do not understand actors compiled with older kube version.
+//! This may lead to various nasty situations (such as lock being constantly stolen, multiple leaders elected at once, and so on). However, kube guarantees that
+//! 1. This may not happen if all actors share one or two consecutive `kube` minor versions. (E.g. if all your instances use `v0.378.0`, `v0.278.3` or `v0.379.1`, this is supported version skew)
+//! 2. Each time new kube minor release drops compatibility with some older releases, it is reflected in release notes as a breaking change.
+pub mod raw;

--- a/kube-runtime/src/lock/raw.rs
+++ b/kube-runtime/src/lock/raw.rs
@@ -1,0 +1,319 @@
+//! Low-level lock implementation
+
+use k8s_openapi::{
+    api::coordination::v1::Lease,
+    apimachinery::pkg::apis::meta::v1::MicroTime,
+    chrono::{DateTime, Duration, Utc},
+};
+use kube_client::{core::ObjectMeta, Api};
+
+pub struct LockSettings {
+    pub lease_name: String,
+    /// Identity is a string which uniquely determines actor among all other
+    /// actors using same lease in same namespace.
+    /// If two or more actors use the same identity, "at most one" property
+    /// will be completely violated (if one actor will acquire lock, other will also believe
+    /// it acquired it).
+    pub identity: String,
+    pub expiration_timeout_secs: i32,
+}
+
+#[derive(Clone)]
+struct State(Option<Lease>);
+
+/// Pure type that only manipulates lease state.
+/// It always assumes that it is given latest and up-to-date
+/// lease state. If this assumption turns wrong, compare-and-set simply fails.
+struct StateEditor(LockSettings);
+
+impl StateEditor {
+    fn is_eligible_for_acquire(&self, state: &State, now: DateTime<Utc>) -> bool {
+        let lease = match state.0.as_ref() {
+            Some(l) => l,
+            // lease not exists -> no holder -> can acquire
+            None => return true,
+        };
+        let spec = match lease.spec.as_ref() {
+            Some(s) => s,
+            // empty spec -> no holder -> can acquire
+            None => return true,
+        };
+        let holder = match spec.holder_identity.as_ref() {
+            Some(h) => h,
+            // no holder -> can acquire
+            None => return true,
+        };
+        if *holder == self.0.identity {
+            // held by us -> can acquire (aka renew)
+            return true;
+        }
+        let last_renewed_at = match spec.renew_time.clone() {
+            Some(t) => t,
+            // no renew_time -> no holder -> can acquire
+            None => return true,
+        };
+        let expires_at =
+            last_renewed_at.0 + Duration::seconds(spec.lease_duration_seconds.unwrap_or(0).into());
+        expires_at < now
+    }
+
+    fn acquire(&self, state: State, now: DateTime<Utc>) -> Result<Lease, State> {
+        if !self.is_eligible_for_acquire(&state, now) {
+            tracing::debug!("lock is acquired by other actor and did not expire yet");
+            return Err(state);
+        }
+        let mut lease = state.0.unwrap_or_else(|| Lease {
+            metadata: ObjectMeta {
+                name: Some(self.0.lease_name.clone()),
+                ..Default::default()
+            },
+            spec: None,
+        });
+        let spec = lease.spec.get_or_insert_with(Default::default);
+        spec.renew_time = Some(MicroTime(now));
+        let prev_holder = spec.holder_identity.replace(self.0.identity.clone());
+        if prev_holder.as_ref() != Some(&self.0.identity) {
+            spec.acquire_time = Some(MicroTime(now));
+            let transitions_cnt = spec.lease_transitions.map_or(0, |cnt| cnt.saturating_add(1));
+            spec.lease_transitions = Some(transitions_cnt);
+        }
+        spec.lease_duration_seconds = Some(self.0.expiration_timeout_secs);
+        Ok(lease)
+    }
+
+    fn release(&self, mut state: State) -> Result<Lease, State> {
+        let lease = match &mut state.0 {
+            Some(l) => l,
+            // we can't own lock if lease not exists
+            None => return Err(state),
+        };
+        let spec = match lease.spec.as_mut() {
+            Some(s) => s,
+            // we can't own lock if spec is None
+            None => return Err(state),
+        };
+        if spec.holder_identity.as_ref() != Some(&self.0.identity) {
+            // we do not own lock
+            return Err(state);
+        }
+        spec.holder_identity = None;
+        spec.acquire_time = None;
+        spec.renew_time = None;
+        spec.lease_duration_seconds = None;
+        Ok(state.0.unwrap())
+    }
+}
+
+// This is the only type that directly communicates with k8s.
+// it also maintains state cache.
+struct StateHolder {
+    leases: Api<Lease>,
+    lease_name: String,
+    // None: we **definitely** don't know current state (e.g. replace failed with Conflict).
+    // Some(State(None)): we believe lease does not exist.
+    // Some(State(Some(l))): we believe lease is l.
+    state: Option<State>,
+    // Unlike `state`, this field is never set to None once it becomes Some.
+    last_observed_lease: Option<Lease>,
+}
+
+enum CasResult {
+    Cancelled,
+    Replaced,
+    Conflict,
+}
+
+impl StateHolder {
+    async fn get_state(&mut self) -> Result<State, kube_client::Error> {
+        let val = match self.leases.get(&self.lease_name).await {
+            Ok(lease) => Some(lease),
+            Err(err) => {
+                if is_api_error(&err, "NotFound") {
+                    None
+                } else {
+                    return Err(err);
+                }
+            }
+        };
+        self.last_observed_lease = val.clone();
+        Ok(State(val))
+    }
+
+    async fn compare_and_set_inner(
+        &self,
+        f: &dyn Fn(State) -> Result<Lease, State>,
+        current_state: State,
+    ) -> Result<(CasResult, Option<State>), kube_client::Error> {
+        let lease_exists = current_state.0.is_some();
+        let new_lease = match f(current_state) {
+            Ok(l) => l,
+            Err(state) => {
+                return Ok((CasResult::Cancelled, Some(state)));
+            }
+        };
+
+        tracing::debug!("Running compare-and-set");
+        let result = if lease_exists {
+            self.leases
+                .replace(&self.lease_name, &Default::default(), &new_lease)
+                .await
+        } else {
+            self.leases.create(&Default::default(), &new_lease).await
+        };
+        match result {
+            Ok(lease) => {
+                // success
+                Ok((CasResult::Replaced, Some(State(Some(lease)))))
+            }
+            Err(err) => {
+                if is_api_error(&err, "Conflict") || is_api_error(&err, "NotFound") {
+                    // our state was not up-to-date
+                    Ok((CasResult::Conflict, None))
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    async fn compare_and_set<F>(&mut self, func: F) -> Result<CasResult, kube_client::Error>
+    where
+        F: Fn(State) -> Result<Lease, State>,
+    {
+        let state = match self.state.take() {
+            Some(s) => s,
+            None => self.get_state().await?,
+        };
+        let (cas_result, state) = self.compare_and_set_inner(&func, state).await?;
+        if let Some(State(Some(lease))) = &state {
+            self.last_observed_lease = Some(lease.clone());
+        }
+        self.state = state;
+        Ok(cas_result)
+    }
+
+    fn last_observed_lease(&self) -> Option<&Lease> {
+        self.last_observed_lease.as_ref()
+    }
+}
+
+/// Raw lock.
+///
+/// You should not use this type directly, because it has error-prone and verbose API.
+/// Use other primitives instead: (TODO).
+/// # Limitations
+/// - `RawLock` does not enforce that work only happens in critical section.
+/// - `RawLock` does not notify about its expiration.
+/// - `RawLock` must be repeatedly explicitly `acquire()`-d for renewal to work.
+#[allow(clippy::module_name_repetitions)] // OK since module is private
+pub struct RawLock {
+    editor: StateEditor,
+    state: StateHolder,
+}
+
+fn is_api_error(err: &kube_client::Error, reason: &str) -> bool {
+    let err = match err {
+        kube_client::Error::Api(e) => e,
+        _ => return false,
+    };
+    err.reason == reason
+}
+
+impl RawLock {
+    /// Creates new `RawLock` (i.e. one actor in distributed locking problem).
+    #[must_use]
+    pub fn new(leases: Api<Lease>, settings: LockSettings) -> Self {
+        let lease_name = settings.lease_name.clone();
+        RawLock {
+            editor: StateEditor(settings),
+            state: StateHolder {
+                leases,
+                lease_name,
+                state: None,
+                last_observed_lease: None,
+            },
+        }
+    }
+
+    /// Returns last observed term of the lock or -1 otherwise. During normal operation,
+    /// this term monotonically increases each time lock changes owner or is re-acquired after an.
+    /// explicit release.
+    /// No two actors may believe they acquired the lock in one term.
+    #[must_use]
+    pub fn term(&self) -> i32 {
+        self.state
+            .last_observed_lease()
+            .and_then(|lease| lease.spec.as_ref())
+            .and_then(|spec| spec.lease_transitions)
+            .unwrap_or(-1)
+    }
+
+    /// Returns last known owner of the lock.
+    #[must_use]
+    pub fn owner(&self) -> Option<&str> {
+        self.state
+            .last_observed_lease()
+            .and_then(|lease| lease.spec.as_ref())
+            .and_then(|s| s.holder_identity.as_deref())
+    }
+
+    /// Returns moment of time when last observed lock will expire.
+    #[must_use]
+    pub fn locked_until(&self) -> DateTime<Utc> {
+        self.state
+            .last_observed_lease()
+            .and_then(|lease| lease.spec.as_ref())
+            .and_then(|s| Option::zip(s.renew_time.clone(), s.lease_duration_seconds))
+            .map_or(DateTime::<Utc>::MIN_UTC, |(last_renewed_at, duration)| {
+                last_renewed_at.0 + Duration::seconds(duration.into())
+            })
+    }
+
+    /// If lock is released or stale, acquires it and returns true.
+    /// If lock is acquired by this actor, renews it and returns true.
+    /// Otherwise returns false.
+    /// This function may return false spuriously if not only `RawLock` actors
+    /// modify the lease.
+    /// # Errors
+    /// This function fails if apiserver returns unexpected error.
+    pub async fn try_acquire(&mut self, now: DateTime<Utc>) -> Result<bool, kube_client::Error> {
+        tracing::debug!("trying to acquire or renew lock");
+        let func = |state: State| self.editor.acquire(state, now);
+        let res = self.state.compare_and_set(func).await?;
+        match res {
+            CasResult::Replaced => {
+                tracing::debug!("lock was successfully acquired or renewed");
+                Ok(true)
+            }
+            CasResult::Conflict => {
+                tracing::debug!("Acquire operation failed due to CAS conflict");
+                Ok(false)
+            }
+            CasResult::Cancelled => Ok(false),
+        }
+    }
+
+    /// If lock is acquired by this actor, releases it.
+    /// Returns true if lock is not owned anymore, false otherwise.
+    /// # Errors
+    /// This function fails if apiserver returns unexpected error.
+    pub async fn try_release(&mut self) -> Result<bool, kube_client::Error> {
+        tracing::debug!("trying to release lock");
+        let func = |state: State| self.editor.release(state);
+        let res = self.state.compare_and_set(func).await?;
+        match res {
+            CasResult::Replaced => {
+                tracing::debug!("Lock was successfully released");
+                Ok(true)
+            }
+            CasResult::Conflict => {
+                tracing::debug!("Release operation failed due to CAS conflict");
+                Ok(false)
+            }
+            CasResult::Cancelled => {
+                tracing::debug!("Lock was not owned");
+                Ok(true)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Mikail Bagishov <bagishov.mikail@yandex.ru>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Leader election was requested in #485. It is widely used when implementing controllers (if two instances try to run some controller simultaneously, they will create excessive load on apiserver and huge amount of `Conflict` HTTP errors).

There were several attempts to implement this feature, but they seem stalled.
It looks like there are questions about how the API should look like.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

This PR (based on #843) adds a **low-level** distributed lock on top of the Kubernetes leases.
It is not expected that an end user will somehow interact with this API. It may become private in the future.
On the other hand, RawLock should be a sound basis for user-facing API (i.e. all that remains is somehow periodically call `try_acquire` and do something if we can't do that). I hope this separation will aid in finding simple and safe interface for leader election in `kube`.

PR includes a simple example. Better ways to test correctness are appreciated :)

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
## Future extensions
+ Detecting that `identity` is not unique. This can be added to RawLock later and without major changes.
+ Live reconfiguration (rename lease / split lock into several finer-grained / merging several locks into one coarser-grained). Should all be possible on top of the proposed API.