### PR TITLE
exec: ensure certs always end with a new line

### DIFF
--- a/kube-client/src/client/config_ext.rs
+++ b/kube-client/src/client/config_ext.rs
@@ -232,8 +232,12 @@ impl Config {
     fn exec_identity_pem(&self) -> Option<Vec<u8>> {
         match Auth::try_from(&self.auth_info) {
             Ok(Auth::Certificate(client_certificate_data, client_key_data)) => {
+                const NEW_LINE: u8 = b'\n';
+
                 let mut buffer = client_key_data.expose_secret().as_bytes().to_vec();
+                buffer.push(NEW_LINE);
                 buffer.extend_from_slice(client_certificate_data.as_bytes());
+                buffer.push(NEW_LINE);
                 Some(buffer)
             }
             _ => None,


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>


## Motivation

While testing it changes from #1089, I got this error:

    1: failed to deserialize PEM-encoded chain of certificates: error:0908F066:PEM routines:get_header_and_data:bad end line:crypto/pem/pem_lib.c:856:

It worked on kubectl, but not on kube-rs. 

## Solution

After some digging I noticed that PEM-encoded was missing a \n at the end, which seems to be what OpenSSL expects. Apparently Go is a bit more flexible with this and it's ok to not end with a new line. 

This PR ensures that certs always end with a new line. OpenSSL doesn't seem to care about ending with double new lines, so this PR simply appends a new line regardless if it already ends in one. Alternatively we could check before pushing.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
