### PR TITLE
Integration tests; add `#[ignore = "msg"]` messages

### DIFF
--- a/kube-client/src/api/entry.rs
+++ b/kube-client/src/api/entry.rs
@@ -326,7 +326,7 @@ mod tests {
     };
 
     #[tokio::test]
-    #[ignore] // needs cluster (gets and writes cms)
+    #[ignore = "needs cluster (gets and writes cms)"]
     async fn entry_create_missing_object() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
         let api = Api::<ConfigMap>::default_namespaced(client);
@@ -407,7 +407,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (gets and writes cms)
+    #[ignore = "needs cluster (gets and writes cms)"]
     async fn entry_update_existing_object() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
         let api = Api::<ConfigMap>::default_namespaced(client);
@@ -478,7 +478,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (gets and writes cms)
+    #[ignore = "needs cluster (gets and writes cms)"]
     async fn entry_create_dry_run() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
         let api = Api::<ConfigMap>::default_namespaced(client);

--- a/kube-client/src/api/util/mod.rs
+++ b/kube-client/src/api/util/mod.rs
@@ -73,7 +73,7 @@ mod test {
     use serde_json::json;
 
     #[tokio::test]
-    #[ignore] // needs kubeconfig
+    #[ignore = "needs kubeconfig"]
     async fn node_cordon_and_uncordon_works() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
 
@@ -105,7 +105,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // requires a cluster
+    #[ignore = "requires a cluster"]
     async fn create_token_request() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
 

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -148,7 +148,7 @@ mod test {
     // hard disabled test atm due to k3d rustls issues: https://github.com/kube-rs/kube/issues?q=is%3Aopen+is%3Aissue+label%3Arustls
     #[cfg(feature = "when_rustls_works_with_k3d")]
     #[tokio::test]
-    #[ignore] // needs cluster (lists pods)
+    #[ignore = "needs cluster (lists pods)"]
     #[cfg(all(feature = "rustls-tls"))]
     async fn custom_client_rustls_configuration() -> Result<(), Box<dyn std::error::Error>> {
         let config = Config::infer().await?;
@@ -163,7 +163,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (lists pods)
+    #[ignore = "needs cluster (lists pods)"]
     #[cfg(all(feature = "openssl-tls"))]
     async fn custom_client_openssl_tls_configuration() -> Result<(), Box<dyn std::error::Error>> {
         let config = Config::infer().await?;
@@ -178,7 +178,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (lists api resources)
+    #[ignore = "needs cluster (lists api resources)"]
     #[cfg(all(feature = "discovery"))]
     async fn group_discovery_oneshot() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{core::DynamicObject, discovery};
@@ -192,7 +192,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (will create and edit a pod)
+    #[ignore = "needs cluster (will create and edit a pod)"]
     async fn pod_can_use_core_apis() -> Result<(), Box<dyn std::error::Error>> {
         use kube::api::{DeleteParams, ListParams, Patch, PatchParams, PostParams, WatchEvent};
 
@@ -272,7 +272,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (will create and attach to a pod)
+    #[ignore = "needs cluster (will create and attach to a pod)"]
     #[cfg(all(feature = "ws"))]
     async fn pod_can_exec_and_write_to_stdin() -> Result<(), Box<dyn std::error::Error>> {
         use crate::api::{DeleteParams, ListParams, Patch, PatchParams, WatchEvent};
@@ -384,7 +384,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (will create and tail logs from a pod)
+    #[ignore = "needs cluster (will create and tail logs from a pod)"]
     async fn can_get_pod_logs_and_evict() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{
             api::{DeleteParams, EvictParams, ListParams, Patch, PatchParams, WatchEvent},
@@ -470,7 +470,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // requires a cluster
+    #[ignore = "requires a cluster"]
     async fn can_operate_on_pod_metadata() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{
             api::{DeleteParams, EvictParams, ListParams, Patch, PatchParams, WatchEvent},
@@ -556,7 +556,7 @@ mod test {
         Ok(())
     }
     #[tokio::test]
-    #[ignore] // needs cluster (will create a CertificateSigningRequest)
+    #[ignore = "needs cluster (will create a CertificateSigningRequest)"]
     async fn csr_can_be_approved() -> Result<(), Box<dyn std::error::Error>> {
         use crate::api::PostParams;
         use k8s_openapi::api::certificates::v1::{

--- a/kube-runtime/src/events.rs
+++ b/kube-runtime/src/events.rs
@@ -249,7 +249,7 @@ mod test {
     use super::{Event, EventType, Recorder};
 
     #[tokio::test]
-    #[ignore] // needs cluster (creates a pointless event on the kubernetes main service)
+    #[ignore = "needs cluster (creates an event for the default kubernetes service)"]
     async fn event_recorder_attaches_events() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
 
@@ -278,7 +278,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (creates a pointless event on the kubernetes main service)
+    #[ignore = "needs cluster (creates an event for the default kubernetes service)"]
     async fn event_recorder_attaches_events_without_namespace() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
 

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -25,7 +25,6 @@ use std::{
 use stream::IntoStream;
 use tokio::{runtime::Handle, task::JoinHandle};
 
-
 /// Allows splitting a `Stream` into several streams that each emit a disjoint subset of the input stream's items,
 /// like a streaming variant of pattern matching.
 ///

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -210,7 +210,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs kubeconfig
+    #[ignore = "needs kubeconfig"]
     async fn custom_resource_generates_correct_core_structs() {
         use crate::core::{ApiResource, DynamicObject, GroupVersionKind};
         let client = Client::try_default().await.unwrap();
@@ -229,7 +229,7 @@ mod test {
         apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
     };
     #[tokio::test]
-    #[ignore] // needs cluster (creates + patches foo crd)
+    #[ignore = "needs cluster (creates + patches foo crd)"]
     #[cfg(all(feature = "derive", feature = "runtime"))]
     async fn derived_resource_queriable_and_has_subresources() -> Result<(), Box<dyn std::error::Error>> {
         use crate::runtime::wait::{await_condition, conditions};
@@ -305,7 +305,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (lists pods)
+    #[ignore = "needs cluster (lists pods)"]
     async fn custom_serialized_objects_are_queryable_and_iterable() -> Result<(), Box<dyn std::error::Error>>
     {
         use crate::core::{
@@ -356,7 +356,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (fetches api resources, and lists all)
+    #[ignore = "needs cluster (fetches api resources, and lists all)"]
     #[cfg(all(feature = "derive"))]
     async fn derived_resources_discoverable() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{
@@ -432,7 +432,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (will create await a pod)
+    #[ignore = "needs cluster (will create await a pod)"]
     #[cfg(all(feature = "runtime"))]
     async fn pod_can_await_conditions() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{
@@ -514,7 +514,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (lists cms)
+    #[ignore = "needs cluster (lists cms)"]
     async fn api_get_opt_handles_404() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
         let api = Api::<ConfigMap>::default_namespaced(client);

--- a/scripts/release-post.sh
+++ b/scripts/release-post.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 main() {
   cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. # aka $WORKSPACE_ROOT
-  local -r CURRENT_VER="$(rg "kube =" README.md | head -n 1 | awk -F"\"" '{print $2}')"
+  local -r CURRENT_VER="$(rg "kube =" README.md | head -n 1 | rg 'version = "(\S*)"' -or '$1')"
   git tag -a "${CURRENT_VER}" -m "${CURRENT_VER}"
   git push
   git push --tags

--- a/scripts/release-pre.sh
+++ b/scripts/release-pre.sh
@@ -16,7 +16,7 @@ replace-docs() {
 }
 
 sanity() {
-  CARGO_TREE_OPENAPI="$(cargo tree -i k8s-openapi | head -n 1 | awk '{print $2}')"
+  CARGO_TREE_OPENAPI="$(cargo tree -i k8s-openapi | head -n 1 | choose 1)"
   USED_K8S_OPENAPI="${CARGO_TREE_OPENAPI:1}"
   RECOMMENDED_K8S_OPENAPI="$(rg "k8s-openapi =" README.md | head -n 1)" # only check first instance
   if ! [[ $RECOMMENDED_K8S_OPENAPI =~ $USED_K8S_OPENAPI ]]; then
@@ -29,7 +29,7 @@ sanity() {
 main() {
   # We only want this to run ONCE at workspace level
   cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. # aka $WORKSPACE_ROOT
-  local -r CURRENT_VER="$(rg "kube =" README.md | head -n 1 | awk -F"\"" '{print $2}')"
+  local -r CURRENT_VER="$(rg "kube =" README.md | head -n 1 | rg 'version = "(\S*)"' -or '$1')"
 
   # If the main README has been bumped, assume we are done:
   if [[ "${NEW_VERSION}" = "${CURRENT_VER}" ]]; then


### PR DESCRIPTION
Use rust 1.61 ignore messages in integration tests. shows up nicer for devs:

<img width="1136" alt="Screenshot 2023-02-16 at 07 43 26" src="https://user-images.githubusercontent.com/134092/219300297-8930d1cf-fd8e-41d0-81ff-7c5c96d4902f.png">

..might not even affect the msrv because it's only for tests (although bumping to 6 versions behind should be fine)

(also does some slight tweaks to release scripts that had compat issues on mac -moving away from gnu tooling in favour of what's listed in https://kube.rs/tools )