### PR TITLE
Bump Rust MSRV to 1.63.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.60.0-bullseye
+FROM docker.io/rust:1.63.0-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kube-rs
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
-[![Rust 1.60](https://img.shields.io/badge/MSRV-1.60-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.60.0)
+[![Rust 1.63](https://img.shields.io/badge/MSRV-1.63-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.63.0)
 [![Tested against Kubernetes v1_21 and above](https://img.shields.io/badge/MK8SV-v1_21-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 keywords = ["kubernetes", "client",]
 categories = ["web-programming::http-client", "configuration", "network-programming", "api-bindings"]
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 edition = "2021"
 
 [features]

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "kazk <kazk.dev@gmail.com>",
 ]
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 license = "Apache-2.0"
 keywords = ["kubernetes", "apimachinery"]
 categories = ["api-bindings", "encoding", "parser-implementations"]

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "kazk <kazk.dev@gmail.com>",
 ]
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 license = "Apache-2.0"
 repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 keywords = ["kubernetes", "runtime", "reflector", "watcher", "controller"]
 categories = ["web-programming::http-client", "caching", "network-programming"]
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 edition = "2021"
 
 [package.metadata.docs.rs]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 keywords = ["kubernetes", "client", "runtime", "cncf"]
 categories = ["network-programming", "caching", "api-bindings", "configuration", "encoding"]
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
Update Rust stable MSRV to `1.63.0`. MSRV prior to this change is `1.60.0`. The bump is in line with the project's policy of attempting to trail the latest stable by at least 2 versions.

---

This will also unblock #1145 and allow the project to use `impl Trait` in argument positions (see https://github.com/rust-lang/rust/issues/83701).
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->



<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->



<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
