### PR TITLE
Revert rename of blacklisted-names -> disallowed-names

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-disallowed-names = []
+blacklisted-names = []


### PR DESCRIPTION
It's a good change, but currently breaks the current stable clippy (0.1.64). Beta clippy (0.1.65) supports it and will emit a warning, reminding us to revert this reversion.

Reverts part of #1043.