### PR TITLE
Bump `k8s-openapi@0.17.0` and MK8SV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run these tests against older clusters as well
-        k8s: [v1.20, latest]
+        k8s: [v1.21, latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -199,7 +199,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.20
+          version: v1.21
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
 [![Rust 1.60](https://img.shields.io/badge/MSRV-1.60-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.60.0)
-[![Tested against Kubernetes v1_20 and above](https://img.shields.io/badge/MK8SV-v1_20-326ce5.svg)](https://kube.rs/kubernetes-version)
+[![Tested against Kubernetes v1_21 and above](https://img.shields.io/badge/MK8SV-v1_21-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)
 
@@ -17,7 +17,7 @@ Select a version of `kube` along with the generated [k8s-openapi](https://github
 ```toml
 [dependencies]
 kube = { version = "0.77.0", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.16.0", features = ["v1_25"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_26"] }
 ```
 
 [Features are available](https://github.com/kube-rs/kube/blob/main/kube/Cargo.toml#L18).
@@ -153,7 +153,7 @@ Kube has basic support ([with caveats](https://github.com/kube-rs/kube/issues?q=
 ```toml
 [dependencies]
 kube = { version = "0.77.0", default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.16.0", features = ["v1_25"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_26"] }
 ```
 
 This will pull in `rustls` and `hyper-rustls`.

--- a/deny.toml
+++ b/deny.toml
@@ -108,3 +108,8 @@ version = "0.36"
 # ahash -> getrandom -> wasi old
 # tokio -> mio -> wasi new
 name = "wasi"
+
+[[bans.skip]]
+# waiting for pem to bump base64
+# https://github.com/jcreekmore/pem-rs/blob/master/Cargo.toml#L16
+name = "base64"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -18,8 +18,8 @@ name = "boot"
 path = "boot.rs"
 
 [features]
-latest = ["k8s-openapi/v1_25"]
-mk8sv = ["k8s-openapi/v1_20"]
+latest = ["k8s-openapi/v1_26"]
+mk8sv = ["k8s-openapi/v1_21"]
 rustls = ["kube/rustls-tls"]
 openssl = ["kube/openssl-tls"]
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -29,6 +29,6 @@ tracing = "0.1.36"
 tracing-subscriber = "0.3.3"
 futures = "0.3.17"
 kube = { path = "../kube", version = "^0.77.0", default-features = false, features = ["client", "runtime", "ws", "admission", "gzip"] }
-k8s-openapi = { version = "0.16.0", default-features = false }
+k8s-openapi = { version = "0.17.0", default-features = false }
 serde_json = "1.0.68"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -31,7 +31,7 @@ futures = "0.3.17"
 jsonpath_lib = "0.3.0"
 kube = { path = "../kube", version = "^0.77.0", default-features = false, features = ["admission"] }
 kube-derive = { path = "../kube-derive", version = "^0.77.0", default-features = false } # only needed to opt out of schema
-k8s-openapi = { version = "0.16.0", default-features = false }
+k8s-openapi = { version = "0.17.0", default-features = false }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.8.21"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,7 +20,7 @@ openssl-tls = ["kube/client", "kube/openssl-tls"]
 rustls-tls = ["kube/client", "kube/rustls-tls"]
 runtime = ["kube/runtime"]
 ws = ["kube/ws"]
-latest = ["k8s-openapi/v1_25"]
+latest = ["k8s-openapi/v1_26"]
 
 [dev-dependencies]
 tokio-util = "0.7.0"

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ fmt:
   rustfmt +nightly --edition 2021 $(find . -type f -iname *.rs)
 
 doc:
-  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,jsonpatch,client,derive,runtime,admission,k8s-openapi/v1_25 --open
+  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,jsonpatch,client,derive,runtime,admission,k8s-openapi/v1_26 --open
 
 # Unit tests
 test:
@@ -117,6 +117,7 @@ bump-k8s:
   # bump mk8sv badge
   badge="[![Tested against Kubernetes ${mk8svnew} and above](https://img.shields.io/badge/MK8SV-${mk8svnew}-326ce5.svg)](https://kube.rs/kubernetes-version)"
   sd "^.+badge/MK8SV.+$" "${badge}" README.md
+  echo "remember to bump kubernetes-version.md in kube-rs/website"
 
 # mode: makefile
 # End:

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -36,7 +36,7 @@ features = ["client", "rustls-tls", "openssl-tls", "ws", "oauth", "jsonpatch", "
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-base64 = { version = "0.13.0", optional = true }
+base64 = { version = "0.20.0", optional = true }
 chrono = { version = "0.4.23", optional = true, default-features = false }
 dirs = { package = "dirs-next", optional = true, version = "2.0.0" }
 serde = { version = "1.0.130", features = ["derive"] }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -31,7 +31,7 @@ config = ["__non_core", "pem", "dirs"]
 __non_core = ["tracing", "serde_yaml", "base64"]
 
 [package.metadata.docs.rs]
-features = ["client", "rustls-tls", "openssl-tls", "ws", "oauth", "jsonpatch", "admission", "k8s-openapi/v1_25"]
+features = ["client", "rustls-tls", "openssl-tls", "ws", "oauth", "jsonpatch", "admission", "k8s-openapi/v1_26"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -85,4 +85,4 @@ tower-test = "0.4.0"
 [dev-dependencies.k8s-openapi]
 version = "0.17.0"
 default-features = false
-features = ["v1_25"]
+features = ["v1_26"]

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -47,7 +47,7 @@ http-body = { version = "0.4.2", optional = true }
 either = { version = "1.6.1", optional = true }
 thiserror = "1.0.29"
 futures = { version = "0.3.17", optional = true }
-pem = { version = "1.0.1", optional = true }
+pem = { version = "1.1.0", optional = true }
 openssl = { version = "0.10.36", optional = true }
 rustls = { version = "0.20.3", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "1.0.0", optional = true }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -70,7 +70,7 @@ tracing = { version = "0.1.36", features = ["log"], optional = true }
 hyper-openssl = { version = "0.9.2", optional = true }
 
 [dependencies.k8s-openapi]
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 features = []
 
@@ -83,6 +83,6 @@ tokio-test = "0.4.0"
 tower-test = "0.4.0"
 
 [dev-dependencies.k8s-openapi]
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 features = ["v1_25"]

--- a/kube-client/src/api/util/mod.rs
+++ b/kube-client/src/api/util/mod.rs
@@ -9,9 +9,7 @@ use k8s_openapi::api::{
 use kube_core::{params::PostParams, util::Restart};
 use serde::de::DeserializeOwned;
 
-k8s_openapi::k8s_if_ge_1_19! {
-    mod csr;
-}
+mod csr;
 
 impl<K> Api<K>
 where

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -34,12 +34,12 @@ chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 schemars = { version = "0.8.6", optional = true }
 
 [dependencies.k8s-openapi]
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 features = []
 
 [dev-dependencies.k8s-openapi]
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 features = ["v1_25"]
 

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 
 [package.metadata.docs.rs]
-features = ["ws", "admission", "jsonpatch", "k8s-openapi/v1_25"]
+features = ["ws", "admission", "jsonpatch", "k8s-openapi/v1_26"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -41,7 +41,7 @@ features = []
 [dev-dependencies.k8s-openapi]
 version = "0.17.0"
 default-features = false
-features = ["v1_25"]
+features = ["v1_26"]
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro = true
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.8.21"
 kube = { path = "../kube", default-features = false, version = "<1.0.0, >=0.61.0", features = ["derive"] }
-k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_25"] }
+k8s-openapi = { version = "0.17.0", default-features = false, features = ["v1_25"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 validator = { version = "0.16.0", features = ["derive"] }
 chrono = { version = "0.4.19", default-features = false }

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro = true
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.8.21"
 kube = { path = "../kube", default-features = false, version = "<1.0.0, >=0.61.0", features = ["derive"] }
-k8s-openapi = { version = "0.17.0", default-features = false, features = ["v1_25"] }
+k8s-openapi = { version = "0.17.0", default-features = false, features = ["v1_26"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 validator = { version = "0.16.0", features = ["derive"] }
 chrono = { version = "0.4.19", default-features = false }

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0.29"
 backoff = "0.4.0"
 
 [dependencies.k8s-openapi]
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 
 [dev-dependencies]
@@ -48,6 +48,6 @@ rand = "0.8.0"
 schemars = "0.8.6"
 
 [dev-dependencies.k8s-openapi]
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 features = ["v1_25"]

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [package.metadata.docs.rs]
-features = ["k8s-openapi/v1_25"]
+features = ["k8s-openapi/v1_26"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -50,4 +50,4 @@ schemars = "0.8.6"
 [dev-dependencies.k8s-openapi]
 version = "0.17.0"
 default-features = false
-features = ["v1_25"]
+features = ["v1_26"]

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -18,9 +18,8 @@
 #![allow(clippy::semicolon_if_nothing_returned)]
 
 pub mod controller;
-k8s_openapi::k8s_if_ge_1_19! {
-    pub mod events;
-}
+pub mod events;
+
 pub mod finalizer;
 pub mod reflector;
 pub mod scheduler;

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -43,7 +43,7 @@ kube-runtime = { path = "../kube-runtime", version = "=0.77.0", optional = true}
 # Not used directly, but required by resolver 2.0 to ensure that the k8s-openapi dependency
 # is considered part of the "deps" graph rather than just the "dev-deps" graph
 [dependencies.k8s-openapi]
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 
 [dev-dependencies]
@@ -55,6 +55,6 @@ serde = { version = "1.0.130", features = ["derive"] }
 schemars = "0.8.6"
 
 [dev-dependencies.k8s-openapi]
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 features = ["v1_25"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -30,7 +30,7 @@ config = ["kube-client/config"]
 runtime = ["kube-runtime"]
 
 [package.metadata.docs.rs]
-features = ["client", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_25"]
+features = ["client", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_26"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -57,4 +57,4 @@ schemars = "0.8.6"
 [dev-dependencies.k8s-openapi]
 version = "0.17.0"
 default-features = false
-features = ["v1_25"]
+features = ["v1_26"]

--- a/release.toml
+++ b/release.toml
@@ -4,7 +4,7 @@
 #
 # 0. (optional) cargo release minor ; verify readme + changelog bumped; then git reset --hard
 # 1. PUBLISH_GRACE_SLEEP=20 cargo release minor --execute
-# 1X.  - on failure: follow plan manually, cd into next dirs and publish insequence with cargo publish --features=k8s-openapi/v1_25
+# 1X.  - on failure: follow plan manually, cd into next dirs and publish insequence with cargo publish --features=k8s-openapi/v1_26
 # 2. check consolidated commit
 # 2X.  - on failure: git commit --amend and insert version
 # 3. ./scripts/release-post.sh
@@ -21,4 +21,4 @@ push = false
 tag = false
 # A Kubernetes version is normally supplied by the application consuming the library in the end.
 # Since we don't have that when verifying, supply one ourselves.
-enable-features = ["k8s-openapi/v1_25"]
+enable-features = ["k8s-openapi/v1_26"]


### PR DESCRIPTION
See [upstream release](https://github.com/Arnavion/k8s-openapi/releases/tag/v0.17.0)

- [x] `cargo upgrade -p k8s-openapi --incompatible`
- [x] update `base64` cherry picked and replaces #1103
- [x] ..deny override for `base64` because `pem` uses an older one
- [x]  `just bump-k8s` to set [MK8SV](https://kube.rs/kubernetes-version/) to 1.21
- [x] Remove version gate on runtime's event `Recorder` (always available now)
- [x] bump mk8sv at website - https://github.com/kube-rs/website/pull/29