### PR TITLE
Skip cargo-deny issue on windows deps + rustfmt

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -83,6 +83,26 @@ multiple-versions = "deny"
 name = "idna"
 version = "0.2"
 
+# waiting on hyper-rustls and below to bump its chain
+[[bans.skip]]
+name = "windows_i686_msvc"
+version = "0.36"
+[[bans.skip]]
+name = "windows_aarch64_msvc"
+version = "0.36"
+[[bans.skip]]
+name = "windows-sys"
+version = "0.36"
+[[bans.skip]]
+name = "windows_i686_gnu"
+version = "0.36"
+[[bans.skip]]
+name = "windows_x86_64_msvc"
+version = "0.36"
+[[bans.skip]]
+name = "windows_x86_64_gnu"
+version = "0.36"
+
 [[bans.skip]]
 # waiting for ahash/getrandom to bump wasi as we have two branches:
 # ahash -> getrandom -> wasi old

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -325,7 +325,7 @@ fn token_from_provider(provider: &AuthProviderConfig) -> Result<ProviderToken, E
         "oidc" => token_from_oidc_provider(provider),
         "gcp" => token_from_gcp_provider(provider),
         "azure" => Err(Error::AuthExec(
-            "The azure auth plugin is not supported; use https://github.com/Azure/kubelogin instead".into()
+            "The azure auth plugin is not supported; use https://github.com/Azure/kubelogin instead".into(),
         )),
         _ => Err(Error::AuthExec(format!(
             "Authentication with provider {:} not supported",


### PR DESCRIPTION
Replaces https://github.com/kube-rs/kube/pull/1084 and skips the lint issue that caused me to merge early.