### PR TITLE
fix: align kube-rs with client-go config parsing

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -42,6 +42,7 @@ dirs = { package = "dirs-next", optional = true, version = "2.0.0" }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = { version = "0.8.21", optional = true }
+serde_with = { version = "2.0.1" }
 http = "0.2.5"
 http-body = { version = "0.4.2", optional = true }
 either = { version = "1.6.1", optional = true }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -42,7 +42,6 @@ dirs = { package = "dirs-next", optional = true, version = "2.0.0" }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = { version = "0.8.21", optional = true }
-serde_with = { version = "2.0.1" }
 http = "0.2.5"
 http-body = { version = "0.4.2", optional = true }
 either = { version = "1.6.1", optional = true }

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -533,7 +533,7 @@ mod test {
         );
 
         let config: Kubeconfig = serde_yaml::from_str(&test_file).unwrap();
-        let auth_info = &config.auth_infos[0].auth_info;
+        let auth_info = config.auth_infos[0].auth_info.as_ref().unwrap();
         match Auth::try_from(auth_info).unwrap() {
             Auth::RefreshableToken(RefreshableToken::Exec(refreshable)) => {
                 let (token, _expire, info) = Arc::try_unwrap(refreshable).unwrap().into_inner();

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -76,6 +76,10 @@ pub enum Error {
     #[error("failed to parse token-key")]
     ParseTokenKey(#[source] serde_json::Error),
 
+    /// command was missing from exec config
+    #[error("command must be specified to use exec authentication plugin")]
+    MissingCommand,
+
     /// OAuth error
     #[cfg(feature = "oauth")]
     #[cfg_attr(docsrs, doc(cfg(feature = "oauth")))]
@@ -461,7 +465,11 @@ pub struct ExecCredentialStatus {
 }
 
 fn auth_exec(auth: &ExecConfig) -> Result<ExecCredential, Error> {
-    let mut cmd = Command::new(&auth.command);
+    let mut cmd = match &auth.command {
+        Some(cmd) => Command::new(cmd),
+        None => return Err(Error::MissingCommand),
+    };
+
     if let Some(args) = &auth.args {
         cmd.args(args);
     }

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -120,7 +120,7 @@ pub struct NamedAuthInfo {
     #[serde(default)]
     pub name: String,
     /// Information that describes identity of the user
-    #[serde(rename = "user", default)]
+    #[serde(rename = "user")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_info: Option<AuthInfo>,
 }

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -223,7 +223,6 @@ impl PartialEq for AuthInfo {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct AuthProviderConfig {
     /// Name of the auth provider
-    #[serde(default)]
     pub name: String,
     /// Auth provider configuration
     #[serde(default)]

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -77,8 +77,7 @@ pub struct NamedExtension {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct NamedCluster {
     /// Name of cluster
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     /// Information about how to communicate with a kubernetes cluster
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster: Option<Cluster>,
@@ -117,8 +116,7 @@ pub struct Cluster {
 #[cfg_attr(test, derive(PartialEq))]
 pub struct NamedAuthInfo {
     /// Name of the user
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     /// Information that describes identity of the user
     #[serde(rename = "user")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -266,8 +264,7 @@ pub struct ExecConfig {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct NamedContext {
     /// Name of the context
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     /// Associations for the context
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<Context>,
@@ -278,11 +275,9 @@ pub struct NamedContext {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct Context {
     /// Name of the cluster for this context
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cluster: Option<String>,
+    pub cluster: String,
     /// Name of the `AuthInfo` for this context
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<String>,
+    pub user: String,
     /// The default namespace to use on unspecified requests
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
@@ -432,7 +427,7 @@ fn kubeconfig_from_yaml(text: &str) -> Result<Vec<Kubeconfig>, KubeconfigError> 
 #[allow(clippy::redundant_closure)]
 fn append_new_named<T, F>(base: &mut Vec<T>, next: Vec<T>, f: F)
 where
-    F: Fn(&T) -> &Option<String>,
+    F: Fn(&T) -> &String,
 {
     use std::collections::HashSet;
     base.extend({
@@ -542,7 +537,7 @@ mod tests {
         let kubeconfig1 = Kubeconfig {
             current_context: Some("default".into()),
             auth_infos: vec![NamedAuthInfo {
-                name: Some("red-user".into()),
+                name: "red-user".into(),
                 auth_info: Some(AuthInfo {
                     token: Some(SecretString::from_str("first-token").unwrap()),
                     ..Default::default()
@@ -554,7 +549,7 @@ mod tests {
             current_context: Some("dev".into()),
             auth_infos: vec![
                 NamedAuthInfo {
-                    name: Some("red-user".into()),
+                    name: "red-user".into(),
                     auth_info: Some(AuthInfo {
                         token: Some(SecretString::from_str("second-token").unwrap()),
                         username: Some("red-user".into()),
@@ -562,7 +557,7 @@ mod tests {
                     }),
                 },
                 NamedAuthInfo {
-                    name: Some("green-user".into()),
+                    name: "green-user".into(),
                     auth_info: Some(AuthInfo {
                         token: Some(SecretString::from_str("new-token").unwrap()),
                         ..Default::default()
@@ -576,7 +571,7 @@ mod tests {
         // Preserves first `current_context`
         assert_eq!(merged.current_context, Some("default".into()));
         // Auth info with the same name does not overwrite
-        assert_eq!(merged.auth_infos[0].name.as_ref().unwrap(), "red-user");
+        assert_eq!(merged.auth_infos[0].name, "red-user");
         assert_eq!(
             merged.auth_infos[0]
                 .auth_info
@@ -590,7 +585,7 @@ mod tests {
         // Even if it's not conflicting
         assert_eq!(merged.auth_infos[0].auth_info.as_ref().unwrap().username, None);
         // New named auth info is appended
-        assert_eq!(merged.auth_infos[1].name.as_ref().unwrap(), "green-user");
+        assert_eq!(merged.auth_infos[1].name, "green-user");
     }
 
     #[test]
@@ -652,8 +647,8 @@ users:
 
         let config = Kubeconfig::from_yaml(config_yaml).unwrap();
 
-        assert_eq!(config.clusters[0].name.as_ref().unwrap(), "eks");
-        assert_eq!(config.clusters[1].name.as_ref().unwrap(), "minikube");
+        assert_eq!(config.clusters[0].name, "eks");
+        assert_eq!(config.clusters[1].name, "minikube");
 
         let cluster1 = config.clusters[1].cluster.as_ref().unwrap();
         assert_eq!(
@@ -708,8 +703,8 @@ users:
         let cfg = Kubeconfig::from_yaml(config_yaml)?;
 
         // Ensure we have data from both documents:
-        assert_eq!(cfg.clusters[0].name.as_ref().unwrap(), "k3d-promstack");
-        assert_eq!(cfg.clusters[1].name.as_ref().unwrap(), "k3d-k3s-default");
+        assert_eq!(cfg.clusters[0].name, "k3d-promstack");
+        assert_eq!(cfg.clusters[1].name, "k3d-k3s-default");
 
         Ok(())
     }

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -66,7 +66,6 @@ pub struct Preferences {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct NamedExtension {
     /// Name of extension
-    #[serde(default)]
     pub name: String,
     /// Additional information for extenders so that reads and writes don't clobber unknown fields
     pub extension: serde_json::Value,
@@ -77,7 +76,6 @@ pub struct NamedExtension {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct NamedCluster {
     /// Name of cluster
-    #[serde(default)]
     pub name: String,
     /// Information about how to communicate with a kubernetes cluster
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -89,8 +87,8 @@ pub struct NamedCluster {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct Cluster {
     /// The address of the kubernetes cluster (https://hostname:port).
-    #[serde(default)]
-    pub server: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
     /// Skips the validity check for the server's certificate. This will make your HTTPS connections insecure.
     #[serde(rename = "insecure-skip-tls-verify")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -117,7 +115,6 @@ pub struct Cluster {
 #[cfg_attr(test, derive(PartialEq))]
 pub struct NamedAuthInfo {
     /// Name of the user
-    #[serde(default)]
     pub name: String,
     /// Information that describes identity of the user
     #[serde(rename = "user")]
@@ -243,8 +240,8 @@ pub struct ExecConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_version: Option<String>,
     /// Command to execute.
-    #[serde(default)]
-    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
     /// Arguments to pass to the command when executing it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub args: Option<Vec<String>>,
@@ -266,7 +263,6 @@ pub struct ExecConfig {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct NamedContext {
     /// Name of the context
-    #[serde(default)]
     pub name: String,
     /// Associations for the context
     #[serde(default)]

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -66,7 +66,6 @@ pub struct Preferences {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct NamedExtension {
     /// Name of extension
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// Additional information for extenders so that reads and writes don't clobber unknown fields
     pub extension: serde_json::Value,

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -66,7 +66,7 @@ pub struct Preferences {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct NamedExtension {
     /// Name of extension
-    pub name: Option<String>,
+    pub name: String,
     /// Additional information for extenders so that reads and writes don't clobber unknown fields
     pub extension: serde_json::Value,
 }

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -662,33 +662,6 @@ users:
         );
     }
 
-//     #[test]
-//     fn kubeconfig_deserialize_emptystrings() {
-//         let config_yaml = "apiVersion: v1
-// clusters:
-// - cluster:
-//     certificate-authority: /home/kevin/.minikube/ca.crt
-//     server: d
-//   name: minikube
-// contexts:
-// - context:
-//     cluster: minikube
-//     user: minikube
-//   name: minikube
-// current-context: minikube
-// kind: Config
-// preferences: {}
-// users:
-// - name: minikube
-//   user:
-//     client-certificate: /home/kevin/.minikube/profiles/minikube/client.crt
-//     client-key: /home/kevin/.minikube/profiles/minikube/client.key";
-
-//         let config = Kubeconfig::from_yaml(config_yaml).unwrap();
-
-//         assert_eq!(config.clusters[0].cluster.as_ref().unwrap().server, "");
-//     }
-
     #[test]
     fn kubeconfig_multi_document_merge() -> Result<(), KubeconfigError> {
         let config_yaml = r#"---

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -305,7 +305,7 @@ impl Kubeconfig {
         for mut config in kubeconfig_from_yaml(&data)? {
             if let Some(dir) = path.as_ref().parent() {
                 for named in config.clusters.iter_mut() {
-                    if let Some(cluster) =  &mut named.cluster {
+                    if let Some(cluster) = &mut named.cluster {
                         if let Some(path) = &cluster.certificate_authority {
                             if let Some(abs_path) = to_absolute(dir, path) {
                                 cluster.certificate_authority = Some(abs_path);
@@ -314,7 +314,7 @@ impl Kubeconfig {
                     }
                 }
                 for named in config.auth_infos.iter_mut() {
-                    if let Some(auth_info) =  &mut named.auth_info {
+                    if let Some(auth_info) = &mut named.auth_info {
                         if let Some(path) = &auth_info.client_certificate {
                             if let Some(abs_path) = to_absolute(dir, path) {
                                 auth_info.client_certificate = Some(abs_path);
@@ -654,10 +654,10 @@ users:
 
         assert_eq!(config.clusters[0].name.as_ref().unwrap(), "eks");
         assert_eq!(config.clusters[1].name.as_ref().unwrap(), "minikube");
+
+        let cluster1 = config.clusters[1].cluster.as_ref().unwrap();
         assert_eq!(
-            config.clusters[1].cluster.as_ref().unwrap().extensions.as_ref().unwrap()[0]
-                .extension
-                .get("provider"),
+            cluster1.extensions.as_ref().unwrap()[0].extension.get("provider"),
             Some(&Value::String("minikube.sigs.k8s.io".to_owned()))
         );
     }

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -6,6 +6,7 @@ use std::{
 
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_with::serde_as;
 
 use super::{KubeconfigError, LoadDataError};
 
@@ -72,20 +73,24 @@ pub struct NamedExtension {
 }
 
 /// NamedCluster associates name with cluster.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct NamedCluster {
     /// Name of cluster
+    #[serde(default)]
     pub name: String,
     /// Information about how to communicate with a kubernetes cluster
+    #[serde_as(as = "serde_with::DefaultOnNull")]
     pub cluster: Cluster,
 }
 
 /// Cluster stores information to connect Kubernetes cluster.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct Cluster {
     /// The address of the kubernetes cluster (https://hostname:port).
+    #[serde(default)]
     pub server: String,
     /// Skips the validity check for the server's certificate. This will make your HTTPS connections insecure.
     #[serde(rename = "insecure-skip-tls-verify")]
@@ -109,13 +114,16 @@ pub struct Cluster {
 }
 
 /// NamedAuthInfo associates name with authentication.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct NamedAuthInfo {
     /// Name of the user
+    #[serde(default)]
     pub name: String,
     /// Information that describes identity of the user
-    #[serde(rename = "user")]
+    #[serde(rename = "user", default)]
+    #[serde_as(as = "serde_with::DefaultOnNull")]
     pub auth_info: AuthInfo,
 }
 
@@ -214,12 +222,16 @@ impl PartialEq for AuthInfo {
 }
 
 /// AuthProviderConfig stores auth for specified cloud provider.
+#[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct AuthProviderConfig {
     /// Name of the auth provider
+    #[serde(default)]
     pub name: String,
     /// Auth provider configuration
+    #[serde(default)]
+    #[serde_as(as = "serde_with::DefaultOnNull")]
     pub config: HashMap<String, String>,
 }
 
@@ -252,22 +264,26 @@ pub struct ExecConfig {
 }
 
 /// NamedContext associates name with context.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct NamedContext {
     /// Name of the context
+    #[serde(default)]
     pub name: String,
     /// Associations for the context
+    #[serde(default)]
     pub context: Context,
 }
 
 /// Context stores tuple of cluster and user information.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct Context {
     /// Name of the cluster for this context
+    #[serde(default)]
     pub cluster: String,
     /// Name of the `AuthInfo` for this context
+    #[serde(default)]
     pub user: String,
     /// The default namespace to use on unspecified requests
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/kube-client/src/config/file_loader.rs
+++ b/kube-client/src/config/file_loader.rs
@@ -78,7 +78,7 @@ impl ConfigLoader {
             .clusters
             .iter()
             .find(|named_cluster| &named_cluster.name == cluster_name)
-            .map(|named_cluster| &named_cluster.cluster)
+            .and_then(|named_cluster| named_cluster.cluster.clone())
             .ok_or_else(|| KubeconfigError::LoadClusterOfContext(cluster_name.clone()))?;
 
         let user_name = user.unwrap_or(&current_context.user);
@@ -86,13 +86,13 @@ impl ConfigLoader {
             .auth_infos
             .iter()
             .find(|named_user| &named_user.name == user_name)
-            .map(|named_user| &named_user.auth_info)
+            .and_then(|named_user| named_user.auth_info.clone())
             .ok_or_else(|| KubeconfigError::FindUser(user_name.clone()))?;
 
         Ok(ConfigLoader {
             current_context: current_context.clone(),
-            cluster: cluster.clone().unwrap_or_default(),
-            user: user.clone().unwrap_or_default(),
+            cluster,
+            user,
         })
     }
 

--- a/kube-client/src/config/file_loader.rs
+++ b/kube-client/src/config/file_loader.rs
@@ -66,26 +66,29 @@ impl ConfigLoader {
         } else {
             return Err(KubeconfigError::CurrentContextNotSet);
         };
+
         let current_context = config
             .contexts
             .iter()
-            .find(|named_context| &named_context.name == context_name)
-            .map(|named_context| &named_context.context)
+            .find(|named_context| &named_context.name.clone().unwrap_or_default() == context_name)
+            .and_then(|named_context| named_context.context.clone())
             .ok_or_else(|| KubeconfigError::LoadContext(context_name.clone()))?;
 
-        let cluster_name = cluster.unwrap_or(&current_context.cluster);
+        let current_cluster_name = &current_context.cluster.clone().unwrap_or_default();
+        let cluster_name = cluster.unwrap_or(current_cluster_name);
         let cluster = config
             .clusters
             .iter()
-            .find(|named_cluster| &named_cluster.name == cluster_name)
+            .find(|named_cluster| &named_cluster.name.clone().unwrap_or_default() == cluster_name)
             .and_then(|named_cluster| named_cluster.cluster.clone())
             .ok_or_else(|| KubeconfigError::LoadClusterOfContext(cluster_name.clone()))?;
 
-        let user_name = user.unwrap_or(&current_context.user);
+        let current_user_name = &current_context.user.clone().unwrap_or_default();
+        let user_name = user.unwrap_or(&current_user_name);
         let user = config
             .auth_infos
             .iter()
-            .find(|named_user| &named_user.name == user_name)
+            .find(|named_user| &named_user.name.clone().unwrap_or_default() == user_name)
             .and_then(|named_user| named_user.auth_info.clone())
             .ok_or_else(|| KubeconfigError::FindUser(user_name.clone()))?;
 

--- a/kube-client/src/config/file_loader.rs
+++ b/kube-client/src/config/file_loader.rs
@@ -59,12 +59,11 @@ impl ConfigLoader {
         cluster: Option<&String>,
         user: Option<&String>,
     ) -> Result<Self, KubeconfigError> {
+        let current_context_name = &config.current_context.clone().unwrap_or_default();
         let context_name = if let Some(name) = context {
             name
-        } else if let Some(name) = &config.current_context {
-            name
         } else {
-            return Err(KubeconfigError::CurrentContextNotSet);
+            current_context_name
         };
 
         let current_context = config

--- a/kube-client/src/config/file_loader.rs
+++ b/kube-client/src/config/file_loader.rs
@@ -91,8 +91,8 @@ impl ConfigLoader {
 
         Ok(ConfigLoader {
             current_context: current_context.clone(),
-            cluster: cluster.clone(),
-            user: user.clone(),
+            cluster: cluster.clone().unwrap_or_default(),
+            user: user.clone().unwrap_or_default(),
         })
     }
 

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -299,6 +299,8 @@ impl Config {
         let cluster_url = loader
             .cluster
             .server
+            .clone()
+            .unwrap_or_default()
             .parse::<http::Uri>()
             .map_err(KubeconfigError::ParseClusterUrl)?;
 

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -29,10 +29,6 @@ pub struct InferConfigError {
 /// Possible errors when loading kubeconfig
 #[derive(Error, Debug)]
 pub enum KubeconfigError {
-    /// Failed to determine current context
-    #[error("failed to determine current context")]
-    CurrentContextNotSet,
-
     /// Kubeconfigs with mismatching kind cannot be merged
     #[error("kubeconfigs with mismatching kind cannot be merged")]
     KindMismatch,

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -69,6 +69,10 @@ pub enum KubeconfigError {
     #[error("the structure of the parsed kubeconfig is invalid: {0}")]
     InvalidStructure(#[source] serde_yaml::Error),
 
+    /// Cluster url is missing on selected cluster
+    #[error("cluster url is missing on selected cluster")]
+    MissingClusterUrl,
+
     /// Failed to parse cluster url
     #[error("failed to parse cluster url: {0}")]
     ParseClusterUrl(#[source] http::uri::InvalidUri),
@@ -300,7 +304,7 @@ impl Config {
             .cluster
             .server
             .clone()
-            .unwrap_or_default()
+            .ok_or(KubeconfigError::MissingClusterUrl)?
             .parse::<http::Uri>()
             .map_err(KubeconfigError::ParseClusterUrl)?;
 

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -29,6 +29,10 @@ pub struct InferConfigError {
 /// Possible errors when loading kubeconfig
 #[derive(Error, Debug)]
 pub enum KubeconfigError {
+    /// Failed to determine current context
+    #[error("failed to determine current context")]
+    CurrentContextNotSet,
+
     /// Kubeconfigs with mismatching kind cannot be merged
     #[error("kubeconfigs with mismatching kind cannot be merged")]
     KindMismatch,


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Fixes #1076

## Solution

I went through each field on my kubeconfig and removed it / set it to null, then I tried both kubectl and cube-rs example kubectl. If it succeeded on kubectl but failed on kube-rs, I added a default and moved to the next field.

The part I struggled with was parsing of null values, such as 

```
  - cluster:
    name: gke_oenning-sandbox_us-central1-c_cluster-1
```

I couldn't find how to do it with serve alone, so I had to add the serde_with crate.

Some properties like `cluster.server` are useless when empty, but the user might not be interacting with that cluster/context, so it should not be causing errors for something that might not impact its usage. If they try to use that cluster, they'll then have an error somewhere else. 

Note: I'll add a unit test as well, but I want to get it out here for feedback early on in case someone disagree with the solution.