### PR TITLE
load kubeconfig from custom environment variables 

### DIFF
--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -350,7 +350,17 @@ impl Kubeconfig {
     ///
     /// Panics if `KUBECONFIG` value contains the NUL character.
     pub fn from_env() -> Result<Option<Self>, KubeconfigError> {
-        match std::env::var_os(KUBECONFIG) {
+        Self::from_custom_env(KUBECONFIG)
+    }
+
+    /// Create `Kubeconfig` from a given environment variable.
+    /// Supports list of files to be merged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the environment variable value contains the NUL character.
+    pub fn from_custom_env(env_name: &str) -> Result<Option<Self>, KubeconfigError> {
+        match std::env::var_os(env_name) {
             Some(value) => {
                 let paths = std::env::split_paths(&value)
                     .filter(|p| !p.as_os_str().is_empty())


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

## Motivation
I'd like to support loading kubeconfig files from a non-standard environment variable name.

## Solution
I first tried to copy this function over to my project, but Kubeconfig's merge fn is private. We could make it public, but I thought it might be beneficial to make have this small additional function on kube-rs
