### PR TITLE
Return error from `watcher` when kinds do not support watch

### DIFF
--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -25,7 +25,7 @@ pub enum Error {
     WatchError(#[source] kube_client::error::ErrorResponse),
     #[error("watch stream failed: {0}")]
     WatchFailed(#[source] kube_client::Error),
-    #[error("No metadata.resourceVersion in watch result (does kind support watch?)")]
+    #[error("no metadata.resourceVersion in watch result (does resource support watch?)")]
     NoResourceVersion,
     #[error("too many objects matched search criteria")]
     TooManyObjects,

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -25,6 +25,8 @@ pub enum Error {
     WatchError(#[source] kube_client::error::ErrorResponse),
     #[error("watch stream failed: {0}")]
     WatchFailed(#[source] kube_client::Error),
+    #[error("No metadata.resourceVersion in watch result (does kind support watch?)")]
+    NoResourceVersion,
     #[error("too many objects matched search criteria")]
     TooManyObjects,
 }
@@ -139,9 +141,15 @@ async fn step_trampolined<K: Resource + Clone + DeserializeOwned + Debug + Send 
 ) -> (Option<Result<Event<K>>>, State<K>) {
     match state {
         State::Empty => match api.list(list_params).await {
-            Ok(list) => (Some(Ok(Event::Restarted(list.items))), State::InitListed {
-                resource_version: list.metadata.resource_version.unwrap(),
-            }),
+            Ok(list) => {
+                if let Some(resource_version) = list.metadata.resource_version {
+                    (Some(Ok(Event::Restarted(list.items))), State::InitListed {
+                        resource_version,
+                    })
+                } else {
+                    (Some(Err(Error::NoResourceVersion)), State::Empty)
+                }
+            }
             Err(err) => (Some(Err(err).map_err(Error::InitialListFailed)), State::Empty),
         },
         State::InitListed { resource_version } => match api.watch(list_params, &resource_version).await {


### PR DESCRIPTION
A quick fix for #1092. This should just cause the watcher to spin infinitely (like in the case where the crd isn't installed and people try to watch there). It's not 100% ideal, as an explicit crash __might__ be better for many users to be seen early.

> **sidenote**: A previously considered alternative we have thought about is to look at having `watcher` separate between **recoverable** and **irrecoverable** errors (e.g. a resource not being installed or support watch). The problem between trying to do that separation is that those classes are not static; irrecoverably may become recoverable due to external factors (a crd might become installed, a crd might be upgraded to support watch in a new release).

This PR avoids crashing user code without their knowledge (something users generally hate), but it will also potentially not work, get successfully deployed (replacing an older version in a rolling upgrade due to no crashloop), but will just spin-error continuously without actually doing anything. Then again, it's not like an earlier version will have worked with watch, because if a resource does not support watch, it did not support watch before we started error handling.

Passing an error here does give the whole system a (slim) chance to fix itself **if** a simultaneous upgrade to a resource (adding watch support for the resource) gets deployed. So it's in-line with standard "eventual consistency" ideals. The spin-lock problem is also somewhat mitigated with backoff support.