### PR TITLE
SharedStore provider

### DIFF
--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -3,7 +3,7 @@ use crate::request::Error;
 use serde::Serialize;
 
 /// Common query parameters used in watch/list/delete calls on collections
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ListParams {
     /// A selector to restrict the list of returned objects by their labels.
     ///

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -15,8 +15,9 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [features]
-unstable-runtime = ["unstable-runtime-subscribe"]
+unstable-runtime = ["unstable-runtime-subscribe", "unstable-runtime-shared-store"]
 unstable-runtime-subscribe = []
+unstable-runtime-shared-store = []
 
 [package.metadata.docs.rs]
 features = ["k8s-openapi/v1_26", "unstable-runtime"]
@@ -46,6 +47,7 @@ default-features = false
 
 [dev-dependencies]
 kube = { path = "../kube", features = ["derive", "client", "runtime"], version = "<1.0.0, >=0.60.0" }
+maplit = "1.0.2"
 serde_json = "1.0.68"
 tokio = { version = "1.14.0", features = ["full", "test-util"] }
 rand = "0.8.0"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -14,8 +14,12 @@ categories = ["web-programming::http-client", "caching", "network-programming"]
 rust-version = "1.60.0"
 edition = "2021"
 
+[features]
+unstable-runtime = ["unstable-runtime-subscribe"]
+unstable-runtime-subscribe = []
+
 [package.metadata.docs.rs]
-features = ["k8s-openapi/v1_26"]
+features = ["k8s-openapi/v1_26", "unstable-runtime"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -1,6 +1,7 @@
 //! Caches objects in memory
 
 mod object_ref;
+#[cfg(feature = "unstable-runtime-shared-store")] pub mod shared_store;
 pub mod store;
 
 pub use self::object_ref::{Extra as ObjectRefExtra, ObjectRef};

--- a/kube-runtime/src/reflector/shared_store.rs
+++ b/kube-runtime/src/reflector/shared_store.rs
@@ -1,0 +1,401 @@
+use crate::{
+    reflector::{
+        reflector,
+        store::{Store, Writer},
+    },
+    utils::{stream_subscribe, StreamSubscribe, WatchStreamExt},
+    watcher::{self, watcher, Event},
+};
+use futures::{stream, Stream, StreamExt};
+use k8s_openapi::NamespaceResourceScope;
+use kube_client::{api::ListParams, Api, Client, Resource};
+use serde::de::DeserializeOwned;
+use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
+use stream::BoxStream;
+
+pub struct SharedStore<K, W = WatcherFactory<K>>
+where
+    K: 'static + Resource + Clone + DeserializeOwned + Debug + Send,
+    K::DynamicType: Hash + Eq,
+    W: CreateWatcher<K>,
+{
+    watcher_provider: W,
+    reflectors: HashMap<ScopedListParams, (Store<K>, BoxStreamSubscribe<K>)>,
+}
+
+type ScopedListParams = (Option<String>, ListParams);
+type BoxStreamSubscribe<K> = StreamSubscribe<BoxStream<'static, watcher::Result<Event<K>>>>;
+
+impl<K> SharedStore<K>
+where
+    K: 'static + Resource + Clone + DeserializeOwned + Debug + Send + Sync,
+    K::DynamicType: Default + Eq + Hash + Clone,
+{
+    pub fn new(client: Client) -> Self {
+        Self {
+            watcher_provider: WatcherFactory::new(client),
+            reflectors: HashMap::new(),
+        }
+    }
+}
+
+impl<K, W> SharedStore<K, W>
+where
+    K: Clone + Resource + DeserializeOwned + Debug + Send + Sync + 'static,
+    K::DynamicType: Default + Eq + Hash + Clone,
+    W: CreateWatcher<K> + 'static,
+{
+    pub fn run(self) -> impl Stream<Item = Arc<watcher::Result<Event<K>>>> {
+        stream::select_all(self.reflectors.into_iter().map(|(_, (_, reflector))| reflector))
+    }
+
+    pub fn namespaced(&mut self, namespace: &str, list_params: ListParams) -> Store<K>
+    where
+        K: Resource<Scope = NamespaceResourceScope>,
+    {
+        self.reflectors
+            .entry((Some(namespace.to_string()), list_params.clone()))
+            .or_insert_with(|| setup_reflector(self.watcher_provider.namespaced(namespace, list_params)))
+            .0
+            .clone()
+    }
+
+    pub fn all(&mut self, list_params: ListParams) -> Store<K> {
+        self.reflectors
+            .entry((None, list_params.clone()))
+            .or_insert_with(|| setup_reflector(self.watcher_provider.all(list_params)))
+            .0
+            .clone()
+    }
+
+    pub fn subscribe_namespaced(
+        &mut self,
+        namespace: &str,
+        list_params: ListParams,
+    ) -> impl Stream<Item = Result<Arc<watcher::Result<Event<K>>>, stream_subscribe::Error>>
+    where
+        K: Resource<Scope = NamespaceResourceScope>,
+    {
+        self.reflectors
+            .entry((Some(namespace.to_string()), list_params.clone()))
+            .or_insert_with(|| setup_reflector(self.watcher_provider.namespaced(namespace, list_params)))
+            .1
+            .subscribe()
+    }
+
+    pub fn subscribe_all(
+        &mut self,
+        list_params: ListParams,
+    ) -> impl Stream<Item = Result<Arc<watcher::Result<Event<K>>>, stream_subscribe::Error>>
+    where
+        K: Resource<Scope = NamespaceResourceScope>,
+    {
+        self.reflectors
+            .entry((None, list_params.clone()))
+            .or_insert_with(|| setup_reflector(self.watcher_provider.all(list_params)))
+            .1
+            .subscribe()
+    }
+}
+
+fn setup_reflector<K>(
+    watcher: BoxStream<'static, watcher::Result<Event<K>>>,
+) -> (Store<K>, BoxStreamSubscribe<K>)
+where
+    K: Resource + Clone + Send + Sync,
+    K::DynamicType: Default + Eq + Hash + Clone,
+{
+    let store_writer = Writer::default();
+    let store_reader = store_writer.as_reader();
+    let reflector = reflector(store_writer, watcher).boxed().stream_subscribe();
+
+    (store_reader, reflector)
+}
+
+pub trait CreateWatcher<K> {
+    fn all(&self, list_params: ListParams) -> BoxStream<'static, watcher::Result<Event<K>>>;
+
+    fn namespaced(
+        &self,
+        namespace: &str,
+        list_params: ListParams,
+    ) -> BoxStream<'static, watcher::Result<Event<K>>>
+    where
+        K: Resource<Scope = NamespaceResourceScope>;
+}
+
+pub struct WatcherFactory<K> {
+    client: Client,
+    _phantom: std::marker::PhantomData<K>,
+}
+
+impl<K> WatcherFactory<K> {
+    fn new(client: Client) -> Self {
+        Self {
+            client,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<K> CreateWatcher<K> for WatcherFactory<K>
+where
+    K: Resource + Clone + DeserializeOwned + Debug + Send + 'static,
+    <K as Resource>::DynamicType: Default,
+{
+    fn all(&self, list_params: ListParams) -> BoxStream<'static, watcher::Result<Event<K>>> {
+        watcher(Api::all(self.client.clone()), list_params).boxed()
+    }
+
+    fn namespaced(
+        &self,
+        namespace: &str,
+        list_params: ListParams,
+    ) -> BoxStream<'static, watcher::Result<Event<K>>>
+    where
+        K: Resource<Scope = NamespaceResourceScope>,
+    {
+        watcher(Api::namespaced(self.client.clone(), namespace), list_params).boxed()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::expect_used)]
+mod test {
+    use super::*;
+    use futures::stream;
+    use k8s_openapi::{
+        api::core::v1::{ConfigMap, Pod},
+        apimachinery::pkg::apis::meta::v1::ObjectMeta,
+    };
+    use maplit::hashmap;
+    use std::{
+        collections::VecDeque,
+        fmt::{Display, Formatter},
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    #[tokio::test]
+    async fn returns_stores_that_updates_on_events() {
+        let lp = ListParams::default();
+        let expected_state = vec![test_pod(1)];
+        let mut pod_ss = TestSharedStore::<Pod>::new(
+            hashmap!((None, lp.clone().into()) => vec![Event::Restarted(expected_state.clone())]),
+        );
+        let store = pod_ss.all(lp);
+
+        pod_ss.spawn().await;
+
+        assert_eq!(store.cloned_state(), expected_state);
+    }
+
+    #[tokio::test]
+    async fn returns_the_same_store_for_the_same_list_params() {
+        let lp = ListParams::default().labels("foo=bar");
+        let expected_state = vec![test_pod(1)];
+        let mut pod_ss = TestSharedStore::<Pod>::new(
+            hashmap!((None, lp.clone().into()) => vec![Event::Restarted(expected_state.clone())]),
+        );
+
+        let store1 = pod_ss.all(lp.clone());
+        let store2 = pod_ss.all(lp);
+
+        pod_ss.spawn().await;
+
+        assert_eq!(store1.cloned_state(), expected_state);
+        assert_eq!(store2.cloned_state(), expected_state);
+    }
+
+    #[tokio::test]
+    async fn returns_a_different_store_for_different_list_params() {
+        let lp1 = ListParams::default().labels("foo=bar");
+        let lp2 = ListParams::default().labels("foo=baz");
+        let expected_state1 = vec![test_pod(1)];
+        let expected_state2 = vec![test_pod(2)];
+        let mut ss = TestSharedStore::<Pod>::new(hashmap!(
+            (None, lp1.clone().into()) => vec![Event::Restarted(expected_state1.clone())],
+            (None, lp2.clone().into()) => vec![Event::Restarted(expected_state2.clone())],
+        ));
+
+        let store1 = ss.all(lp1);
+        let store2 = ss.all(lp2);
+
+        ss.spawn().await;
+
+        assert_eq!(store1.cloned_state(), expected_state1, "Store 1");
+        assert_eq!(store2.cloned_state(), expected_state2, "Store 2");
+    }
+
+    #[tokio::test]
+    async fn returns_different_stores_for_same_list_params_with_different_scope() {
+        let lp = ListParams::default().labels("foo=bar");
+        let ns = "ns1";
+        let expected_state1 = vec![test_pod(1)];
+        let expected_state2 = vec![test_pod(2)];
+        let mut ss = TestSharedStore::<Pod>::new(hashmap!(
+            (None, lp.clone().into()) => vec![Event::Restarted(expected_state1.clone())],
+            (Some(ns.to_string()), lp.clone().into()) => vec![Event::Restarted(expected_state2.clone())],
+        ));
+
+        let cluster_store1 = ss.all(lp.clone());
+        let ns_store1 = ss.namespaced(ns, lp.clone());
+        let cluster_store2 = ss.all(lp);
+
+        ss.spawn().await;
+
+        assert_eq!(cluster_store1.cloned_state(), expected_state1, "ClusterStore 1");
+        assert_eq!(ns_store1.cloned_state(), expected_state2, "NS Store 1");
+        assert_eq!(cluster_store2.cloned_state(), expected_state1, "Cluster Store 2");
+    }
+
+    // TODO - Tests for the subscriptions
+
+    fn test_pod(postfix: usize) -> Pod {
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(format!("test-pod-{}", postfix)),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn test_cm(postfix: usize) -> ConfigMap {
+        ConfigMap {
+            metadata: ObjectMeta {
+                name: Some(format!("test-pod-{}", postfix)),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    type TestSharedStore<K> = SharedStore<K, TestWatcherFactory<K>>;
+
+    impl<K> SharedStore<K, TestWatcherFactory<K>>
+    where
+        K: 'static + Resource + Clone + DeserializeOwned + Debug + Send + Sync,
+        K::DynamicType: Clone + Debug + Default + Eq + Hash + Unpin,
+    {
+        fn new(events: HashMap<(Option<String>, ListParams), Vec<Event<K>>>) -> Self {
+            Self {
+                watcher_provider: TestWatcherFactory {
+                    events: Mutex::new(events.into_iter().map(|(k, v)| (k, v.into())).collect()),
+                },
+                reflectors: HashMap::new(),
+            }
+        }
+
+        async fn spawn(self) {
+            tokio::spawn(async move {
+                self.run().for_each(|_| async {}).await;
+            });
+
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct TestContext {
+        reconciled: Arc<Mutex<bool>>,
+    }
+
+    impl TestContext {
+        fn new() -> Self {
+            Self {
+                reconciled: Arc::new(Mutex::new(false)),
+            }
+        }
+
+        fn reconciled(&self) -> bool {
+            *self.reconciled.lock().unwrap()
+        }
+    }
+
+    struct TestWatcherFactory<K> {
+        events: Mutex<HashMap<(Option<String>, ListParams), VecDeque<Event<K>>>>,
+    }
+
+    impl<K> CreateWatcher<K> for TestWatcherFactory<K>
+    where
+        K: 'static + Resource + Clone + DeserializeOwned + Debug + Send,
+        K::DynamicType: Hash + Eq,
+    {
+        fn all(&self, list_params: ListParams) -> BoxStream<'static, watcher::Result<Event<K>>> {
+            self.watcher(None, list_params).boxed()
+        }
+
+        fn namespaced(
+            &self,
+            namespace: &str,
+            list_params: ListParams,
+        ) -> BoxStream<'static, watcher::Result<Event<K>>>
+        where
+            K: Resource<Scope = NamespaceResourceScope>,
+        {
+            self.watcher(Some(namespace.to_string()), list_params).boxed()
+        }
+    }
+
+    impl<K> TestWatcherFactory<K>
+    where
+        K: 'static + Resource + Clone + DeserializeOwned + Debug + Send,
+        K::DynamicType: Hash + Eq,
+    {
+        fn watcher(
+            &self,
+            scope: Option<String>,
+            list_params: ListParams,
+        ) -> impl Stream<Item = watcher::Result<Event<K>>> + Send {
+            let events = self
+                .events
+                .lock()
+                .unwrap()
+                .remove(&(scope, list_params.into()))
+                .expect("There can be only one stream per ListParams");
+
+            stream::unfold(events, |mut events| async move {
+                match events.pop_front() {
+                    Some(event) => Some((Ok(event), events)),
+                    // if there's nothing left we block to simulate waiting for a change
+                    None => futures::future::pending().await,
+                }
+            })
+        }
+    }
+
+    enum TestError {
+        TestError,
+    }
+
+    impl Debug for TestError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            unimplemented!()
+        }
+    }
+
+    impl Display for TestError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            unimplemented!()
+        }
+    }
+
+    impl std::error::Error for TestError {}
+
+    trait ClonedState<K> {
+        fn cloned_state(&self) -> Vec<K>;
+    }
+
+    impl<K> ClonedState<K> for Store<K>
+    where
+        K: 'static + Resource + Clone + DeserializeOwned + Debug + Send + Sync,
+        K::DynamicType: Clone + Debug + Default + Eq + Hash + Unpin,
+    {
+        fn cloned_state(&self) -> Vec<K> {
+            self.state().into_iter().map(|k| (*k).clone()).collect::<Vec<_>>()
+        }
+    }
+}

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -9,6 +9,7 @@ mod watch_ext;
 pub use backoff_reset_timer::ResetTimerBackoff;
 pub use event_flatten::EventFlatten;
 pub use stream_backoff::StreamBackoff;
+#[cfg(feature = "unstable_runtime_subscribe")]
 pub use stream_subscribe::StreamSubscribe;
 pub use watch_ext::WatchStreamExt;
 

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -3,7 +3,7 @@
 mod backoff_reset_timer;
 mod event_flatten;
 mod stream_backoff;
-#[cfg(feature = "unstable-runtime-subscribe")] mod stream_subscribe;
+#[cfg(feature = "unstable-runtime-subscribe")] pub mod stream_subscribe;
 mod watch_ext;
 
 pub use backoff_reset_timer::ResetTimerBackoff;

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -3,13 +3,13 @@
 mod backoff_reset_timer;
 mod event_flatten;
 mod stream_backoff;
-#[cfg(feature = "unstable_runtime_subscribe")] mod stream_subscribe;
+#[cfg(feature = "unstable-runtime-subscribe")] mod stream_subscribe;
 mod watch_ext;
 
 pub use backoff_reset_timer::ResetTimerBackoff;
 pub use event_flatten::EventFlatten;
 pub use stream_backoff::StreamBackoff;
-#[cfg(feature = "unstable_runtime_subscribe")]
+#[cfg(feature = "unstable-runtime-subscribe")]
 pub use stream_subscribe::StreamSubscribe;
 pub use watch_ext::WatchStreamExt;
 

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -3,11 +3,13 @@
 mod backoff_reset_timer;
 mod event_flatten;
 mod stream_backoff;
+mod stream_subscribe;
 mod watch_ext;
 
 pub use backoff_reset_timer::ResetTimerBackoff;
 pub use event_flatten::EventFlatten;
 pub use stream_backoff::StreamBackoff;
+pub use stream_subscribe::StreamSubscribe;
 pub use watch_ext::WatchStreamExt;
 
 use futures::{

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -3,6 +3,7 @@
 mod backoff_reset_timer;
 mod event_flatten;
 mod stream_backoff;
+#[cfg(feature = "unstable_runtime_subscribe")]
 mod stream_subscribe;
 mod watch_ext;
 

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -3,8 +3,7 @@
 mod backoff_reset_timer;
 mod event_flatten;
 mod stream_backoff;
-#[cfg(feature = "unstable_runtime_subscribe")]
-mod stream_subscribe;
+#[cfg(feature = "unstable_runtime_subscribe")] mod stream_subscribe;
 mod watch_ext;
 
 pub use backoff_reset_timer::ResetTimerBackoff;

--- a/kube-runtime/src/utils/stream_subscribe.rs
+++ b/kube-runtime/src/utils/stream_subscribe.rs
@@ -1,0 +1,116 @@
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::{stream, Stream, TryStream};
+use pin_project::pin_project;
+use tokio::sync::broadcast;
+
+/// Exposes the [`StreamSubscribe::subscribe_ok()`] method that allows additional
+/// consumers of [`Ok`] events from a stream without consuming the stream itself.
+///
+/// If the [`Stream`] is dropped or ends, any [`StreamSubscribe::subscribe_ok()`] streams
+/// will also end.
+#[pin_project]
+#[must_use = "streams do nothing unless polled"]
+pub struct StreamSubscribe<S>
+where
+    S: TryStream,
+{
+    #[pin]
+    stream: S,
+    sender: broadcast::Sender<Option<S::Ok>>,
+}
+
+impl<S: TryStream> StreamSubscribe<S>
+where
+    S::Ok: Clone,
+{
+    pub fn new(stream: S) -> Self {
+        let (sender, _) = broadcast::channel(100);
+
+        Self { stream, sender }
+    }
+
+    /// Subscribe to success events from this stream
+    pub fn subscribe_ok(&self) -> impl Stream<Item = S::Ok> {
+        stream::unfold(self.sender.subscribe(), |mut rx| async move {
+            match rx.recv().await {
+                Ok(Some(obj)) => Some((obj, rx)),
+                _ => None,
+            }
+        })
+    }
+}
+
+impl<S: TryStream> Stream for StreamSubscribe<S>
+where
+    S::Ok: Clone,
+{
+    type Item = Result<S::Ok, S::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        let item = this.stream.try_poll_next(cx);
+
+        if let Poll::Ready(Some(Ok(item))) = &item {
+            this.sender.send(Some((*item).clone())).ok();
+        } else if let Poll::Ready(None) = &item {
+            // If the stream is closed, we need to send a None to all subscribers
+            // which will cause them to close.
+            this.sender.send(None).ok();
+        }
+
+        item
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{pin_mut, poll, stream, StreamExt};
+
+    #[tokio::test]
+    async fn stream_subscribe_continues_to_propagate_values() {
+        let rx = stream::iter([Ok(0), Ok(1), Err(2), Ok(3), Ok(4)]);
+        let rx = StreamSubscribe::new(rx);
+
+        pin_mut!(rx);
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(0))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(1))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Err(2))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(3))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(4))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(None));
+    }
+
+    #[tokio::test]
+    async fn all_subscribers_get_success_events() {
+        let rx = stream::iter([Ok(0), Err(1)]);
+        let rx = StreamSubscribe::new(rx);
+
+        let rx_s1 = rx.subscribe_ok();
+        let rx_s2 = rx.subscribe_ok();
+
+        pin_mut!(rx);
+        pin_mut!(rx_s1);
+        pin_mut!(rx_s2);
+
+        assert_eq!(poll!(rx_s1.next()), Poll::Pending, "rx_s1");
+        assert_eq!(poll!(rx_s2.next()), Poll::Pending, "rx_s2");
+
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(0))), "rx");
+        assert_eq!(poll!(rx_s1.next()), Poll::Ready(Some(0)), "rx_s1");
+        assert_eq!(poll!(rx_s2.next()), Poll::Ready(Some(0)), "rx_s2");
+
+        // Subscribers don't get error events
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Err(1))), "rx");
+        assert_eq!(poll!(rx_s1.next()), Poll::Pending, "rx_s1");
+        assert_eq!(poll!(rx_s1.next()), Poll::Pending, "rx_s2");
+
+        // Ensure that if the stream is closed, all subscribers are closed
+        assert_eq!(poll!(rx.next()), Poll::Ready(None), "rx");
+        assert_eq!(poll!(rx_s1.next()), Poll::Ready(None), "rx_s1");
+        assert_eq!(poll!(rx_s2.next()), Poll::Ready(None), "rx_s2");
+    }
+}

--- a/kube-runtime/src/utils/stream_subscribe.rs
+++ b/kube-runtime/src/utils/stream_subscribe.rs
@@ -4,6 +4,7 @@ use core::{
 };
 use futures::{stream, Stream, TryStream};
 use pin_project::pin_project;
+use std::sync::Arc;
 use tokio::sync::broadcast;
 
 /// Exposes the [`StreamSubscribe::subscribe_ok()`] method that allows additional
@@ -19,21 +20,18 @@ where
 {
     #[pin]
     stream: S,
-    sender: broadcast::Sender<Option<S::Ok>>,
+    sender: broadcast::Sender<Option<Arc<Result<S::Ok, S::Error>>>>,
 }
 
-impl<S: TryStream> StreamSubscribe<S>
-where
-    S::Ok: Clone,
-{
+impl<S: TryStream> StreamSubscribe<S> {
     pub fn new(stream: S) -> Self {
         let (sender, _) = broadcast::channel(100);
 
         Self { stream, sender }
     }
 
-    /// Subscribe to success events from this stream
-    pub fn subscribe_ok(&self) -> impl Stream<Item = S::Ok> {
+    /// Subscribe to events from this stream
+    pub fn subscribe(&self) -> impl Stream<Item = Arc<Result<S::Ok, S::Error>>> {
         stream::unfold(self.sender.subscribe(), |mut rx| async move {
             match rx.recv().await {
                 Ok(Some(obj)) => Some((obj, rx)),
@@ -43,25 +41,25 @@ where
     }
 }
 
-impl<S: TryStream> Stream for StreamSubscribe<S>
-where
-    S::Ok: Clone,
-{
-    type Item = Result<S::Ok, S::Error>;
+impl<S: TryStream> Stream for StreamSubscribe<S> {
+    type Item = Arc<Result<S::Ok, S::Error>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
         let item = this.stream.try_poll_next(cx);
 
-        if let Poll::Ready(Some(Ok(item))) = &item {
-            this.sender.send(Some((*item).clone())).ok();
-        } else if let Poll::Ready(None) = &item {
-            // If the stream is closed, we need to send a None to all subscribers
-            // which will cause them to close.
-            this.sender.send(None).ok();
+        match item {
+            Poll::Ready(Some(item)) => {
+                let item = Arc::new(item);
+                this.sender.send(Some(item.clone())).ok();
+                Poll::Ready(Some(item))
+            }
+            Poll::Ready(None) => {
+                this.sender.send(None).ok();
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
         }
-
-        item
     }
 }
 
@@ -76,41 +74,42 @@ mod tests {
         let rx = StreamSubscribe::new(rx);
 
         pin_mut!(rx);
-        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(0))));
-        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(1))));
-        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Err(2))));
-        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(3))));
-        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(4))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Arc::new(Ok(0)))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Arc::new(Ok(1)))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Arc::new(Err(2)))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Arc::new(Ok(3)))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Arc::new(Ok(4)))));
         assert_eq!(poll!(rx.next()), Poll::Ready(None));
     }
 
     #[tokio::test]
-    async fn all_subscribers_get_success_events() {
-        let rx = stream::iter([Ok(0), Err(1)]);
+    async fn all_subscribers_get_events() {
+        let items = [Ok(0), Ok(1), Err(2), Ok(3), Ok(4)];
+        let rx = stream::iter(items.clone());
         let rx = StreamSubscribe::new(rx);
 
-        let rx_s1 = rx.subscribe_ok();
-        let rx_s2 = rx.subscribe_ok();
+        let rx_s1 = rx.subscribe();
+        let rx_s2 = rx.subscribe();
 
         pin_mut!(rx);
         pin_mut!(rx_s1);
         pin_mut!(rx_s2);
 
-        assert_eq!(poll!(rx_s1.next()), Poll::Pending, "rx_s1");
-        assert_eq!(poll!(rx_s2.next()), Poll::Pending, "rx_s2");
+        // Subscribers are pending until we start consuming the stream
+        assert_eq!(poll!(rx_s1.next()), Poll::Pending, "rx_s1 - pending");
+        assert_eq!(poll!(rx_s2.next()), Poll::Pending, "rx_s2 - pending");
 
-        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(0))), "rx");
-        assert_eq!(poll!(rx_s1.next()), Poll::Ready(Some(0)), "rx_s1");
-        assert_eq!(poll!(rx_s2.next()), Poll::Ready(Some(0)), "rx_s2");
-
-        // Subscribers don't get error events
-        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Err(1))), "rx");
-        assert_eq!(poll!(rx_s1.next()), Poll::Pending, "rx_s1");
-        assert_eq!(poll!(rx_s1.next()), Poll::Pending, "rx_s2");
+        for (index, item) in items.into_iter().enumerate() {
+            let expected = Poll::Ready(Some(Arc::new(item)));
+            assert_eq!(poll!(rx.next()), expected, "rx - {}", index);
+            assert_eq!(poll!(rx_s1.next()), expected, "rx_s1 - {}", index);
+            assert_eq!(poll!(rx_s2.next()), expected, "rx_s2 - {}", index);
+        }
 
         // Ensure that if the stream is closed, all subscribers are closed
-        assert_eq!(poll!(rx.next()), Poll::Ready(None), "rx");
-        assert_eq!(poll!(rx_s1.next()), Poll::Ready(None), "rx_s1");
-        assert_eq!(poll!(rx_s2.next()), Poll::Ready(None), "rx_s2");
+        let expected = Poll::Ready(None);
+        assert_eq!(poll!(rx.next()), expected, "rx - close");
+        assert_eq!(poll!(rx_s1.next()), expected, "rx_s1 - close");
+        assert_eq!(poll!(rx_s2.next()), expected, "rx_s2 - close");
     }
 }

--- a/kube-runtime/src/utils/stream_subscribe.rs
+++ b/kube-runtime/src/utils/stream_subscribe.rs
@@ -2,51 +2,60 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use futures::{stream, Stream, TryStream};
+use futures::{stream, Stream};
 use pin_project::pin_project;
+use std::fmt;
 use std::sync::Arc;
 use tokio::sync::broadcast;
+use tokio::sync::broadcast::error::RecvError;
 
-/// Exposes the [`StreamSubscribe::subscribe_ok()`] method that allows additional
-/// consumers of [`Ok`] events from a stream without consuming the stream itself.
+const CHANNEL_CAPACITY: usize = 128;
+
+/// Exposes the [`StreamSubscribe::subscribe()`] method which allows additional
+/// consumers of events from a stream without consuming the stream itself.
 ///
-/// If the [`Stream`] is dropped or ends, any [`StreamSubscribe::subscribe_ok()`] streams
+/// If a subscriber beings to lag behind the stream, it will receive a [`StreamSubscribeError::Lagged`]
+/// error. The subscriber can then decide to abort its or tolerate the lost events.
+///
+/// If the [`Stream`] is dropped or ends, any [`StreamSubscribe::subscribe()`] streams
 /// will also end.
 #[pin_project]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "subscribers will not get events unless this stream is polled"]
 pub struct StreamSubscribe<S>
 where
-    S: TryStream,
+    S: Stream,
 {
     #[pin]
     stream: S,
-    sender: broadcast::Sender<Option<Arc<Result<S::Ok, S::Error>>>>,
+    sender: broadcast::Sender<Option<Arc<S::Item>>>,
 }
 
-impl<S: TryStream> StreamSubscribe<S> {
+impl<S: Stream> StreamSubscribe<S> {
     pub fn new(stream: S) -> Self {
-        let (sender, _) = broadcast::channel(100);
+        let (sender, _) = broadcast::channel(CHANNEL_CAPACITY);
 
         Self { stream, sender }
     }
 
     /// Subscribe to events from this stream
-    pub fn subscribe(&self) -> impl Stream<Item = Arc<Result<S::Ok, S::Error>>> {
+    #[must_use = "streams do nothing unless polled"]
+    pub fn subscribe(&self) -> impl Stream<Item = Result<Arc<S::Item>, StreamSubscribeError>> {
         stream::unfold(self.sender.subscribe(), |mut rx| async move {
             match rx.recv().await {
-                Ok(Some(obj)) => Some((obj, rx)),
+                Ok(Some(obj)) => Some((Ok(obj), rx)),
+                Err(RecvError::Lagged(amt)) => Some((Err(StreamSubscribeError::Lagged(amt)), rx)),
                 _ => None,
             }
         })
     }
 }
 
-impl<S: TryStream> Stream for StreamSubscribe<S> {
-    type Item = Arc<Result<S::Ok, S::Error>>;
+impl<S: Stream> Stream for StreamSubscribe<S> {
+    type Item = Arc<S::Item>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
-        let item = this.stream.try_poll_next(cx);
+        let item = this.stream.poll_next(cx);
 
         match item {
             Poll::Ready(Some(item)) => {
@@ -62,6 +71,26 @@ impl<S: TryStream> Stream for StreamSubscribe<S> {
         }
     }
 }
+
+/// An error returned from the inner stream of a [`StreamSubscribe`].
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum StreamSubscribeError {
+    /// The subscriber lagged too far behind. Polling again will return
+    /// the oldest event still retained.
+    ///
+    /// Includes the number of skipped events.
+    Lagged(u64),
+}
+
+impl fmt::Display for StreamSubscribeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StreamSubscribeError::Lagged(amt) => write!(f, "subscriber lagged by {}", amt),
+        }
+    }
+}
+
+impl std::error::Error for StreamSubscribeError {}
 
 #[cfg(test)]
 mod tests {
@@ -84,8 +113,8 @@ mod tests {
 
     #[tokio::test]
     async fn all_subscribers_get_events() {
-        let items = [Ok(0), Ok(1), Err(2), Ok(3), Ok(4)];
-        let rx = stream::iter(items.clone());
+        let events = [Ok(0), Ok(1), Err(2), Ok(3), Ok(4)];
+        let rx = stream::iter(events.clone());
         let rx = StreamSubscribe::new(rx);
 
         let rx_s1 = rx.subscribe();
@@ -96,20 +125,113 @@ mod tests {
         pin_mut!(rx_s2);
 
         // Subscribers are pending until we start consuming the stream
-        assert_eq!(poll!(rx_s1.next()), Poll::Pending, "rx_s1 - pending");
-        assert_eq!(poll!(rx_s2.next()), Poll::Pending, "rx_s2 - pending");
+        assert_eq!(poll!(rx_s1.next()), Poll::Pending, "rx_s1");
+        assert_eq!(poll!(rx_s2.next()), Poll::Pending, "rx_s2");
 
-        for (index, item) in items.into_iter().enumerate() {
-            let expected = Poll::Ready(Some(Arc::new(item)));
-            assert_eq!(poll!(rx.next()), expected, "rx - {}", index);
-            assert_eq!(poll!(rx_s1.next()), expected, "rx_s1 - {}", index);
-            assert_eq!(poll!(rx_s2.next()), expected, "rx_s2 - {}", index);
+        for item in events {
+            assert_eq!(poll!(rx.next()), Poll::Ready(Some(Arc::new(item))), "rx");
+            let expected = Poll::Ready(Some(Ok(Arc::new(item))));
+            assert_eq!(poll!(rx_s1.next()), expected, "rx_s1");
+            assert_eq!(poll!(rx_s2.next()), expected, "rx_s2");
         }
 
         // Ensure that if the stream is closed, all subscribers are closed
-        let expected = Poll::Ready(None);
-        assert_eq!(poll!(rx.next()), expected, "rx - close");
-        assert_eq!(poll!(rx_s1.next()), expected, "rx_s1 - close");
-        assert_eq!(poll!(rx_s2.next()), expected, "rx_s2 - close");
+        assert_eq!(poll!(rx.next()), Poll::Ready(None), "rx");
+        assert_eq!(poll!(rx_s1.next()), Poll::Ready(None), "rx_s1");
+        assert_eq!(poll!(rx_s2.next()), Poll::Ready(None), "rx_s2");
+    }
+
+    #[tokio::test]
+    async fn subscribers_can_catch_up_to_the_main_stream() {
+        let events = (0..CHANNEL_CAPACITY).map(Ok::<_, ()>).collect::<Vec<_>>();
+        let rx = stream::iter(events.clone());
+        let rx = StreamSubscribe::new(rx);
+
+        let rx_s1 = rx.subscribe();
+
+        pin_mut!(rx);
+        pin_mut!(rx_s1);
+
+        for item in events.clone() {
+            assert_eq!(poll!(rx.next()), Poll::Ready(Some(Arc::new(item))), "rx",);
+        }
+
+        for item in events {
+            assert_eq!(
+                poll!(rx_s1.next()),
+                Poll::Ready(Some(Ok(Arc::new(item)))),
+                "rx_s1"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn if_the_subscribers_lag_they_get_a_lagged_error_as_the_next_event() {
+        // The broadcast channel rounds the capacity up to the next power of two.
+        let max_capacity = CHANNEL_CAPACITY.next_power_of_two();
+        let overflow = 5;
+        let events = (0..max_capacity + overflow).collect::<Vec<_>>();
+        let rx = stream::iter(events.clone());
+        let rx = StreamSubscribe::new(rx);
+
+        let rx_s1 = rx.subscribe();
+
+        pin_mut!(rx);
+        pin_mut!(rx_s1);
+
+        // Consume the entire stream, overflowing the inner channel
+        for _ in events {
+            let _ = poll!(rx.next());
+        }
+
+        assert_eq!(
+            poll!(rx_s1.next()),
+            Poll::Ready(Some(Err(StreamSubscribeError::Lagged(overflow as u64)))),
+        );
+
+        let expected_next_event = overflow;
+        assert_eq!(
+            poll!(rx_s1.next()),
+            Poll::Ready(Some(Ok(Arc::new(expected_next_event)))),
+        );
+    }
+
+    #[tokio::test]
+    async fn a_lagging_subscriber_does_not_impact_a_well_behaved_subscriber() {
+        // The broadcast channel rounds the capacity up to the next power of two.
+        let max_capacity = CHANNEL_CAPACITY.next_power_of_two();
+        let overflow = 5;
+        let events = (0..max_capacity + overflow).collect::<Vec<_>>();
+        let rx = stream::iter(events.clone());
+        let rx = StreamSubscribe::new(rx);
+
+        let rx_s1 = rx.subscribe();
+        let rx_s2 = rx.subscribe();
+
+        pin_mut!(rx);
+        pin_mut!(rx_s1);
+        pin_mut!(rx_s2);
+
+        for event in events {
+            let _ = poll!(rx.next());
+            assert_eq!(
+                poll!(rx_s1.next()),
+                Poll::Ready(Some(Ok(Arc::new(event)))),
+                "rx_s1"
+            );
+        }
+
+        assert_eq!(
+            poll!(rx_s2.next()),
+            Poll::Ready(Some(Err(StreamSubscribeError::Lagged(overflow as u64)))),
+            "rx_s2"
+        );
+
+        let expected_next_event = overflow;
+        assert_eq!(
+            poll!(rx_s2.next()),
+            Poll::Ready(Some(Ok(Arc::new(expected_next_event)))),
+            "rx_s2"
+        );
     }
 }

--- a/kube-runtime/src/utils/stream_subscribe.rs
+++ b/kube-runtime/src/utils/stream_subscribe.rs
@@ -17,6 +17,11 @@ const CHANNEL_CAPACITY: usize = 128;
 ///
 /// If the [`Stream`] is dropped or ends, any [`StreamSubscribe::subscribe()`] streams
 /// will also end.
+///
+/// ## Warning
+///
+/// If the primary [`Stream`] is not polled, the [`StreamSubscribe::subscribe()`] streams
+/// will never receive any events.
 #[pin_project]
 #[must_use = "subscribers will not get events unless this stream is polled"]
 pub struct StreamSubscribe<S>
@@ -211,6 +216,8 @@ mod tests {
         pin_mut!(rx_s2);
 
         for event in events {
+            assert_eq!(poll!(rx_s1.next()), Poll::Pending, "rx_s1");
+
             rx.next().await;
 
             assert_eq!(

--- a/kube-runtime/src/utils/stream_subscribe.rs
+++ b/kube-runtime/src/utils/stream_subscribe.rs
@@ -14,8 +14,8 @@ const CHANNEL_CAPACITY: usize = 128;
 /// Exposes the [`StreamSubscribe::subscribe()`] method which allows additional
 /// consumers of events from a stream without consuming the stream itself.
 ///
-/// If a subscriber beings to lag behind the stream, it will receive a [`Error::Lagged`]
-/// error. The subscriber can then decide to abort its or tolerate the lost events.
+/// If a subscriber begins to lag behind the stream, it will receive an [`Error::Lagged`]
+/// error. The subscriber can then decide to abort its task or tolerate the lost events.
 ///
 /// If the [`Stream`] is dropped or ends, any [`StreamSubscribe::subscribe()`] streams
 /// will also end.

--- a/kube-runtime/src/utils/stream_subscribe.rs
+++ b/kube-runtime/src/utils/stream_subscribe.rs
@@ -4,10 +4,8 @@ use core::{
 };
 use futures::{stream, Stream};
 use pin_project::pin_project;
-use std::fmt;
-use std::sync::Arc;
-use tokio::sync::broadcast;
-use tokio::sync::broadcast::error::RecvError;
+use std::{fmt, sync::Arc};
+use tokio::sync::{broadcast, broadcast::error::RecvError};
 
 const CHANNEL_CAPACITY: usize = 128;
 
@@ -40,7 +38,7 @@ impl<S: Stream> StreamSubscribe<S> {
     /// Subscribe to events from this stream
     #[must_use = "streams do nothing unless polled"]
     pub fn subscribe(&self) -> impl Stream<Item = Result<Arc<S::Item>, Error>> {
-        stream::unfold(self.sender.subscribe(), |mut rx| async move {
+        stream::unfold(self.sender.subscribe(), |mut rx| async {
             match rx.recv().await {
                 Ok(Some(obj)) => Some((Ok(obj), rx)),
                 Err(RecvError::Lagged(amt)) => Some((Err(Error::Lagged(amt)), rx)),

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "unstable_runtime_subscribe")]
+#[cfg(feature = "unstable-runtime-subscribe")]
 use crate::utils::stream_subscribe::StreamSubscribe;
 use crate::{
     utils::{event_flatten::EventFlatten, stream_backoff::StreamBackoff},
@@ -93,7 +93,7 @@ pub trait WatchStreamExt: Stream {
     ///     (stream_subscribe, explain_stream)
     /// }
     /// ```
-    #[cfg(feature = "unstable_runtime_subscribe")]
+    #[cfg(feature = "unstable-runtime-subscribe")]
     fn stream_subscribe<K>(self) -> StreamSubscribe<Self>
     where
         Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Send + Sized + 'static,

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -41,7 +41,7 @@ pub trait WatchStreamExt: Stream {
     /// Create a [`StreamSubscribe`] from a [`watcher()`] stream
     ///
     /// Allows additional consumers to subscribe to the stream, without consuming the stream itself.
-    fn subscribable<K>(self) -> StreamSubscribe<Self>
+    fn subscribe<K>(self) -> StreamSubscribe<Self>
     where
         Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Send + Sized + 'static,
     {

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -1,10 +1,10 @@
+#[cfg(feature = "unstable_runtime_subscribe")]
+use crate::utils::stream_subscribe::StreamSubscribe;
 use crate::{
     utils::{event_flatten::EventFlatten, stream_backoff::StreamBackoff},
     watcher,
 };
 use backoff::backoff::Backoff;
-
-use crate::utils::stream_subscribe::StreamSubscribe;
 use futures::{Stream, TryStream};
 
 /// Extension trait for streams returned by [`watcher`](watcher()) or [`reflector`](crate::reflector::reflector)
@@ -93,6 +93,7 @@ pub trait WatchStreamExt: Stream {
     ///     (stream_subscribe, explain_stream)
     /// }
     /// ```
+    #[cfg(feature = "unstable_runtime_subscribe")]
     fn stream_subscribe<K>(self) -> StreamSubscribe<Self>
     where
         Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Send + Sized + 'static,

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -38,10 +38,62 @@ pub trait WatchStreamExt: Stream {
         EventFlatten::new(self, true)
     }
 
-    /// Create a [`StreamSubscribe`] from a [`watcher()`] stream
+    /// Create a [`StreamSubscribe`] from a [`watcher()`] stream.
     ///
-    /// Allows additional consumers to subscribe to the stream, without consuming the stream itself.
-    fn subscribe<K>(self) -> StreamSubscribe<Self>
+    /// The [`StreamSubscribe::subscribe()`] method which allows additional consumers
+    /// of events from a stream without consuming the stream itself.
+    ///
+    /// If a subscriber begins to lag behind the stream, it will receive an [`Error::Lagged`]
+    /// error. The subscriber can then decide to abort its task or tolerate the lost events.
+    ///
+    /// If the [`Stream`] is dropped or ends, any [`StreamSubscribe::subscribe()`] streams
+    /// will also end.
+    ///
+    /// ## Warning
+    ///
+    /// If the primary [`Stream`] is not polled, the [`StreamSubscribe::subscribe()`] streams
+    /// will never receive any events.
+    ///
+    /// # Usage
+    ///
+    /// ```
+    /// use futures::{Stream, StreamExt};
+    /// use std::{fmt::Debug, sync::Arc};
+    /// use kube_runtime::{watcher, WatchStreamExt};
+    ///
+    /// fn explain_events<K, S>(
+    ///     stream: S,
+    /// ) -> (
+    ///     impl Stream<Item = Arc<Result<watcher::Event<K>, watcher::Error>>> + Send + Sized + 'static,
+    ///     impl Stream<Item = String> + Send + Sized + 'static,
+    /// )
+    /// where
+    ///     K: Debug + Send + Sync + 'static,
+    ///     S: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Send + Sized + 'static,
+    /// {
+    ///     // Create a stream that can be subscribed to
+    ///     let stream_subscribe = stream.stream_subscribe();
+    ///     // Create a subscription to that stream
+    ///     let subscription = stream_subscribe.subscribe();
+    ///
+    ///     // Create a stream of descriptions of the events
+    ///     let explain_stream = subscription.filter_map(|event| async move {
+    ///         // We don't care about lagged events so we can throw that error away
+    ///         match event.ok()?.as_deref() {
+    ///             Ok(watcher::Event::Applied(event)) => {
+    ///                 Some(format!("An object was added or modified: {event:?}"))
+    ///             }
+    ///             Ok(_) => todo!("explain other events"),
+    ///             // We don't care about watcher errors either
+    ///             Err(_) => None,
+    ///         }
+    ///     });
+    ///
+    ///     // We now still have the original stream, and a secondary stream of explanations
+    ///     (stream_subscribe, explain_stream)
+    /// }
+    /// ```
+    fn stream_subscribe<K>(self) -> StreamSubscribe<Self>
     where
         Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Send + Sized + 'static,
     {

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -41,7 +41,7 @@ pub trait WatchStreamExt: Stream {
     /// Create a [`StreamSubscribe`] from a [`watcher()`] stream
     ///
     /// Allows additional consumers to subscribe to the stream, without consuming the stream itself.
-    fn subscribable<K: Clone>(self) -> StreamSubscribe<Self>
+    fn subscribable<K>(self) -> StreamSubscribe<Self>
     where
         Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Send + Sized + 'static,
     {

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use backoff::backoff::Backoff;
 
+use crate::utils::stream_subscribe::StreamSubscribe;
 use futures::{Stream, TryStream};
 
 /// Extension trait for streams returned by [`watcher`](watcher()) or [`reflector`](crate::reflector::reflector)
@@ -36,5 +37,16 @@ pub trait WatchStreamExt: Stream {
     {
         EventFlatten::new(self, true)
     }
+
+    /// Create a [`StreamSubscribe`] from a [`watcher()`] stream
+    ///
+    /// Allows additional consumers to subscribe to the stream, without consuming the stream itself.
+    fn subscribable<K: Clone>(self) -> StreamSubscribe<Self>
+    where
+        Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Send + Sized + 'static,
+    {
+        StreamSubscribe::new(self)
+    }
 }
+
 impl<St: ?Sized> WatchStreamExt for St where St: Stream {}

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -28,6 +28,7 @@ admission = ["kube-core/admission"]
 derive = ["kube-derive", "kube-core/schema"]
 config = ["kube-client/config"]
 runtime = ["kube-runtime"]
+unstable-runtime = ["kube-runtime/unstable-runtime"]
 
 [package.metadata.docs.rs]
 features = ["client", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_26"]


### PR DESCRIPTION
## Motivation

**For additional context see:** https://github.com/kube-rs/kube/pull/1128 

In large controllers you can end up with multiple instances of the same store, this has the potential to case a split brain problem where different bits of the application have a different view of the cluster.

This can be solved by creating stores at the top level of the application and passing them down; but the definition of the stores is then required to be at a distance from the usage sites, smearing responsibilities around the codebase.

## Solution

The `SharedStore` struct will always return a clone of the same `Store` for a given scope and `ListParams`. The aim is to minimise the knowledge that must exist at a distance (only the types must be known, which can be cleanly asked for in controller interfaces), while still allowing separate parts of the application to share stores.
