### PR TITLE
Improve error message on azure auth not being supported

### DIFF
--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -324,6 +324,9 @@ fn token_from_provider(provider: &AuthProviderConfig) -> Result<ProviderToken, E
     match provider.name.as_ref() {
         "oidc" => token_from_oidc_provider(provider),
         "gcp" => token_from_gcp_provider(provider),
+        "azure" => Err(Error::AuthExec(
+            "The azure auth plugin is not supported; use https://github.com/Azure/kubelogin instead".into()
+        )),
         _ => Err(Error::AuthExec(format!(
             "Authentication with provider {:} not supported",
             provider.name


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

It's reasonable not to support the deprecated azure auth provider, but the error message should guide users to an alternative, like kubectl does.

## Solution

Improve error message.