### PR TITLE
kube-derive: Disable `option_nullable` for CRD generation

### DIFF
--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -374,6 +374,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
                 .with(|s| {
                     s.inline_subschemas = true;
                     s.meta_schema = None;
+                    s.option_nullable = false;
                 })
                 .with_visitor(#kube_core::schema::StructuralSchemaRewriter)
                 .into_generator();

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -27,15 +27,15 @@ struct FooSpec {
     non_nullable_with_default: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    nullable_skipped: Option<String>,
-    nullable: Option<String>,
+    option_skipped: Option<String>,
+    option: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default = "default_nullable")]
-    nullable_skipped_with_default: Option<String>,
+    #[serde(default = "default_option")]
+    option_skipped_with_default: Option<String>,
 
-    #[serde(default = "default_nullable")]
-    nullable_with_default: Option<String>,
+    #[serde(default = "default_option")]
+    option_with_default: Option<String>,
 
     // Using feature `chrono`
     timestamp: DateTime<Utc>,
@@ -51,8 +51,8 @@ fn default_value() -> String {
     "default_value".into()
 }
 
-fn default_nullable() -> Option<String> {
-    Some("default_nullable".into())
+fn default_option() -> Option<String> {
+    Some("default_option".into())
 }
 
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
@@ -128,10 +128,10 @@ fn test_serialized_matches_expected() {
         serde_json::to_value(Foo::new("bar", FooSpec {
             non_nullable: "asdf".to_string(),
             non_nullable_with_default: "asdf".to_string(),
-            nullable_skipped: None,
-            nullable: None,
-            nullable_skipped_with_default: None,
-            nullable_with_default: None,
+            option_skipped: None,
+            option: None,
+            option_skipped_with_default: None,
+            option_with_default: None,
             timestamp: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
             complex_enum: ComplexEnum::VariantOne { int: 23 },
             untagged_enum_person: UntaggedEnumPerson::GenderAndAge(GenderAndAge {
@@ -149,8 +149,8 @@ fn test_serialized_matches_expected() {
             "spec": {
                 "nonNullable": "asdf",
                 "nonNullableWithDefault": "asdf",
-                "nullable": null,
-                "nullableWithDefault": null,
+                "option": null,
+                "optionWithDefault": null,
                 "timestamp": "1970-01-01T00:00:00Z",
                 "complexEnum": {
                     "variantOne": {
@@ -206,23 +206,18 @@ fn test_crd_schema_matches_expected() {
                                                 "default": "default_value",
                                                 "type": "string"
                                             },
-
-                                            "nullableSkipped": {
-                                                "nullable": true,
+                                            "optionSkipped": {
                                                 "type": "string"
                                             },
-                                            "nullable": {
-                                                "nullable": true,
+                                            "option": {
                                                 "type": "string"
                                             },
-                                            "nullableSkippedWithDefault": {
-                                                "default": "default_nullable",
-                                                "nullable": true,
+                                            "optionSkippedWithDefault": {
+                                                "default": "default_option",
                                                 "type": "string"
                                             },
-                                            "nullableWithDefault": {
-                                                "default": "default_nullable",
-                                                "nullable": true,
+                                            "optionWithDefault": {
+                                                "default": "default_option",
                                                 "type": "string"
                                             },
                                             "timestamp": {


### PR DESCRIPTION
Fixes: #1078 

Check the related issue for discussion.

See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting-and-nullable for what this option does.