### PR TITLE
Bump tracing dependency to 0.1.36

### DIFF
--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -25,7 +25,7 @@ openssl = ["kube/openssl-tls"]
 
 [dependencies]
 anyhow = "1.0.44"
-tracing = "0.1.29"
+tracing = "0.1.36"
 tracing-subscriber = "0.3.3"
 futures = "0.3.17"
 kube = { path = "../kube", version = "^0.76.0", default-features = false, features = ["client", "runtime", "ws", "admission", "gzip"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -40,7 +40,7 @@ either = "1.6.1"
 schemars = "0.8.6"
 static_assertions = "1.1.0"
 tar = "0.4.37"
-tracing = "0.1.29"
+tracing = "0.1.36"
 tracing-subscriber = "0.3.3"
 warp = { version = "0.3", default-features = false, features = ["tls"] }
 http = "0.2.5"

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -66,7 +66,7 @@ tame-oauth = { version = "0.7.0", features = ["gcp"], optional = true }
 pin-project = { version = "1.0.4", optional = true }
 rand = { version = "0.8.3", optional = true }
 secrecy = { version = "0.8.0", features = ["alloc", "serde"] }
-tracing = { version = "0.1.29", features = ["log"], optional = true }
+tracing = { version = "0.1.36", features = ["log"], optional = true }
 hyper-openssl = { version = "0.9.2", optional = true }
 
 [dependencies.k8s-openapi]

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -30,7 +30,7 @@ parking_lot = "0.12.0"
 pin-project = "1.0.2"
 tokio = { version = "1.14.0", features = ["time"] }
 tokio-util = { version = "0.7.0", features = ["time"] }
-tracing = "0.1.29"
+tracing = "0.1.36"
 json-patch = "0.2.6"
 serde_json = "1.0.68"
 thiserror = "1.0.29"


### PR DESCRIPTION
This was already required in practice, we just forgot to bump the version bound accordingly.

Fixes #1069.