### PR TITLE
Change `Kubeconfig::merge` fn to public.

### DIFF
--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -392,7 +392,7 @@ impl Kubeconfig {
     /// >   Example: Preserve the context of the first file to set `current-context`.
     /// >   Example: If two files specify a `red-user`, use only values from the first file's `red-user`.
     /// >            Even if the second file has non-conflicting entries under `red-user`, discard them.
-    fn merge(mut self, next: Kubeconfig) -> Result<Self, KubeconfigError> {
+    pub fn merge(mut self, next: Kubeconfig) -> Result<Self, KubeconfigError> {
         if self.kind.is_some() && next.kind.is_some() && self.kind != next.kind {
             return Err(KubeconfigError::KindMismatch);
         }


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

I need to support loading Kubeconfig from different locations and merge them myself, but unfortunately the merge fn is private.

## Solution

Change `Kubeconfig::merge` fn to public.