### PR TITLE
add fieldManager querystring to all operations

### DIFF
--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -183,6 +183,15 @@ pub struct PostParams {
 }
 
 impl PostParams {
+    pub(crate) fn populate_qp(&self, qp: &mut form_urlencoded::Serializer<String>) {
+        if self.dry_run {
+            qp.append_pair("dryRun", "All");
+        }
+        if let Some(ref fm) = self.field_manager {
+            qp.append_pair("fieldManager", fm);
+        }
+    }
+
     pub(crate) fn validate(&self) -> Result<(), Error> {
         if let Some(field_manager) = &self.field_manager {
             // Implement the easy part of validation, in future this may be extended to provide validation as in go code

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -115,12 +115,7 @@ impl Request {
         pp.validate()?;
         let target = format!("{}?", self.url_path);
         let mut qp = form_urlencoded::Serializer::new(target);
-        if pp.dry_run {
-            qp.append_pair("dryRun", "All");
-        }
-        if let Some(ref fm) = pp.field_manager {
-            qp.append_pair("fieldManager", fm);
-        }
+        pp.populate_qp(&mut qp);
         let urlstr = qp.finish();
         let req = http::Request::post(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
         req.body(data).map_err(Error::BuildRequest)
@@ -195,12 +190,7 @@ impl Request {
     ) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}/{}?", self.url_path, name);
         let mut qp = form_urlencoded::Serializer::new(target);
-        if pp.dry_run {
-            qp.append_pair("dryRun", "All");
-        }
-        if let Some(ref fm) = pp.field_manager {
-            qp.append_pair("fieldManager", fm);
-        }
+        pp.populate_qp(&mut qp);
         let urlstr = qp.finish();
         let req = http::Request::put(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
         req.body(data).map_err(Error::BuildRequest)
@@ -232,9 +222,7 @@ impl Request {
     ) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}/{}/{}?", self.url_path, name, subresource_name);
         let mut qp = form_urlencoded::Serializer::new(target);
-        if pp.dry_run {
-            qp.append_pair("dryRun", "All");
-        }
+        pp.populate_qp(&mut qp);
         let urlstr = qp.finish();
         let req = http::Request::post(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
         req.body(data).map_err(Error::BuildRequest)
@@ -271,12 +259,7 @@ impl Request {
     ) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}/{}/{}?", self.url_path, name, subresource_name);
         let mut qp = form_urlencoded::Serializer::new(target);
-        if pp.dry_run {
-            qp.append_pair("dryRun", "All");
-        }
-        if let Some(ref fm) = pp.field_manager {
-            qp.append_pair("fieldManager", fm);
-        }
+        pp.populate_qp(&mut qp);
         let urlstr = qp.finish();
         let req = http::Request::put(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
         req.body(data).map_err(Error::BuildRequest)

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -118,6 +118,9 @@ impl Request {
         if pp.dry_run {
             qp.append_pair("dryRun", "All");
         }
+        if let Some(ref fm) = pp.field_manager {
+            qp.append_pair("fieldManager", fm);
+        }
         let urlstr = qp.finish();
         let req = http::Request::post(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
         req.body(data).map_err(Error::BuildRequest)
@@ -195,6 +198,9 @@ impl Request {
         if pp.dry_run {
             qp.append_pair("dryRun", "All");
         }
+        if let Some(ref fm) = pp.field_manager {
+            qp.append_pair("fieldManager", fm);
+        }
         let urlstr = qp.finish();
         let req = http::Request::put(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
         req.body(data).map_err(Error::BuildRequest)
@@ -267,6 +273,9 @@ impl Request {
         let mut qp = form_urlencoded::Serializer::new(target);
         if pp.dry_run {
             qp.append_pair("dryRun", "All");
+        }
+        if let Some(ref fm) = pp.field_manager {
+            qp.append_pair("fieldManager", fm);
         }
         let urlstr = qp.finish();
         let req = http::Request::put(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -105,6 +105,9 @@ impl Request {
         if pp.dry_run {
             qp.append_pair("dryRun", "All");
         }
+        if let Some(ref fm) = pp.field_manager {
+            qp.append_pair("fieldManager", fm);
+        }
         let urlstr = qp.finish();
         // eviction body parameters are awkward, need metadata with name
         let data = serde_json::to_vec(&serde_json::json!({

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -102,12 +102,7 @@ impl Request {
         let pp = &ep.post_options;
         pp.validate()?;
         let mut qp = form_urlencoded::Serializer::new(target);
-        if pp.dry_run {
-            qp.append_pair("dryRun", "All");
-        }
-        if let Some(ref fm) = pp.field_manager {
-            qp.append_pair("fieldManager", fm);
-        }
+        pp.populate_qp(&mut qp);
         let urlstr = qp.finish();
         // eviction body parameters are awkward, need metadata with name
         let data = serde_json::to_vec(&serde_json::json!({


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

Not too sure if the fieldManager was intentionally not set or just forgotten, but the *Params struct accepted a field_manager and never used it. I noticed this when I used the `replace` function with a PostParams that had field_manager set, but the resulting YAML after the update had `unknown` on the `manager` field, instead of the name of my app.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

set the fieldManager for create/update/replace operations just like patch does.