### PR TITLE
cargo clippy --fix for uninlined fmt args

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,0 @@
-blacklisted-names = []

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+disallowed-names = []

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -51,7 +51,7 @@ fn main() {
     });
     println!("Spec: {:?}", foo.spec);
     let crd = serde_json::to_string_pretty(&FooCrd::crd()).unwrap();
-    println!("Foo CRD: \n{}", crd);
+    println!("Foo CRD: \n{crd}");
 
     println!("Spec (via HasSpec): {:?}", foo.spec());
     println!("Status (via HasStatus): {:?}", foo.status());

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -250,7 +250,7 @@ async fn delete_crd(client: Client) -> Result<()> {
                 return Ok(());
             }
         }
-        Err(anyhow!(format!("CRD not deleted after {} seconds", timeout_secs)))
+        Err(anyhow!(format!("CRD not deleted after {timeout_secs} seconds")))
     } else {
         Ok(())
     }

--- a/examples/kubectl.rs
+++ b/examples/kubectl.rs
@@ -125,7 +125,7 @@ impl App {
 
     async fn watch(&self, api: Api<DynamicObject>, mut lp: ListParams) -> Result<()> {
         if let Some(n) = &self.name {
-            lp = lp.fields(&format!("metadata.name={}", n));
+            lp = lp.fields(&format!("metadata.name={n}"));
         }
         // present a dumb table for it for now. kubectl does not do this anymore.
         let mut stream = watcher(api, lp).applied_objects().boxed();
@@ -196,7 +196,7 @@ async fn main() -> Result<()> {
     if let Some(resource) = &app.resource {
         // Common discovery, parameters, and api configuration for a single resource
         let (ar, caps) = resolve_api_resource(&discovery, resource)
-            .with_context(|| format!("resource {:?} not found in cluster", resource))?;
+            .with_context(|| format!("resource {resource:?} not found in cluster"))?;
         let mut lp = ListParams::default();
         if let Some(label) = &app.selector {
             lp = lp.labels(label);
@@ -238,9 +238,9 @@ fn format_creation_since(time: Option<Time>) -> String {
 }
 fn format_duration(dur: Duration) -> String {
     match (dur.num_days(), dur.num_hours(), dur.num_minutes()) {
-        (days, _, _) if days > 0 => format!("{}d", days),
-        (_, hours, _) if hours > 0 => format!("{}h", hours),
-        (_, _, mins) => format!("{}m", mins),
+        (days, _, _) if days > 0 => format!("{days}d"),
+        (_, hours, _) if hours > 0 => format!("{hours}h"),
+        (_, _, mins) => format!("{mins}m"),
     }
 }
 

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -48,7 +48,7 @@ async fn check_for_node_failures(events: &Api<Event>, o: Node) -> anyhow::Result
         warn!("Unschedulable Node: {}, ({:?})", name, failed);
         // Find events related to this node
         let opts =
-            ListParams::default().fields(&format!("involvedObject.kind=Node,involvedObject.name={}", name));
+            ListParams::default().fields(&format!("involvedObject.kind=Node,involvedObject.name={name}"));
         let evlist = events.list(&opts).await?;
         for e in evlist {
             warn!("Node event: {:?}", serde_json::to_string_pretty(&e)?);

--- a/examples/pod_cp.rs
+++ b/examples/pod_cp.rs
@@ -77,7 +77,7 @@ async fn main() -> anyhow::Result<()> {
     {
         let ap = AttachParams::default().stderr(false);
         let mut cat = pods
-            .exec("example", vec!["cat", &format!("/{}", file_name)], &ap)
+            .exec("example", vec!["cat", &format!("/{file_name}")], &ap)
             .await?;
         let mut cat_out = tokio_util::io::ReaderStream::new(cat.stdout().unwrap());
         let next_stdout = cat_out.next().await.unwrap()?;

--- a/examples/pod_exec.rs
+++ b/examples/pod_exec.rs
@@ -62,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
             )
             .await?;
         let output = get_output(attached).await;
-        println!("{}", output);
+        println!("{output}");
         assert_eq!(output.lines().count(), 3);
     }
 
@@ -71,7 +71,7 @@ async fn main() -> anyhow::Result<()> {
             .exec("example", vec!["uptime"], &AttachParams::default().stderr(false))
             .await?;
         let output = get_output(attached).await;
-        println!("{}", output);
+        println!("{output}");
         assert_eq!(output.lines().count(), 1);
     }
 
@@ -89,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
         let next_stdout = stdout_stream.next();
         stdin_writer.write_all(b"echo test string 1\n").await?;
         let stdout = String::from_utf8(next_stdout.await.unwrap().unwrap().to_vec()).unwrap();
-        println!("{}", stdout);
+        println!("{stdout}");
         assert_eq!(stdout, "test string 1\n");
 
         // AttachedProcess provides access to a future that resolves with a status object.
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
         // Send `exit 1` to get a failure status.
         stdin_writer.write_all(b"exit 1\n").await?;
         if let Some(status) = status.await {
-            println!("{:?}", status);
+            println!("{status:?}");
             assert_eq!(status.status, Some("Failure".to_owned()));
             assert_eq!(status.reason, Some("NonZeroExitCode".to_owned()));
         }

--- a/examples/pod_shell_crossterm.rs
+++ b/examples/pod_shell_crossterm.rs
@@ -18,7 +18,7 @@ async fn handle_terminal_size(mut channel: Sender<TerminalSize>) -> Result<(), a
     // create a stream to catch SIGWINCH signal
     let mut sig = signal::unix::signal(signal::unix::SignalKind::window_change())?;
     loop {
-        if sig.recv().await == None {
+        if (sig.recv().await).is_none() {
             return Ok(());
         }
 
@@ -126,6 +126,6 @@ async fn main() -> anyhow::Result<()> {
             assert_eq!(pdel.name_any(), "example");
         });
 
-    println!("");
+    println!();
     Ok(())
 }

--- a/examples/secret_syncer.rs
+++ b/examples/secret_syncer.rs
@@ -32,7 +32,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 fn secret_name_for_configmap(cm: &ConfigMap) -> Result<String> {
     let name = cm.metadata.name.as_deref().ok_or(Error::NoName)?;
-    Ok(format!("cmsyncer-{}", name))
+    Ok(format!("cmsyncer-{name}"))
 }
 
 async fn apply(cm: Arc<ConfigMap>, secrets: &kube::Api<Secret>) -> Result<Action> {

--- a/kube-client/src/api/entry.rs
+++ b/kube-client/src/api/entry.rs
@@ -429,11 +429,11 @@ mod tests {
 
         let mut entry = match api.entry(object_name).await? {
             Entry::Occupied(entry) => entry,
-            entry => panic!("entry for existing object must be occupied: {:?}", entry),
+            entry => panic!("entry for existing object must be occupied: {entry:?}"),
         };
         let mut entry2 = match api.entry(object_name).await? {
             Entry::Occupied(entry) => entry,
-            entry => panic!("entry for existing object must be occupied: {:?}", entry),
+            entry => panic!("entry for existing object must be occupied: {entry:?}"),
         };
 
         // Entry is up-to-date, modify cleanly

--- a/kube-client/src/api/util/mod.rs
+++ b/kube-client/src/api/util/mod.rs
@@ -161,8 +161,7 @@ mod test {
         assert_eq!(
             tokenreviewstatus.user.unwrap().username,
             Some(format!(
-                "system:serviceaccount:{}:{}",
-                serviceaccount_namespace, serviceaccount_name
+                "system:serviceaccount:{serviceaccount_namespace}:{serviceaccount_name}"
             ))
         );
 

--- a/kube-client/src/client/middleware/base_uri.rs
+++ b/kube-client/src/client/middleware/base_uri.rs
@@ -70,7 +70,7 @@ fn set_base_uri(base_uri: &http::Uri, req_pandq: Option<&uri::PathAndQuery>) -> 
             // Remove any trailing slashes and join.
             // `PathAndQuery` always starts with a slash.
             let base_path = pandq.path().trim_end_matches('/');
-            builder.path_and_query(format!("{}{}", base_path, req_pandq))
+            builder.path_and_query(format!("{base_path}{req_pandq}"))
         } else {
             builder.path_and_query(pandq.as_str())
         };

--- a/kube-client/src/client/middleware/mod.rs
+++ b/kube-client/src/client/middleware/mod.rs
@@ -55,7 +55,7 @@ mod tests {
             let (request, send) = handle.next_request().await.expect("service not called");
             assert_eq!(
                 request.headers().get(AUTHORIZATION).unwrap(),
-                HeaderValue::try_from(format!("Bearer {}", TOKEN)).unwrap()
+                HeaderValue::try_from(format!("Bearer {TOKEN}")).unwrap()
             );
             send.send_response(Response::builder().body(Body::empty()).unwrap());
         });

--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -382,7 +382,7 @@ impl Client {
     /// # }
     /// ```
     pub async fn list_api_group_resources(&self, apiversion: &str) -> Result<k8s_meta_v1::APIResourceList> {
-        let url = format!("/apis/{}", apiversion);
+        let url = format!("/apis/{apiversion}");
         self.request(
             Request::builder()
                 .uri(url)
@@ -405,7 +405,7 @@ impl Client {
 
     /// Lists resources served in particular `core` group version.
     pub async fn list_core_api_resources(&self, version: &str) -> Result<k8s_meta_v1::APIResourceList> {
-        let url = format!("/api/{}", version);
+        let url = format!("/api/{version}");
         self.request(
             Request::builder()
                 .uri(url)
@@ -435,7 +435,7 @@ fn handle_api_errors(text: &str, s: StatusCode) -> Result<()> {
             let ae = ErrorResponse {
                 status: s.to_string(),
                 code: s.as_u16(),
-                message: format!("{:?}", text),
+                message: format!("{text:?}"),
                 reason: "Failed to parse error data".into(),
             };
             tracing::debug!("Unsuccessful: {:?} (reconstruct)", ae);

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -708,7 +708,7 @@ username: user
 password: kube_rs
 "#;
         let authinfo: AuthInfo = serde_yaml::from_str(authinfo_yaml).unwrap();
-        let authinfo_debug_output = format!("{:?}", authinfo);
+        let authinfo_debug_output = format!("{authinfo:?}");
         let expected_output = "AuthInfo { \
         username: Some(\"user\"), \
         password: Some(Secret([REDACTED alloc::string::String])), \

--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -140,9 +140,7 @@ impl ApiGroup {
                 return Ok((ar, caps));
             }
         }
-        Err(Error::Discovery(DiscoveryError::MissingKind(format!(
-            "{gvk:?}"
-        ))))
+        Err(Error::Discovery(DiscoveryError::MissingKind(format!("{gvk:?}"))))
     }
 
     // shortcut method to give cheapest return for a pinned group

--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -141,8 +141,7 @@ impl ApiGroup {
             }
         }
         Err(Error::Discovery(DiscoveryError::MissingKind(format!(
-            "{:?}",
-            gvk
+            "{gvk:?}"
         ))))
     }
 

--- a/kube-client/src/discovery/parse.rs
+++ b/kube-client/src/discovery/parse.rs
@@ -39,7 +39,7 @@ pub(crate) fn parse_apicapabilities(list: &APIResourceList, name: &str) -> Resul
         Scope::Cluster
     };
 
-    let subresource_name_prefix = format!("{}/", name);
+    let subresource_name_prefix = format!("{name}/");
     let mut subresources = vec![];
     for res in &list.resources {
         if let Some(subresource_name) = res.name.strip_prefix(&subresource_name_prefix) {

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -234,7 +234,7 @@ mod test {
         let mut stream = pods.watch(&lp, "0").await?.boxed();
         while let Some(ev) = stream.try_next().await? {
             // can debug format watch event
-            let _ = format!("we: {:?}", ev);
+            let _ = format!("we: {ev:?}");
             match ev {
                 WatchEvent::Modified(o) => {
                     let s = o.status.as_ref().expect("status exists on pod");
@@ -243,7 +243,7 @@ mod test {
                         break;
                     }
                 }
-                WatchEvent::Error(e) => panic!("watch error: {}", e),
+                WatchEvent::Error(e) => panic!("watch error: {e}"),
                 _ => {}
             }
         }
@@ -321,7 +321,7 @@ mod test {
                         break;
                     }
                 }
-                WatchEvent::Error(e) => panic!("watch error: {}", e),
+                WatchEvent::Error(e) => panic!("watch error: {e}"),
                 _ => {}
             }
         }
@@ -361,7 +361,7 @@ mod test {
             let next_stdout = stdout_stream.next();
             stdin_writer.write_all(b"echo test string 1\n").await?;
             let stdout = String::from_utf8(next_stdout.await.unwrap().unwrap().to_vec()).unwrap();
-            println!("{}", stdout);
+            println!("{stdout}");
             assert_eq!(stdout, "test string 1\n");
 
             // AttachedProcess resolves with status object.
@@ -369,7 +369,7 @@ mod test {
             stdin_writer.write_all(b"exit 1\n").await?;
             let status = attached.take_status().unwrap();
             if let Some(status) = status.await {
-                println!("{:?}", status);
+                println!("{status:?}");
                 assert_eq!(status.status, Some("Failure".to_owned()));
                 assert_eq!(status.reason, Some("NonZeroExitCode".to_owned()));
             }
@@ -435,7 +435,7 @@ mod test {
                         break;
                     }
                 }
-                WatchEvent::Error(e) => panic!("watch error: {}", e),
+                WatchEvent::Error(e) => panic!("watch error: {e}"),
                 _ => {}
             }
         }

--- a/kube-core/src/discovery.rs
+++ b/kube-core/src/discovery.rs
@@ -125,7 +125,7 @@ fn to_plural(word: &str) -> String {
         || word.ends_with("ch")
         || word.ends_with("sh")
     {
-        return format!("{}es", word);
+        return format!("{word}es");
     }
 
     // Words ending in y that are preceded by a consonant will be pluralized by
@@ -142,7 +142,7 @@ fn to_plural(word: &str) -> String {
     }
 
     // All other words will have "s" added to the end (eg. days).
-    format!("{}s", word)
+    format!("{word}s")
 }
 
 #[test]

--- a/kube-core/src/gvk.rs
+++ b/kube-core/src/gvk.rs
@@ -132,7 +132,7 @@ impl GroupVersionResource {
         let api_version = if group.is_empty() {
             version.to_string()
         } else {
-            format!("{}/{}", group, version)
+            format!("{group}/{version}")
         };
 
         Self {

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -534,15 +534,15 @@ mod test {
     #[test]
     fn delete_param_constructors() {
         let dp_background = DeleteParams::background();
-        let ser = serde_json::to_value(&dp_background).unwrap();
+        let ser = serde_json::to_value(dp_background).unwrap();
         assert_eq!(ser, serde_json::json!({"propagationPolicy": "Background"}));
 
         let dp_foreground = DeleteParams::foreground();
-        let ser = serde_json::to_value(&dp_foreground).unwrap();
+        let ser = serde_json::to_value(dp_foreground).unwrap();
         assert_eq!(ser, serde_json::json!({"propagationPolicy": "Foreground"}));
 
         let dp_orphan = DeleteParams::orphan();
-        let ser = serde_json::to_value(&dp_orphan).unwrap();
+        let ser = serde_json::to_value(dp_orphan).unwrap();
         assert_eq!(ser, serde_json::json!({"propagationPolicy": "Orphan"}));
     }
 

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -567,6 +567,6 @@ mod test {
         let lp = ListParams::default().limit(5);
         let url = corev1::Pod::url_path(&(), Some("ns"));
         let err = Request::new(url).watch(&lp, "0").unwrap_err();
-        assert!(format!("{}", err).contains("limit cannot be used with a watch"));
+        assert!(format!("{err}").contains("limit cannot be used with a watch"));
     }
 }

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -64,7 +64,7 @@ pub trait Resource {
     /// Creates a url path for http requests for this resource
     fn url_path(dt: &Self::DynamicType, namespace: Option<&str>) -> String {
         let n = if let Some(ns) = namespace {
-            format!("namespaces/{}/", ns)
+            format!("namespaces/{ns}/")
         } else {
             "".into()
         };

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -179,8 +179,7 @@ fn merge_metadata(
         (Some(common_type), Some(variant_type)) => {
             if *common_type != variant_type {
                 panic!(
-                    "variant defined type {:?}, conflicting with existing type {:?}",
-                    variant_type, common_type
+                    "variant defined type {variant_type:?}, conflicting with existing type {common_type:?}"
                 );
             }
         }

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -392,8 +392,7 @@ impl Request {
             for port in ports.iter() {
                 if seen.contains(port) {
                     return Err(Error::Validation(format!(
-                        "ports must be unique, found multiple {}",
-                        port
+                        "ports must be unique, found multiple {port}"
                     )));
                 }
                 seen.insert(port);

--- a/kube-core/src/watch.rs
+++ b/kube-core/src/watch.rs
@@ -34,7 +34,7 @@ impl<K> Debug for WatchEvent<K> {
             WatchEvent::Modified(_) => write!(f, "Modified event"),
             WatchEvent::Deleted(_) => write!(f, "Deleted event"),
             WatchEvent::Bookmark(_) => write!(f, "Bookmark event"),
-            WatchEvent::Error(e) => write!(f, "Error event: {:?}", e),
+            WatchEvent::Error(e) => write!(f, "Error event: {e:?}"),
         }
     }
 }

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -238,7 +238,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         derive_paths.push(syn::parse_quote! { #schemars::JsonSchema });
     }
 
-    let docstr = format!(" Auto-generated derived type for {} via `CustomResource`", ident);
+    let docstr = format!(" Auto-generated derived type for {ident} via `CustomResource`");
     let root_obj = quote! {
         #[doc = #docstr]
         #[automatically_derived]
@@ -287,7 +287,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         ("Cluster", quote! { #kube_core::ClusterResourceScope })
     };
 
-    let api_ver = format!("{}/{}", group, version);
+    let api_ver = format!("{group}/{version}");
     let impl_resource = quote! {
         impl #kube_core::Resource for #rootident {
             type DynamicType = ();
@@ -364,7 +364,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
 
     let categories_json = serde_json::to_string(&categories).unwrap();
     let short_json = serde_json::to_string(&shortnames).unwrap();
-    let crd_meta_name = format!("{}.{}", plural, group);
+    let crd_meta_name = format!("{plural}.{group}");
     let crd_meta = quote! { { "name": #crd_meta_name } };
 
     let schemagen = if schema_mode.use_in_crd() {
@@ -571,7 +571,7 @@ fn to_plural(word: &str) -> String {
         || word.ends_with("ch")
         || word.ends_with("sh")
     {
-        return format!("{}es", word);
+        return format!("{word}es");
     }
 
     // Words ending in y that are preceded by a consonant will be pluralized by
@@ -588,7 +588,7 @@ fn to_plural(word: &str) -> String {
     }
 
     // All other words will have "s" added to the end (eg. days).
-    format!("{}s", word)
+    format!("{word}s")
 }
 
 #[cfg(test)]

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -78,8 +78,7 @@ where
                             "`try_extract_item_case` returned `None` despite `should_consume_item` returning `true`",
                         ))),
                         res => panic!(
-                    "Peekable::poll_next() returned {:?} when Peekable::peek() returned Ready(Some(_))",
-                    res
+                    "Peekable::poll_next() returned {res:?} when Peekable::peek() returned Ready(Some(_))"
                 ),
                     }
                 } else {


### PR DESCRIPTION
Clippy CI has started complaining about [uninlined format args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)

We could have done this ages ago, but i think it conflicted with MSRV at some point.
It does look like this is from [rust 1.58](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html) though, so this should be fine from an MSRV perspective now.

Commits are all automated via `cargo +nightly clippy --fix -p kube-*` or `just fmt` (apart from a single deprecation rename in `clippy.toml` highlighted below)