### PR TITLE
kubeconfig: deserialize null vectors as default

### DIFF
--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -25,14 +25,14 @@ pub struct Kubeconfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferences: Option<Preferences>,
     /// Referencable names to cluster configs
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub clusters: Vec<NamedCluster>,
     /// Referencable names to user configs
     #[serde(rename = "users")]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub auth_infos: Vec<NamedAuthInfo>,
     /// Referencable names to context configs
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub contexts: Vec<NamedContext>,
     /// The name of the context that you would like to use by default
     #[serde(rename = "current-context")]
@@ -150,6 +150,15 @@ where
         Ok(None) => Ok(None),
         Err(e) => Err(e),
     }
+}
+
+fn deserialize_null_as_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
 }
 
 /// AuthInfo stores information to tell cluster who you are.


### PR DESCRIPTION
## Motivation

Follow up from discussion on: https://github.com/kube-rs/kube/pull/1120

## Solution

Seems like we can solve this with a simple deserialize function instead of pulling another dependency.