### PR TITLE
enable inject related_obj into reconciler

### DIFF
--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -28,7 +28,7 @@ pub mod utils;
 pub mod wait;
 pub mod watcher;
 
-pub use controller::{applier, Controller};
+pub use controller::{applier, applier_with_injection, Controller};
 pub use finalizer::finalizer;
 pub use reflector::reflector;
 pub use scheduler::scheduler;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

The `reconciler` callback function of the `Controller` does not currently support getting the related object.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

Defining a trait `Reconciler` and implement it for `fn(Arc<K>, Arc<Ctx>)`, `fn(Arc<K>, Arc<Ctx>, Option<Box<ObjectRef<DynamicObject>>>)` and `fn(Arc<K>, Arc<Ctx>, ReconcileRequest<K>)`

Then the code can be like
```rust
async fn reconcile(
    generator: Arc<ConfigMapGenerator>,
    ctx: Arc<Data>,
    // without `related_obj` is also ok, this param will be injected by the applier
    related_obj: Option<Box<ObjectRef<DynamicObject>>>,
) -> Result<Action, Error> {
  todo!()
}

Controller::new(cmgs, ListParams::default())
    .owns(cms, ListParams::default())
    .reconcile_all_on(reload_rx.map(|_| ()))
    .shutdown_on_signal()
    .run_with_injection(reconcile, error_policy, Arc::new(Data { client }))
    .for_each(|res| async move {
        match res {
            Ok(o) => info!("reconciled {:?}", o),
            Err(e) => warn!("reconcile failed: {}", e),
        }
    })
    .await;
```