### PR TITLE
Add `DynamicObjects::try_parse` for typed object conversion

### DIFF
--- a/kube-core/src/dynamic.rs
+++ b/kube-core/src/dynamic.rs
@@ -1,14 +1,23 @@
 //! Contains types for using resource kinds not known at compile-time.
 //!
 //! For concrete usage see [examples prefixed with dynamic_](https://github.com/kube-rs/kube/tree/main/examples).
-
 pub use crate::discovery::ApiResource;
 use crate::{
     metadata::TypeMeta,
     resource::{DynamicResourceScope, Resource},
 };
+
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use std::borrow::Cow;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("failed to parse this DynamicObject into a Resource: {source}")]
+/// Failed to parse `DynamicObject` into `Resource`
+pub struct ParseDynamicObjectError {
+    #[from]
+    source: serde_json::Error,
+}
 
 /// A dynamic representation of a kubernetes object
 ///
@@ -57,6 +66,13 @@ impl DynamicObject {
         self.metadata.namespace = Some(ns.into());
         self
     }
+
+    /// Attempt to convert this `DynamicObject` to a `Resource`
+    pub fn try_parse<K: Resource + for<'a> serde::Deserialize<'a>>(
+        self,
+    ) -> Result<K, ParseDynamicObjectError> {
+        Ok(serde_json::from_value(serde_json::to_value(self)?)?)
+    }
 }
 
 impl Resource for DynamicObject {
@@ -101,6 +117,8 @@ mod test {
         request::Request,
         resource::Resource,
     };
+    use k8s_openapi::api::core::v1::Pod;
+
     #[test]
     fn raw_custom_resource() {
         let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo");
@@ -126,5 +144,28 @@ mod test {
         let pp = PostParams::default();
         let req = Request::new(url).create(&pp, vec![]).unwrap();
         assert_eq!(req.uri(), "/api/v1/services?");
+    }
+
+    #[test]
+    fn can_parse_dynamic_object_into_pod() -> Result<(), serde_json::Error> {
+        let original_pod: Pod = serde_json::from_value(serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": { "name": "example" },
+            "spec": {
+                "containers": [{
+                    "name": "example",
+                    "image": "alpine",
+                    // Do nothing
+                    "command": ["tail", "-f", "/dev/null"],
+                }],
+            }
+        }))?;
+        let dynamic_pod: DynamicObject = serde_json::from_str(&serde_json::to_string(&original_pod)?)?;
+        let parsed_pod: Pod = dynamic_pod.try_parse().unwrap();
+
+        assert_eq!(parsed_pod, original_pod);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Signed-off-by: Jessie Chatham Spencer <jessie@teainspace.com>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Issue #1029 requests a method to convert a `DynamicObject` into a `Resource`. Such a method would avoid having to repeatedly implement this logic.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

This PR implements the `DynamicObject::try_parse` method to facilitate easy conversion from a `DynamicObject` to a `Resource`. The method uses `serde_json` to first serialize the `DynamicObject` and then deserialize the JSON to the `Resource`.

A small error type `ParseDynamicObjectError` has been implemented as well to represent a parsing failure. It wraps the original `serde_json::Error` so the original error information is preserved.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
