### PR TITLE
Derive PartialEq for DynamicObject

### DIFF
--- a/kube-core/src/dynamic.rs
+++ b/kube-core/src/dynamic.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 /// A dynamic representation of a kubernetes object
 ///
 /// This will work with any non-list type object.
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct DynamicObject {
     /// The type fields, not always present
     #[serde(flatten, default)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

- Fields of DynamicObject all implement PartialEq
- It would be convenient if DynamicObject implements PartialEq, too.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

- Add PartialEq derive to DynamicObject
