### PR TITLE
Remove deprecated `Config::timeout`

### DIFF
--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -89,13 +89,10 @@ impl TryFrom<Config> for ClientBuilder<BoxService<Request<hyper::Body>, Response
 
             let mut connector = TimeoutConnector::new(connector);
 
-            // Set the timeout for the client and fallback to default deprecated timeout until it's removed
-            #[allow(deprecated)]
-            {
-                connector.set_connect_timeout(config.connect_timeout.or(config.timeout));
-                connector.set_read_timeout(config.read_timeout.or(config.timeout));
-                connector.set_write_timeout(config.write_timeout);
-            }
+            // Set the timeouts for the client
+            connector.set_connect_timeout(config.connect_timeout);
+            connector.set_read_timeout(config.read_timeout);
+            connector.set_write_timeout(config.write_timeout);
 
             hyper::Client::builder().build(connector)
         };

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -144,14 +144,6 @@ pub struct Config {
     ///
     /// A value of `None` means no timeout
     pub write_timeout: Option<std::time::Duration>,
-    /// Timeout for calls to the Kubernetes API.
-    ///
-    /// A value of `None` means no timeout
-    #[deprecated(
-        since = "0.75.0",
-        note = "replaced by more granular members `connect_timeout`, `read_timeout` and `write_timeout`. This member will be removed in 0.78.0."
-    )]
-    pub timeout: Option<std::time::Duration>,
     /// Whether to accept invalid certificates
     pub accept_invalid_certs: bool,
     /// Stores information to tell the cluster who you are.
@@ -172,7 +164,6 @@ impl Config {
     /// Most likely you want to use [`Config::infer`] to infer the config from
     /// the environment.
     pub fn new(cluster_url: http::Uri) -> Self {
-        #[allow(deprecated)]
         Self {
             cluster_url,
             default_namespace: String::from("default"),
@@ -180,7 +171,6 @@ impl Config {
             connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),
             read_timeout: Some(DEFAULT_READ_TIMEOUT),
             write_timeout: None,
-            timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs: false,
             auth_info: AuthInfo::default(),
             proxy_url: None,
@@ -265,7 +255,6 @@ impl Config {
         let default_namespace = incluster_config::load_default_ns()?;
         let root_cert = incluster_config::load_cert()?;
 
-        #[allow(deprecated)]
         Ok(Self {
             cluster_url,
             default_namespace,
@@ -273,7 +262,6 @@ impl Config {
             connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),
             read_timeout: Some(DEFAULT_READ_TIMEOUT),
             write_timeout: None,
-            timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs: false,
             auth_info: AuthInfo {
                 token_file: Some(incluster_config::token_file()),
@@ -327,7 +315,6 @@ impl Config {
             root_cert = Some(ca_bundle);
         }
 
-        #[allow(deprecated)]
         Ok(Self {
             cluster_url,
             default_namespace,
@@ -335,7 +322,6 @@ impl Config {
             connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),
             read_timeout: Some(DEFAULT_READ_TIMEOUT),
             write_timeout: None,
-            timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs,
             proxy_url: loader.proxy_url()?,
             auth_info: loader.user,
@@ -401,8 +387,6 @@ fn certs(data: &[u8]) -> Result<Vec<Vec<u8>>, pem::PemError> {
 }
 
 // https://github.com/kube-rs/kube/issues/146#issuecomment-590924397
-/// Default Timeout
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(295);
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(295);
 


### PR DESCRIPTION
Deprecated in 0.75 and slated for removal in 0.78.