### PR TITLE
Fix interactivity in auth exec

### DIFF
--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -65,7 +65,7 @@ pub enum Error {
     AuthExecParse(#[source] serde_json::Error),
 
     /// Fail to serialize input
-    #[error("fail to serialize input: {0}")]
+    #[error("failed to serialize input: {0}")]
     AuthExecSerialize(#[source] serde_json::Error),
 
     /// Failed to exec auth

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -249,6 +249,22 @@ pub struct ExecConfig {
     /// It has been suggested in client-go via https://github.com/kubernetes/client-go/issues/1177
     #[serde(skip)]
     pub drop_env: Option<Vec<String>>,
+
+    /// Interative mode of the auth plugins
+    #[serde(rename = "interactiveMode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interactive_mode: Option<ExecInteractiveMode>,
+}
+
+/// ExecInteractiveMode define the interactity of the child process
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum ExecInteractiveMode {
+    /// Never get interactive
+    Never,
+    /// If available et interactive
+    IfAvailable,
+    /// Alwayes get interactive
+    Always,
 }
 
 /// NamedContext associates name with context.

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -258,6 +258,7 @@ pub struct ExecConfig {
 
 /// ExecInteractiveMode define the interactity of the child process
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(test, derive(Eq))]
 pub enum ExecInteractiveMode {
     /// Never get interactive
     Never,

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -395,8 +395,8 @@ const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(295);
 
 // Expose raw config structs
 pub use file_config::{
-    AuthInfo, AuthProviderConfig, Cluster, Context, ExecConfig, Kubeconfig, NamedAuthInfo, NamedCluster,
-    NamedContext, NamedExtension, Preferences,
+    AuthInfo, AuthProviderConfig, Cluster, Context, ExecConfig, ExecInteractiveMode, Kubeconfig,
+    NamedAuthInfo, NamedCluster, NamedContext, NamedExtension, Preferences,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
Signed-off-by: armandpicard <armandpicard71@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Adding support for interactivity in auth exec and putting this information to the executed programs is needed; especialy on Windows (#1046 ).
<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
I've added simple support for `interactiveMode` by giving parent process stdin to child process if needed and give information about interactivity with the `KUBERNETES_EXEC_INFO` env variable.