### PR TITLE
Add better keywords/categories to `Cargo.toml`

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 keywords = ["kubernetes", "client",]
-categories = ["web-programming::http-client"]
+categories = ["web-programming::http-client", "configuration", "network-programming", "api-bindings"]
 rust-version = "1.60.0"
 edition = "2021"
 

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -9,6 +9,8 @@ authors = [
 edition = "2021"
 rust-version = "1.60.0"
 license = "Apache-2.0"
+keywords = ["kubernetes", "apimachinery"]
+categories = ["api-bindings", "encoding", "parser-implementations"]
 repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -11,6 +11,9 @@ rust-version = "1.60.0"
 license = "Apache-2.0"
 repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
+keywords = ["kubernetes", "macro", "customresource", "crd"]
+categories = ["api-bindings", "encoding"]
+
 
 [dependencies]
 proc-macro2 = "1.0.29"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 keywords = ["kubernetes", "runtime", "reflector", "watcher", "controller"]
-categories = ["web-programming::http-client"]
+categories = ["web-programming::http-client", "caching", "network-programming"]
 rust-version = "1.60.0"
 edition = "2021"
 

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -10,8 +10,8 @@ authors = [
 license = "Apache-2.0"
 repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
-keywords = ["kubernetes", "client", "runtime"]
-categories = ["web-programming::http-client"]
+keywords = ["kubernetes", "client", "runtime", "cncf"]
+categories = ["network-programming", "caching", "api-bindings", "configuration", "encoding"]
 rust-version = "1.60.0"
 edition = "2021"
 


### PR DESCRIPTION
based on available categories: https://crates.io/categories

where the following seemed the most sensible for us:

- ~~`virtualization`~~ (felt slightly wrong)
- `api-bindings`
- `network-programming`
- `caching`
- `configuration`
- `encoding`
- `parsing`

Also noticed how we show up on [lib.rs](https://lib.rs/) as development-tools 🤔 because they have their own [auto-categorisation setup](https://lib.rs/about) so hopefully this will improve the situation there as well.