### PR TITLE
Remove deprecated `ResourceExt::name`

### DIFF
--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -73,7 +73,7 @@ where
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     let lp = ListParams::default().labels("app=blog"); // for this app only
     ///     for p in pods.list(&lp).await? {
-    ///         println!("Found Pod: {}", p.name());
+    ///         println!("Found Pod: {}", p.name_any());
     ///     }
     ///     Ok(())
     /// }
@@ -158,7 +158,7 @@ where
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     match pods.delete_collection(&DeleteParams::default(), &ListParams::default()).await? {
     ///         either::Left(list) => {
-    ///             let names: Vec<_> = list.iter().map(ResourceExt::name).collect();
+    ///             let names: Vec<_> = list.iter().map(ResourceExt::name_any).collect();
     ///             println!("Deleting collection of pods: {:?}", names);
     ///         },
     ///         either::Right(status) => {
@@ -309,9 +309,9 @@ where
     ///     let mut stream = jobs.watch(&lp, "0").await?.boxed();
     ///     while let Some(status) = stream.try_next().await? {
     ///         match status {
-    ///             WatchEvent::Added(s) => println!("Added {}", s.name()),
-    ///             WatchEvent::Modified(s) => println!("Modified: {}", s.name()),
-    ///             WatchEvent::Deleted(s) => println!("Deleted {}", s.name()),
+    ///             WatchEvent::Added(s) => println!("Added {}", s.name_any()),
+    ///             WatchEvent::Modified(s) => println!("Modified: {}", s.name_any()),
+    ///             WatchEvent::Deleted(s) => println!("Deleted {}", s.name_any()),
     ///             WatchEvent::Bookmark(s) => {},
     ///             WatchEvent::Error(s) => println!("{}", s),
     ///         }

--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -48,7 +48,7 @@ use std::{cmp::Reverse, collections::HashMap, iter::Iterator};
 ///     let (ar, caps) = apigroup.recommended_kind("APIService").unwrap();
 ///     let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
 ///     for service in api.list(&Default::default()).await? {
-///         println!("Found APIService: {}", service.name());
+///         println!("Found APIService: {}", service.name_any());
 ///     }
 ///     Ok(())
 /// }
@@ -227,7 +227,7 @@ impl ApiGroup {
     ///         }
     ///         let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
     ///         for inst in api.list(&Default::default()).await? {
-    ///             println!("Found {}: {}", ar.kind, inst.name());
+    ///             println!("Found {}: {}", ar.kind, inst.name_any());
     ///         }
     ///     }
     ///     Ok(())
@@ -254,7 +254,7 @@ impl ApiGroup {
     ///         }
     ///         let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
     ///         for inst in api.list(&Default::default()).await? {
-    ///             println!("Found {}: {}", ar.kind, inst.name());
+    ///             println!("Found {}: {}", ar.kind, inst.name_any());
     ///         }
     ///     }
     ///     Ok(())
@@ -291,7 +291,7 @@ impl ApiGroup {
     ///     let (ar, caps) = apigroup.recommended_kind("APIService").unwrap();
     ///     let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
     ///     for service in api.list(&Default::default()).await? {
-    ///         println!("Found APIService: {}", service.name());
+    ///         println!("Found APIService: {}", service.name_any());
     ///     }
     ///     Ok(())
     /// }

--- a/kube-client/src/discovery/mod.rs
+++ b/kube-client/src/discovery/mod.rs
@@ -100,7 +100,7 @@ impl Discovery {
     ///             let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
     ///             // can now api.list() to emulate kubectl get all --all
     ///             for obj in api.list(&Default::default()).await? {
-    ///                 println!("{} {}: {}", ar.api_version, ar.kind, obj.name());
+    ///                 println!("{} {}: {}", ar.api_version, ar.kind, obj.name_any());
     ///             }
     ///         }
     ///     }

--- a/kube-client/src/discovery/oneshot.rs
+++ b/kube-client/src/discovery/oneshot.rs
@@ -32,7 +32,7 @@ use kube_core::{
 ///     let (ar, caps) = apigroup.recommended_kind("APIService").unwrap();
 ///     let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
 ///     for service in api.list(&Default::default()).await? {
-///         println!("Found APIService: {}", service.name());
+///         println!("Found APIService: {}", service.name_any());
 ///     }
 ///     Ok(())
 /// }
@@ -69,7 +69,7 @@ pub async fn group(client: &Client, apigroup: &str) -> Result<ApiGroup> {
 ///     let (ar, caps) = apigroup.recommended_kind("APIService").unwrap();
 ///     let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
 ///     for service in api.list(&Default::default()).await? {
-///         println!("Found APIService: {}", service.name());
+///         println!("Found APIService: {}", service.name_any());
 ///     }
 ///     Ok(())
 /// }
@@ -96,7 +96,7 @@ pub async fn pinned_group(client: &Client, gv: &GroupVersion) -> Result<ApiGroup
 ///     let (ar, caps) = discovery::pinned_kind(&client, &gvk).await?;
 ///     let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
 ///     for service in api.list(&Default::default()).await? {
-///         println!("Found APIService: {}", service.name());
+///         println!("Found APIService: {}", service.name_any());
 ///     }
 ///     Ok(())
 /// }

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -47,7 +47,7 @@
 //!
 //!     // List pods in the configured namespace
 //!     for p in pods.list(&ListParams::default()).await? {
-//!         println!("found pod {}", p.name());
+//!         println!("found pod {}", p.name_any());
 //!     }
 //!
 //!     Ok(())

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -155,13 +155,6 @@ where
 
 /// Helper methods for resources.
 pub trait ResourceExt: Resource {
-    /// Deprecated fn equivalent to [`name_unchecked`](ResourceExt::name_unchecked)
-    #[deprecated(
-        since = "0.74.0",
-        note = "ResourceExt::name can panic and has been replaced by `ResourceExt::name_any` and `ResourceExt::name_unchecked`. This fn will be removed in 0.77.0."
-    )]
-    fn name(&self) -> String;
-
     /// Returns the name of the resource, panicking if it is unset
     ///
     /// Only use this function if you know that name is set; for example when
@@ -224,10 +217,6 @@ use once_cell::sync::Lazy;
 static EMPTY_MAP: Lazy<BTreeMap<String, String>> = Lazy::new(BTreeMap::new);
 
 impl<K: Resource> ResourceExt for K {
-    fn name(&self) -> String {
-        self.meta().name.clone().expect(".metadata.name missing")
-    }
-
     fn name_unchecked(&self) -> String {
         self.meta().name.clone().expect(".metadata.name missing")
     }

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -726,7 +726,7 @@ where
     /// .reconcile_all_on(reload_rx.map(|_| ()))
     /// .run(
     ///     |o, _| async move {
-    ///         println!("Reconciling {}", o.name());
+    ///         println!("Reconciling {}", o.name_any());
     ///         Ok(Action::await_change())
     ///     },
     ///     |_object: Arc<ConfigMap>, err: &Infallible, _| Err(err).unwrap(),
@@ -781,7 +781,7 @@ where
     /// .graceful_shutdown_on(tokio::signal::ctrl_c().map(|_| ()))
     /// .run(
     ///     |o, _| async move {
-    ///         println!("Reconciling {}", o.name());
+    ///         println!("Reconciling {}", o.name_any());
     ///         Ok(Action::await_change())
     ///     },
     ///     |_, err: &Infallible, _| Err(err).unwrap(),

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -246,7 +246,7 @@ async fn step<K: Resource + Clone + DeserializeOwned + Debug + Send + 'static>(
 ///
 ///     watcher(pods, ListParams::default()).applied_objects()
 ///         .try_for_each(|p| async move {
-///          println!("Applied: {}", p.name());
+///          println!("Applied: {}", p.name_any());
 ///             Ok(())
 ///         })
 ///         .await?;

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -30,7 +30,7 @@
 //!     // Read pods in the configured namespace into the typed interface from k8s-openapi
 //!     let pods: Api<Pod> = Api::default_namespaced(client);
 //!     for p in pods.list(&ListParams::default()).await? {
-//!         println!("found pod {}", p.name());
+//!         println!("found pod {}", p.name_any());
 //!     }
 //!     Ok(())
 //! }
@@ -90,7 +90,7 @@
 //!     let lp = ListParams::default();
 //!     let mut apply_stream = watcher(foos, lp).applied_objects().boxed();
 //!     while let Some(f) = apply_stream.try_next().await? {
-//!         println!("saw apply to {}", f.name());
+//!         println!("saw apply to {}", f.name_any());
 //!     }
 //!     Ok(())
 //! }


### PR DESCRIPTION
Slated for removal in 0.77.