### PR TITLE
Implement ephemeral containers subresource

### DIFF
--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -14,6 +14,11 @@ mod subresource;
 pub use subresource::{Attach, AttachParams, Execute, Portforward};
 pub use subresource::{Evict, EvictParams, Log, LogParams, ScaleSpec, ScaleStatus};
 
+// Ephemeral containers were stabilized in Kubernetes 1.25.
+k8s_openapi::k8s_if_ge_1_25! {
+    pub use subresource::Ephemeral;
+}
+
 mod util;
 
 pub mod entry;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Implement support for another sub resource, as described in #127.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Support for the ephemeral containers subresource is implemented using a marker `trait` `Ephemeral`, which is implemented for the `Pod` struct. Three methods are implemented for `Api<K>` where `K` is bounded with the `Ephemeral` trait, `replace_ephemeral_containers`, `patch_ephemeral_containers` and `get_ephemeral_containers`. These methods correlate with the operations described in the [Kubernetes API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/), see the section on EphemeralContainers Operations.

### Questions

I have a few questions before this should be merged.

1. I noticed that the patch operation did not return errors for invalid patches. Is that expected behavior when patching a resource? See this [comment](https://github.com/kube-rs/kube/issues/127#issuecomment-1371162352) for examples.
2. This functionality was stabilized in K8S 1.25, so we need to guard this functionality.  A guard was mentioned [here](https://github.com/kube-rs/kube/issues/127#issuecomment-1297418940) but I am not sure how to apply it in this case. Are there other examples in kubers of guarding features based on K8S versions to use as inspiration?
3. I tried to follow the existing structure for sub resources hence the marker trait, but I am unsure if it makes sense in this case. Since ephemeral containers are only relevant for Pods. Do you think the marker trait makes sense here?
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
