### PR TITLE
[windows] skip window creation on auth exec

### DIFF
--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -4,6 +4,9 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 use chrono::{DateTime, Duration, Utc};
 use futures::future::BoxFuture;
 use http::{
@@ -497,6 +500,12 @@ fn auth_exec(auth: &ExecConfig) -> Result<ExecCredential, Error> {
         }
     }
 
+    #[cfg(target_os = "windows")]
+    {
+        static CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    
     let out = cmd.output().map_err(Error::AuthExecStart)?;
     if !out.status.success() {
         return Err(Error::AuthExecRun {

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -4,8 +4,7 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
+#[cfg(target_os = "windows")] use std::os::windows::process::CommandExt;
 
 use chrono::{DateTime, Duration, Utc};
 use futures::future::BoxFuture;
@@ -505,7 +504,7 @@ fn auth_exec(auth: &ExecConfig) -> Result<ExecCredential, Error> {
         static CREATE_NO_WINDOW: u32 = 0x08000000;
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
-    
+
     let out = cmd.output().map_err(Error::AuthExecStart)?;
     if !out.status.success() {
         return Err(Error::AuthExecRun {

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -501,7 +501,7 @@ fn auth_exec(auth: &ExecConfig) -> Result<ExecCredential, Error> {
 
     #[cfg(target_os = "windows")]
     {
-        static CREATE_NO_WINDOW: u32 = 0x08000000;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
 

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -4,7 +4,6 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(target_os = "windows")] use std::os::windows::process::CommandExt;
 
 use chrono::{DateTime, Duration, Utc};
 use futures::future::BoxFuture;
@@ -23,6 +22,7 @@ use crate::config::{AuthInfo, AuthProviderConfig, ExecConfig};
 
 #[cfg(feature = "oauth")] mod oauth;
 #[cfg(feature = "oauth")] pub use oauth::Error as OAuthError;
+#[cfg(target_os = "windows")] use std::os::windows::process::CommandExt;
 
 #[derive(Error, Debug)]
 /// Client auth errors


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>


## Motivation

When using kube-rs on a Windows GUI application, the auth exec is showing a terminal window during execution. It often takes less than 1 second, but it's noticeable enough to become annoying :)

https://user-images.githubusercontent.com/94755/205284967-3466c250-8a09-4cd1-b7df-f7e35dd6d05f.mp4


## Solution

use the CREATE_NO_WINDOW flag to omit that.
