### PR TITLE
Support tls-server-name for rustls

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [features]
-default = ["client", "openssl-tls"]
+default = ["client", "rustls-tls"]
 rustls-tls = ["rustls", "rustls-pemfile", "hyper-rustls"]
 openssl-tls = ["openssl", "hyper-openssl"]
 ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws"]
@@ -57,7 +57,7 @@ kube-core = { path = "../kube-core", version = "=0.75.0" }
 jsonpath_lib = { version = "0.3.0", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
-hyper-rustls = { version = "0.23.0", optional = true }
+hyper-rustls = { git = "https://github.com/rustls/hyper-rustls", version = "0.23.0", optional = true }
 tokio-tungstenite = { version = "0.17.1", optional = true }
 tower = { version = "0.4.6", optional = true, features = ["buffer", "filter", "util"] }
 tower-http = { version = "0.3.2", optional = true, features = ["auth", "map-response-body", "trace"] }

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -103,6 +103,11 @@ pub struct Cluster {
     #[serde(rename = "proxy-url")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proxy_url: Option<String>,
+    /// If set, apiserver certificate will be validated to contain this string
+    /// (instead of hostname or IP address from the url).
+    #[serde(rename = "tls-server-name")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls_server_name: Option<String>,
     /// Additional information for extenders so that reads and writes don't clobber unknown fields
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<Vec<NamedExtension>>,

--- a/kube-client/src/config/file_loader.rs
+++ b/kube-client/src/config/file_loader.rs
@@ -12,6 +12,8 @@ pub struct KubeConfigOptions {
     pub cluster: Option<String>,
     /// The user to load
     pub user: Option<String>,
+    /// Disable rustls-specific override for `tls-server-name`
+    pub disable_rustls_override: bool
 }
 
 /// ConfigLoader loads current context, cluster, and authentication information
@@ -74,12 +76,13 @@ impl ConfigLoader {
             .ok_or_else(|| KubeconfigError::LoadContext(context_name.clone()))?;
 
         let cluster_name = cluster.unwrap_or(&current_context.cluster);
-        let cluster = config
+        let mut cluster = config
             .clusters
             .iter()
             .find(|named_cluster| &named_cluster.name == cluster_name)
             .map(|named_cluster| &named_cluster.cluster)
-            .ok_or_else(|| KubeconfigError::LoadClusterOfContext(cluster_name.clone()))?;
+            .ok_or_else(|| KubeconfigError::LoadClusterOfContext(cluster_name.clone()))?
+            .clone();
 
         let user_name = user.unwrap_or(&current_context.user);
         let user = config
@@ -88,6 +91,11 @@ impl ConfigLoader {
             .find(|named_user| &named_user.name == user_name)
             .map(|named_user| &named_user.auth_info)
             .ok_or_else(|| KubeconfigError::FindUser(user_name.clone()))?;
+
+        // TODO: docs
+        if cfg!(feature = "rustls-tls") && true && cluster.tls_server_name.is_none() {
+            cluster.tls_server_name = Some("kubernetes.default.svc".to_string());
+        }
 
         Ok(ConfigLoader {
             current_context: current_context.clone(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Note that this PR currently is in RFC state. It depends on not-yet-released `hyper-rustls` version, and can be splitted into several PRs. Also we may want to make new workaround opt-in instead of opt-out and so on.

Partially solves #991 ("partially" because the same thing should be repeated for openssl).

Should improve #1003, as with new workaround `kube-rs+rustls` will work for every control plane (both in-cluster and outside) as long as apiserver certificate contains `kubernetes.default.svc` SAN. This is less strict assumption that `incluster_dns` does (i.e. we no longer assume that `kubernetes.default.svc` actually resolves to the apiserver IP), and I expect it to hold for the most control plane architectures. And as long as apiserver has at least one DNS SAN entry, it will be possible to connect to such a cluster with manual `tls-server-name` modification.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

This PR does following partially independent things:
1. Add support for `tls-server-name` in config loading.
2. Pass `tls-server-name` to rustls if enabled.
3. Set `tls-server-name` to `kubernetes.default-svc` if rustls is in use.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
