### PR TITLE
Add support for untagged enums in CRDs

### DIFF
--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -111,14 +111,14 @@ fn hoist_subschema_properties(
                                 continue;
                             }
 
-                            panic!("Property {:?} has the schema {:?} but was already defined as {:?} in another untagged enum variant. The schemas for a property used in multiple untagged enum variants must be identical",
+                            panic!("Property {:?} has the schema {:?} but was already defined as {:?} in another subschema. The schemas for a property used in multiple subschemas must be identical",
                                 entry.key(),
                                 &property,
                                 entry.get());
                         }
 
                         panic!(
-                            "Property {:?} is already defined in another tagged enum variant",
+                            "Property {:?} was already defined in another subschema",
                             entry.key()
                         )
                     }

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -64,7 +64,9 @@ impl Visitor for StructuralSchemaRewriter {
     }
 }
 
-fn convert_to_structural(
+/// Bring all property definitions from subschemas up to the root schema,
+/// since Kubernetes doesn't allow subschemas to define properties.
+fn hoist_subschema_properties(
     subschemas: &mut Vec<Schema>,
     common_obj: &mut Option<Box<ObjectValidation>>,
     instance_type: &mut Option<SingleOrVec<InstanceType>>,

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -109,7 +109,7 @@ fn hoist_subschema_properties(
                                 entry.key()
                             )
                         } else if &property != entry.get() {
-                            panic!("Property {:?} has the schema {:?} but was already defined as {:?} in another untagged enum variant. The schemas for a property used in multiple untagged enum variants must be identical",
+                            panic!("Property {:?} has the schema {:?} but was already defined as {:?} in another enum variant. The schemas for a property used in multiple enum variants must be identical",
                                     entry.key(),
                                     &property,
                                     entry.get());

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -47,6 +47,7 @@ impl Visitor for StructuralSchemaRewriter {
             .as_mut()
             .and_then(|subschemas| subschemas.any_of.as_mut())
         {
+            // Untagged enums are serialized using `any_of`
             convert_to_structural(any_of, &mut schema.object, &mut schema.instance_type, true);
         }
 

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -38,6 +38,7 @@ impl Visitor for StructuralSchemaRewriter {
             .as_mut()
             .and_then(|subschemas| subschemas.one_of.as_mut())
         {
+            // Tagged enums are serialized using `one_of`
             convert_to_structural(one_of, &mut schema.object, &mut schema.instance_type, false);
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->
We want to use untagged enums in our CRDs. This allows us to better validate the users input, without the user realizing that under the hood enums are used.

## Solution
Extending the `Visitor for StructuralSchemaRewriter` to rewrite `anyOf` clauses so that they are accepted by the k8s api-server.
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
