### PR TITLE
Genericize `PartialObjectMeta` over the underlying `Resource`

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -13,5 +13,5 @@ jobs:
           override: true
       - uses: actions-rs/clippy-check@v1
         with:
-          args: "--workspace --all-features"
+          args: "--workspace"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -13,5 +13,5 @@ jobs:
           override: true
       - uses: actions-rs/clippy-check@v1
         with:
-          args: "--workspace"
+          args: "--workspace --all-features"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ default:
 clippy:
   #rustup component add clippy --toolchain nightly
   cargo +nightly clippy --workspace
-  cargo +nightly clippy --no-default-features --features=rustls-tls
+  cargo +nightly clippy --all-features
 
 fmt:
   #rustup component add rustfmt --toolchain nightly

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -158,8 +158,7 @@ where
     ///     let lp = ListParams::default().labels("app=blog"); // for this app only
     ///     let list: ObjectList<PartialObjectMeta<Pod>> = pods.list_metadata(&lp).await?;
     ///     for p in list {
-    ///         let metadata = ObjectMeta::from(p);
-    ///         println!("Found Pod: {}", metadata.name.unwrap());
+    ///         println!("Found Pod: {}", p.name_any());
     ///     }
     ///     Ok(())
     /// }
@@ -330,9 +329,6 @@ where
     ///             "labels": {
     ///                 "key": "value"
     ///             },
-    ///         },
-    ///         "spec": {
-    ///             "activeDeadlineSeconds": 5
     ///         }
     ///     });
     ///     let params = PatchParams::apply("myapp");
@@ -345,8 +341,13 @@ where
     /// [`Patch`]: super::Patch
     /// [`PatchParams`]: super::PatchParams
     ///
-    /// Note that this method cannot write to the status object (when it exists) of a resource.
-    /// To set status objects please see [`Api::replace_status`] or [`Api::patch_status`].
+    /// ### Warnings
+    ///
+    /// The `TypeMeta` (apiVersion + kind) of a patch request (required for apply patches)
+    /// must match the underlying type that is being patched (e.g. "v1" + "Pod").
+    /// The returned `TypeMeta` will always be {"meta.k8s.io/v1", "PartialObjectMetadata"}.
+    ///
+    /// This method can write to non-metadata fields such as spec if included in the patch.
     pub async fn patch_metadata<P: Serialize + Debug>(
         &self,
         name: &str,

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -61,7 +61,7 @@ where
     /// Consider using [`Api::get_metadata_opt`] if you need to handle missing objects.
     pub async fn get_metadata(&self, name: &str) -> Result<PartialObjectMeta<K>> {
         let mut req = self.request.get_metadata(name).map_err(Error::BuildRequest)?;
-        req.extensions_mut().insert("get");
+        req.extensions_mut().insert("get_metadata");
         self.client.request::<PartialObjectMeta<K>>(req).await
     }
 
@@ -156,7 +156,7 @@ where
     ///     let client = Client::try_default().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     let lp = ListParams::default().labels("app=blog"); // for this app only
-    ///     let list: ObjectList<PartialObjectMeta<K>> = pods.list_metadata(&lp).await?;
+    ///     let list: ObjectList<PartialObjectMeta<Pod>> = pods.list_metadata(&lp).await?;
     ///     for p in list {
     ///         let metadata = ObjectMeta::from(p);
     ///         println!("Found Pod: {}", metadata.name.unwrap());
@@ -166,7 +166,7 @@ where
     /// ```
     pub async fn list_metadata(&self, lp: &ListParams) -> Result<ObjectList<PartialObjectMeta<K>>> {
         let mut req = self.request.list_metadata(lp).map_err(Error::BuildRequest)?;
-        req.extensions_mut().insert("list");
+        req.extensions_mut().insert("list_metadata");
         self.client.request::<ObjectList<PartialObjectMeta<K>>>(req).await
     }
 
@@ -357,7 +357,7 @@ where
             .request
             .patch_metadata(name, pp, patch)
             .map_err(Error::BuildRequest)?;
-        req.extensions_mut().insert("patch");
+        req.extensions_mut().insert("patch_metadata");
         self.client.request::<PartialObjectMeta<K>>(req).await
     }
 
@@ -515,7 +515,7 @@ where
             .request
             .watch_metadata(lp, version)
             .map_err(Error::BuildRequest)?;
-        req.extensions_mut().insert("watch");
+        req.extensions_mut().insert("watch_metadata");
         self.client.request_events::<PartialObjectMeta<K>>(req).await
     }
 }

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use kube_core::params;
 pub use kube_core::{
     dynamic::{ApiResource, DynamicObject},
     gvk::{GroupVersionKind, GroupVersionResource},
-    metadata::{ListMeta, ObjectMeta, TypeMeta},
+    metadata::{ListMeta, ObjectMeta, PartialObjectMeta, PartialObjectMetaExt, TypeMeta},
     object::{NotUsed, Object, ObjectList},
     request::Request,
     watch::WatchEvent,

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -28,7 +28,7 @@ pub mod gvk;
 pub use gvk::{GroupVersion, GroupVersionKind, GroupVersionResource};
 
 pub mod metadata;
-pub use metadata::{ListMeta, ObjectMeta, TypeMeta};
+pub use metadata::{ListMeta, ObjectMeta, PartialObjectMeta, PartialObjectMetaExt, TypeMeta};
 
 pub mod object;
 pub use object::{NotUsed, Object, ObjectList};

--- a/kube-core/src/metadata.rs
+++ b/kube-core/src/metadata.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, marker::PhantomData};
 pub use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ListMeta, ObjectMeta};
 use serde::{Deserialize, Serialize};
 
-use crate::Resource;
+use crate::{DynamicObject, Resource};
 
 /// Type information that is flattened into every kubernetes object
 #[derive(Deserialize, Serialize, Clone, Default, Debug, Eq, PartialEq, Hash)]
@@ -21,9 +21,11 @@ pub struct TypeMeta {
 ///
 /// It allows clients to get access to a particular `ObjectMeta`
 /// schema without knowing the details of the version.
+///
+/// See the [`PartialObjectMetaExt`] trait for how to construct one safely.
 #[derive(Deserialize, Serialize, Clone, Default, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct PartialObjectMeta<K> {
+pub struct PartialObjectMeta<K = DynamicObject> {
     /// The type fields, not always present
     #[serde(flatten, default)]
     pub types: Option<TypeMeta>,
@@ -35,22 +37,49 @@ pub struct PartialObjectMeta<K> {
     pub _phantom: PhantomData<K>,
 }
 
-// Users usually want the inner metadata on returns
-impl<K> From<PartialObjectMeta<K>> for ObjectMeta {
-    fn from(obj: PartialObjectMeta<K>) -> Self {
-        ObjectMeta { ..obj.metadata }
-    }
+mod private {
+    pub trait Sealed {}
+    impl Sealed for super::ObjectMeta {}
+}
+/// Helper trait for converting `ObjectMeta` into useful `PartialObjectMeta` variants
+pub trait PartialObjectMetaExt: private::Sealed {
+    /// Convert `ObjectMeta` into a Patch-serializable `PartialObjectMeta`
+    ///
+    /// This object can be passed to `Patch::Apply` and used with `Api::patch_metadata`,
+    /// for an `Api<K>` using the underlying types `TypeMeta`
+    fn into_request_partial<K: Resource<DynamicType = ()>>(self) -> PartialObjectMeta<K>;
+    /// Convert `ObjectMeta` into a response object for a specific `Resource`
+    ///
+    /// This object emulates a response object and **cannot** be used in request bodies
+    /// because it contains erased `TypeMeta` (and the apiserver is doing the erasing).
+    ///
+    /// This method is useful when unit testing local behaviour.
+    fn into_response_partial<K: Resource>(self) -> PartialObjectMeta<K>;
 }
 
-// Unit tests often convert the other way
-impl<K> From<ObjectMeta> for PartialObjectMeta<K> {
-    fn from(meta: ObjectMeta) -> Self {
+impl PartialObjectMetaExt for ObjectMeta {
+    fn into_request_partial<K: Resource<DynamicType = ()>>(self) -> PartialObjectMeta<K>
+    where
+        K::DynamicType: Default,
+    {
+        let dyntype: K::DynamicType = Default::default();
+        PartialObjectMeta {
+            types: Some(TypeMeta {
+                api_version: K::api_version(&dyntype).into(),
+                kind: K::kind(&dyntype).into(),
+            }),
+            metadata: self,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn into_response_partial<K>(self) -> PartialObjectMeta<K> {
         PartialObjectMeta {
             types: Some(TypeMeta {
                 api_version: "meta.k8s.io/v1".to_string(),
                 kind: "PartialObjectMetadata".to_string(),
             }),
-            metadata: meta,
+            metadata: self,
             _phantom: PhantomData,
         }
     }
@@ -87,23 +116,34 @@ impl<K: Resource> Resource for PartialObjectMeta<K> {
 
 #[cfg(test)]
 mod test {
-    use super::{ObjectMeta, PartialObjectMeta};
+    use super::{ObjectMeta, PartialObjectMeta, PartialObjectMetaExt};
     use crate::Resource;
     use k8s_openapi::api::core::v1::Pod;
 
     #[test]
     fn can_convert_and_derive_partial_metadata() {
-        let partial: PartialObjectMeta<Pod> = ObjectMeta {
-            name: Some("mypod".into()),
-            ..Default::default()
-        }
-        .into();
-        assert_eq!(partial.metadata.name, Some("mypod".to_string()));
-        // created type uses verbatim serialization
-        assert_eq!(partial.types.as_ref().unwrap().kind, "PartialObjectMetadata");
-        assert_eq!(partial.types.as_ref().unwrap().api_version, "meta.k8s.io/v1");
-        // resource impl follows the underlying type
+        // can use generic type for static dispatch;
         assert_eq!(PartialObjectMeta::<Pod>::kind(&()), "Pod");
         assert_eq!(PartialObjectMeta::<Pod>::api_version(&()), "v1");
+
+        // can convert from objectmeta to partials for different use cases:
+        let meta = ObjectMeta {
+            name: Some("mypod".into()),
+            ..Default::default()
+        };
+        let request_pom = meta.clone().into_request_partial::<Pod>();
+        let response_pom = meta.into_response_partial::<Pod>();
+
+        // they both basically just inline the metadata;
+        assert_eq!(request_pom.metadata.name, Some("mypod".to_string()));
+        assert_eq!(response_pom.metadata.name, Some("mypod".to_string()));
+
+        // the request_pom will use the TypeMeta from K to support POST/PUT requests
+        assert_eq!(request_pom.types.as_ref().unwrap().api_version, "v1");
+        assert_eq!(request_pom.types.as_ref().unwrap().kind, "Pod");
+
+        // but the response_pom will use the type-erased kinds from the apiserver
+        assert_eq!(response_pom.types.as_ref().unwrap().api_version, "meta.k8s.io/v1");
+        assert_eq!(response_pom.types.as_ref().unwrap().kind, "PartialObjectMetadata");
     }
 }

--- a/kube-core/src/metadata.rs
+++ b/kube-core/src/metadata.rs
@@ -54,19 +54,15 @@ pub trait PartialObjectMetaExt: private::Sealed {
     /// because it contains erased `TypeMeta` (and the apiserver is doing the erasing).
     ///
     /// This method is useful when unit testing local behaviour.
-    fn into_response_partial<K: Resource>(self) -> PartialObjectMeta<K>;
+    fn into_response_partial<K>(self) -> PartialObjectMeta<K>;
 }
 
 impl PartialObjectMetaExt for ObjectMeta {
-    fn into_request_partial<K: Resource<DynamicType = ()>>(self) -> PartialObjectMeta<K>
-    where
-        K::DynamicType: Default,
-    {
-        let dyntype: K::DynamicType = Default::default();
+    fn into_request_partial<K: Resource<DynamicType = ()>>(self) -> PartialObjectMeta<K> {
         PartialObjectMeta {
             types: Some(TypeMeta {
-                api_version: K::api_version(&dyntype).into(),
-                kind: K::kind(&dyntype).into(),
+                api_version: K::api_version(&()).into(),
+                kind: K::kind(&()).into(),
             }),
             metadata: self,
             _phantom: PhantomData,

--- a/kube-core/src/metadata.rs
+++ b/kube-core/src/metadata.rs
@@ -98,6 +98,7 @@ mod test {
             ..Default::default()
         }
         .into();
+        assert_eq!(partial.metadata.name, Some("mypod".to_string()));
         // created type uses verbatim serialization
         assert_eq!(partial.types.as_ref().unwrap().kind, "PartialObjectMetadata");
         assert_eq!(partial.types.as_ref().unwrap().api_version, "meta.k8s.io/v1");

--- a/kube-core/src/metadata.rs
+++ b/kube-core/src/metadata.rs
@@ -32,7 +32,7 @@ pub struct PartialObjectMeta<K> {
     pub metadata: ObjectMeta,
     /// Type information for static dispatch
     #[serde(skip, default)]
-    pub _phantom: std::marker::PhantomData<K>
+    pub _phantom: std::marker::PhantomData<K>,
 }
 
 impl<K> From<PartialObjectMeta<K>> for ObjectMeta {

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -16,6 +16,8 @@
 #![allow(clippy::type_repetition_in_bounds)]
 // Triggered by Tokio macros
 #![allow(clippy::semicolon_if_nothing_returned)]
+// Triggered by nightly clippy on idiomatic code
+#![allow(clippy::let_underscore_untyped)]
 
 pub mod controller;
 pub mod events;

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -185,7 +185,7 @@ impl<K> ApiMode for MetaOnly<'_, K>
 where
     K: Clone + Debug + DeserializeOwned + Send + 'static,
 {
-    type Value = PartialObjectMeta;
+    type Value = PartialObjectMeta<K>;
 
     async fn list(&self, lp: &ListParams) -> kube_client::Result<ObjectList<Self::Value>> {
         self.api.list_metadata(lp).await
@@ -439,7 +439,7 @@ pub fn watcher<K: Resource + Clone + DeserializeOwned + Debug + Send + 'static>(
 pub fn metadata_watcher<K: Resource + Clone + DeserializeOwned + Debug + Send + 'static>(
     api: Api<K>,
     list_params: ListParams,
-) -> impl Stream<Item = Result<Event<PartialObjectMeta>>> + Send {
+) -> impl Stream<Item = Result<Event<PartialObjectMeta<K>>>> + Send {
     futures::stream::unfold(
         (api, list_params, State::Empty),
         |(api, list_params, state)| async {


### PR DESCRIPTION
Allows doing static dispatch using the root type, and avoids having to do stringly typed oob signalling in generic code.

Fixes #1151, in particular:

- Adds a serde skipped + defaulted `PhantomType<K>` to `PartialObjectMeta`
- Fixes broken `Resource` impl for `PartialObjectMeta` by instead proxying to `K: Resource`
- I.e.  all usage of `PartialObjectMeta` has changed to `PartialObjectMeta<K>`
- Still works dynamically via `PartialObjectMeta<DynamicObject>` (which it is inferred to in `dynamic_watcher`)
- Fixes up extension names in metadata api in core_methods used for tracing
- Adds a converter trait `PartialObjectMetaExt` from `ObjectMeta` into `PartialObjectMeta<K>`

Example generic code:

```rust
pub async fn reconcile<K>(obj: Arc<PartialObjectMeta<K>>, ctx: Arc<Context>) -> Result<Action>
where
    K: Resource<Scope = NamespaceResourceScope, DynamicType = ()>
        + Clone
        + DeserializeOwned
        + Debug,
{
    let kind = K::kind(&()).to_string();
    let api: Api<PartialObjectMeta<K>> = Api::default_namespaced(ctx.client.clone());
```

This now gives us a way to get type info in generic code without extra `ApiResource` args and lambdas, while also maintaining all the static type safety we have around scopes.