### PR TITLE
Client: expose `default_namespace()`

### DIFF
--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -104,7 +104,7 @@ impl<K: Resource> Api<K> {
     where
         K: Resource<Scope = DynamicResourceScope>,
     {
-        let ns = client.default_ns().to_string();
+        let ns = client.default_namespace().to_string();
         Self::namespaced_with(client, &ns, dyntype)
     }
 
@@ -208,7 +208,7 @@ where
     where
         K: Resource<Scope = NamespaceResourceScope>,
     {
-        let ns = client.default_ns().to_string();
+        let ns = client.default_namespace().to_string();
         Self::namespaced(client, &ns)
     }
 }

--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -126,7 +126,12 @@ impl Client {
         Self::try_from(Config::infer().await.map_err(Error::InferConfig)?)
     }
 
-    pub(crate) fn default_ns(&self) -> &str {
+    /// Get the default namespace for the client
+    ///
+    /// The namespace is either configured on `context` in the kubeconfig,
+    /// falls back to `default` when running locally,
+    /// or uses the service account's namespace when deployed in-cluster.
+    pub fn default_namespace(&self) -> &str {
         &self.default_ns
     }
 
@@ -464,6 +469,13 @@ mod tests {
     use hyper::Body;
     use k8s_openapi::api::core::v1::Pod;
     use tower_test::mock;
+
+    #[tokio::test]
+    async fn test_default_ns() {
+        let (mock_service, _) = mock::pair::<Request<Body>, Response<Body>>();
+        let client = Client::new(mock_service, "test-namespace");
+        assert_eq!(client.default_namespace(), "test-namespace");
+    }
 
     #[tokio::test]
     async fn test_mock() {


### PR DESCRIPTION
## Motivation

Closes: https://github.com/kube-rs/kube/issues/1118
Succeeds: #1121 (GitHub didn't like me force pushing to my fork's `main` branch and auto closed it 😭 - sorry for the noise)

## Solution

Exposes and documents the `default_namespace()` method for the `Client`. Now, users can get the namespace stored on the client which will be especially useful for in-cluster configs doing namespace specific operations

Added a simple test as well. Let me know if this needs anything else!
