### PR TITLE
Add `Config::tls_server_name` and validate when using rustls

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -57,7 +57,7 @@ kube-core = { path = "../kube-core", version = "=0.76.0" }
 jsonpath_lib = { version = "0.3.0", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
-hyper-rustls = { version = "0.23.0", optional = true }
+hyper-rustls = { version = "0.23.2", optional = true }
 tokio-tungstenite = { version = "0.18.0", optional = true }
 tower = { version = "0.4.6", optional = true, features = ["buffer", "filter", "util"] }
 tower-http = { version = "0.3.2", optional = true, features = ["auth", "map-response-body", "trace"] }

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -85,7 +85,7 @@ impl TryFrom<Config> for ClientBuilder<BoxService<Request<hyper::Body>, Response
             #[cfg(feature = "openssl-tls")]
             let connector = config.openssl_https_connector_with_connector(connector)?;
             #[cfg(all(not(feature = "openssl-tls"), feature = "rustls-tls"))]
-            let connector = config.rustls_https_connector()?;
+            let connector = config.rustls_https_connector_with_connector(connector)?;
 
             let mut connector = TimeoutConnector::new(connector);
 

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -85,10 +85,7 @@ impl TryFrom<Config> for ClientBuilder<BoxService<Request<hyper::Body>, Response
             #[cfg(feature = "openssl-tls")]
             let connector = config.openssl_https_connector_with_connector(connector)?;
             #[cfg(all(not(feature = "openssl-tls"), feature = "rustls-tls"))]
-            let connector = hyper_rustls::HttpsConnector::from((
-                connector,
-                std::sync::Arc::new(config.rustls_client_config()?),
-            ));
+            let connector = config.rustls_https_connector()?;
 
             let mut connector = TimeoutConnector::new(connector);
 

--- a/kube-client/src/client/config_ext.rs
+++ b/kube-client/src/client/config_ext.rs
@@ -43,6 +43,29 @@ pub trait ConfigExt: private::Sealed {
     #[cfg(feature = "rustls-tls")]
     fn rustls_https_connector(&self) -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>;
 
+    /// Create [`hyper_rustls::HttpsConnector`] based on config and `connector`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use kube::{client::ConfigExt, Config};
+    /// # use hyper::client::HttpConnector;
+    /// let config = Config::infer().await?;
+    /// let mut connector = HttpConnector::new();
+    /// connector.enforce_http(false);
+    /// let https = config.rustls_https_connector_with_connector(connector)?;
+    /// let hyper_client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(https);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    #[cfg(feature = "rustls-tls")]
+    fn rustls_https_connector_with_connector(
+        &self,
+        connector: hyper::client::HttpConnector,
+    ) -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>;
+
     /// Create [`rustls::ClientConfig`] based on config.
     /// # Example
     ///
@@ -186,16 +209,24 @@ impl ConfigExt for Config {
 
     #[cfg(feature = "rustls-tls")]
     fn rustls_https_connector(&self) -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>> {
+        let mut connector = hyper::client::HttpConnector::new();
+        connector.enforce_http(false);
+        self.rustls_https_connector_with_connector(connector)
+    }
+
+    #[cfg(feature = "rustls-tls")]
+    fn rustls_https_connector_with_connector(
+        &self,
+        connector: hyper::client::HttpConnector,
+    ) -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>> {
         let rustls_config = self.rustls_client_config()?;
-        let mut http = hyper::client::HttpConnector::new();
-        http.enforce_http(false);
         let mut builder = hyper_rustls::HttpsConnectorBuilder::new()
             .with_tls_config(rustls_config)
             .https_or_http();
         if let Some(tsn) = self.tls_server_name.as_ref() {
             builder = builder.with_server_name(tsn.clone());
         }
-        Ok(builder.enable_http1().wrap_connector(http))
+        Ok(builder.enable_http1().wrap_connector(connector))
     }
 
     #[cfg(feature = "openssl-tls")]

--- a/kube-client/src/client/config_ext.rs
+++ b/kube-client/src/client/config_ext.rs
@@ -187,15 +187,15 @@ impl ConfigExt for Config {
     #[cfg(feature = "rustls-tls")]
     fn rustls_https_connector(&self) -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>> {
         let rustls_config = self.rustls_client_config()?;
-        let http = hyper::client::HttpConnector::new().enforce_http(false);
+        let mut http = hyper::client::HttpConnector::new();
+        http.enforce_http(false);
         let mut builder = hyper_rustls::HttpsConnectorBuilder::new()
             .with_tls_config(rustls_config)
-            .https_or_http()
-            .enable_http1();
+            .https_or_http();
         if let Some(tsn) = self.tls_server_name.as_ref() {
             builder = builder.with_server_name(tsn.clone());
         }
-        Ok(builder.wrap_connector(http))
+        Ok(builder.enable_http1().wrap_connector(http))
     }
 
     #[cfg(feature = "openssl-tls")]

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -105,6 +105,12 @@ pub struct Cluster {
     #[serde(rename = "proxy-url")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proxy_url: Option<String>,
+    /// Name used to check server certificate.
+    ///
+    /// If `tls_server_name` is `None`, the hostname used to contact the server is used.
+    #[serde(rename = "tls-server-name")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls_server_name: Option<String>,
     /// Additional information for extenders so that reads and writes don't clobber unknown fields
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<Vec<NamedExtension>>,

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -231,8 +231,7 @@ impl Config {
     /// <https://github.com/kube-rs/kube/issues/1003>).
     /// To work around this, when rustls is configured, this function automatically appends
     /// `tls-server-name = "kubernetes.default.svc"` to the resulting configuration.
-    /// To opt out of this behavior, use [`Config::incluster_env`] or
-    /// [`Config::incluster_dns`] instead.
+    /// Overriding or unsetting `Config::tls_server_name` can be done to opt out of this behaviour.
     #[cfg(feature = "rustls-tls")]
     pub fn incluster() -> Result<Self, InClusterError> {
         let mut cfg = Self::incluster_env()?;
@@ -247,9 +246,7 @@ impl Config {
     /// `/var/run/secrets/kubernetes.io/serviceaccount/`.
     ///
     /// This method matches the behavior of the official Kubernetes client
-    /// libraries, but it is not compatible with the `rustls-tls` feature . When
-    /// this feature is enabled, [`Config::incluster_dns`] should be used
-    /// instead. See <https://github.com/kube-rs/kube/issues/1003>.
+    /// libraries and is the default for both TLS stacks.
     pub fn incluster_env() -> Result<Self, InClusterError> {
         let uri = incluster_config::try_kube_from_env()?;
         Self::incluster_with_uri(uri)
@@ -262,7 +259,9 @@ impl Config {
     /// `/var/run/secrets/kubernetes.io/serviceaccount/`.
     ///
     /// This behavior does not match that of the official Kubernetes clients,
-    /// but this approach is compatible with the `rustls-tls` feature.
+    /// but this approach is compatible with the `rustls-tls` feature
+    /// without setting `tls_server_name`.
+    /// See <https://github.com/kube-rs/kube/issues/1003>.
     pub fn incluster_dns() -> Result<Self, InClusterError> {
         Self::incluster_with_uri(incluster_config::kube_dns())
     }

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -240,7 +240,6 @@ impl Config {
         Ok(cfg)
     }
 
-
     /// Load an in-cluster config using the `KUBERNETES_SERVICE_HOST` and
     /// `KUBERNETES_SERVICE_PORT` environment variables.
     ///

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -159,6 +159,10 @@ pub struct Config {
     // TODO Actually support proxy or create an example with custom client
     /// Optional proxy URL.
     pub proxy_url: Option<http::Uri>,
+    /// If set, apiserver certificate will be validated to contain this string
+    ///
+    /// If not set, the `cluster_url` is used instead
+    pub tls_server_name: Option<String>,
 }
 
 impl Config {
@@ -180,6 +184,7 @@ impl Config {
             accept_invalid_certs: false,
             auth_info: AuthInfo::default(),
             proxy_url: None,
+            tls_server_name: None,
         }
     }
 
@@ -275,6 +280,7 @@ impl Config {
                 ..Default::default()
             },
             proxy_url: None,
+            tls_server_name: None,
         })
     }
 
@@ -333,6 +339,7 @@ impl Config {
             accept_invalid_certs,
             proxy_url: loader.proxy_url()?,
             auth_info: loader.user,
+            tls_server_name: loader.cluster.tls_server_name,
         })
     }
 

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -218,24 +218,19 @@ impl Config {
 
     /// Load an in-cluster Kubernetes client configuration using
     /// [`Config::incluster_env`].
-    #[cfg(not(feature = "rustls-tls"))]
-    pub fn incluster() -> Result<Self, InClusterError> {
-        Self::incluster_env()
-    }
-
-    /// Load an in-cluster Kubernetes client configuration using
-    /// [`Config::incluster_env`].
     ///
     /// # Rustls-specific behavior
     /// Rustls does not support validating IP addresses (see
     /// <https://github.com/kube-rs/kube/issues/1003>).
     /// To work around this, when rustls is configured, this function automatically appends
     /// `tls-server-name = "kubernetes.default.svc"` to the resulting configuration.
-    /// Overriding or unsetting `Config::tls_server_name` can be done to opt out of this behaviour.
-    #[cfg(feature = "rustls-tls")]
+    /// Overriding or unsetting `Config::tls_server_name` will avoid this behaviour.
     pub fn incluster() -> Result<Self, InClusterError> {
         let mut cfg = Self::incluster_env()?;
-        cfg.tls_server_name = Some("kubernetes.default.svc".to_string());
+        if cfg!(all(not(feature = "openssl-tls"), feature = "rustls-tls")) {
+            // openssl takes precedence when both features present, so only do it when only rustls is there
+            cfg.tls_server_name = Some("kubernetes.default.svc".to_string());
+        }
         Ok(cfg)
     }
 


### PR DESCRIPTION
Functionally equivalent to #1054 which it replaces due to lack of DCO. Main differences:
- no defaulting of `tls_server_name` inside the `ConfigExt` (left to `Config` to set)
- feature selection now respects tls stack precedence

### Exposes `Config::tls_server_name` option
Gets it primarily from `Kubeconfig` when it exists and it's picked up by the `ConfigExt` method (only rustls does this).

In theory this can also be done for openssl, but with `hyper-openssl` is significantly more involved than rustls.
(AFAICT; You can [`configure`](https://docs.rs/openssl/0.10.44/openssl/ssl/struct.SslConnector.html#method.configure) the `SslConnector`, which lets you set the `domain` using [`into_ssl`](https://docs.rs/openssl/0.10.44/openssl/ssl/struct.ConnectConfiguration.html#method.into_ssl), but don't seem to have the same equivalent for the [`SslConnectorBuilder`](https://docs.rs/openssl/0.10.44/openssl/ssl/struct.SslConnectorBuilder.html) where we only have an some possible [callbacks](https://docs.rs/openssl/0.10.44/openssl/ssl/struct.SslConnectorBuilder.html#method.set_servername_callback)). This was ultimately not needed for to validate it with rustls where the problem is actually pressing.

### Changes `Config::incluster` behaviour for rustls
Stops using the deprecated `_dns` variant and instead uses `_env` like openssl. This works once we start setting the server name (and we default to the `kubernetes.default.svc` url). Upstream PR #1054 has the explaination for why this is less strict than the current behaviour and should be better. Users have already reported the original PR fixing certain teleport cases on discord. Tested this with a couple of clusters myself using rustls and it seems to work.

### Feature-based opt-in
The opt-in mechanism is done when __only__ the `rustls-tls` feature is set.  If/when `rustls` it gains the ability to validate IPs then we can remove the hack and have `Config::incluster` be the same across stacks. If both `openssl` and `rustls`  are enabled then the hack is not added due to how we currently pick openssl as the tls stack in the `Client`.