### PR TITLE
Split ListParams and WatchParams

### DIFF
--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -5,8 +5,11 @@ use anyhow::Result;
 use futures::StreamExt;
 use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
-    api::{Api, ListParams, ObjectMeta, Patch, PatchParams, Resource},
-    runtime::controller::{Action, Controller},
+    api::{Api, ObjectMeta, Patch, PatchParams, Resource},
+    runtime::{
+        controller::{Action, Controller},
+        watcher,
+    },
     Client, CustomResource,
 };
 use schemars::JsonSchema;
@@ -99,8 +102,8 @@ async fn main() -> Result<()> {
         }
     });
 
-    Controller::new(cmgs, ListParams::default())
-        .owns(cms, ListParams::default())
+    Controller::new(cmgs, watcher::Config::default())
+        .owns(cms, watcher::Config::default())
         .reconcile_all_on(reload_rx.map(|_| ()))
         .shutdown_on_signal()
         .run(reconcile, error_policy, Arc::new(Data { client }))

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -127,27 +127,24 @@ async fn main() -> Result<()> {
     // Nullables defaults to `None` and only sent if it's not configured to skip.
     let bar = Foo::new("bar", FooSpec { ..FooSpec::default() });
     let bar = foos.create(&PostParams::default(), &bar).await?;
-    assert_eq!(
-        bar.spec,
-        FooSpec {
-            // Nonnullable without default is required.
-            non_nullable: String::default(),
-            // Defaulting didn't happen because an empty string was sent.
-            non_nullable_with_default: String::default(),
-            // `nullable_skipped` field does not exist in the object (see below).
-            nullable_skipped: None,
-            // `nullable` field exists in the object (see below).
-            nullable: None,
-            // Defaulting happened because serialization was skipped.
-            nullable_skipped_with_default: default_nullable(),
-            // Defaulting did not happen because `null` was sent.
-            // Deserialization does not apply the default either.
-            nullable_with_default: None,
-            // Empty listables to be patched in later
-            default_listable: Default::default(),
-            set_listable: Default::default(),
-        }
-    );
+    assert_eq!(bar.spec, FooSpec {
+        // Nonnullable without default is required.
+        non_nullable: String::default(),
+        // Defaulting didn't happen because an empty string was sent.
+        non_nullable_with_default: String::default(),
+        // `nullable_skipped` field does not exist in the object (see below).
+        nullable_skipped: None,
+        // `nullable` field exists in the object (see below).
+        nullable: None,
+        // Defaulting happened because serialization was skipped.
+        nullable_skipped_with_default: default_nullable(),
+        // Defaulting did not happen because `null` was sent.
+        // Deserialization does not apply the default either.
+        nullable_with_default: None,
+        // Empty listables to be patched in later
+        default_listable: Default::default(),
+        set_listable: Default::default(),
+    });
 
     // Set up dynamic resource to test using raw values.
     let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo");

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -3,7 +3,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomRe
 use tracing::*;
 
 use kube::{
-    api::{Api, ListParams, Patch, PatchParams, ResourceExt},
+    api::{Api, Patch, PatchParams, ResourceExt},
     runtime::{reflector, watcher, WatchStreamExt},
     Client, CustomResource, CustomResourceExt,
 };
@@ -36,8 +36,8 @@ async fn main() -> anyhow::Result<()> {
     let (reader, writer) = reflector::store::<Foo>();
 
     let foos: Api<Foo> = Api::default_namespaced(client);
-    let lp = ListParams::default().timeout(20); // low timeout in this example
-    let rf = reflector(writer, watcher(foos, lp));
+    let wc = watcher::Config::default().timeout(20); // low timeout in this example
+    let rf = reflector(writer, watcher(foos, wc));
 
     tokio::spawn(async move {
         loop {

--- a/examples/dynamic_watcher.rs
+++ b/examples/dynamic_watcher.rs
@@ -1,6 +1,6 @@
 use futures::{Stream, StreamExt, TryStreamExt};
 use kube::{
-    api::{Api, DynamicObject, GroupVersionKind, ListParams, Resource, ResourceExt},
+    api::{Api, DynamicObject, GroupVersionKind, Resource, ResourceExt},
     runtime::{metadata_watcher, watcher, watcher::Event, WatchStreamExt},
 };
 use serde::de::DeserializeOwned;
@@ -28,13 +28,13 @@ async fn main() -> anyhow::Result<()> {
 
     // Use the full resource info to create an Api with the ApiResource as its DynamicType
     let api = Api::<DynamicObject>::all_with(client, &ar);
-    let lp = ListParams::default();
+    let wc = watcher::Config::default();
 
     // Start a metadata or a full resource watch
     if watch_metadata {
-        handle_events(metadata_watcher(api, lp)).await
+        handle_events(metadata_watcher(api, wc)).await
     } else {
-        handle_events(watcher(api, lp)).await
+        handle_events(watcher(api, wc)).await
     }
 }
 

--- a/examples/event_watcher.rs
+++ b/examples/event_watcher.rs
@@ -1,7 +1,7 @@
 use futures::{pin_mut, TryStreamExt};
 use k8s_openapi::api::core::v1::Event;
 use kube::{
-    api::{Api, ListParams},
+    api::Api,
     runtime::{watcher, WatchStreamExt},
     Client,
 };
@@ -13,9 +13,9 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
 
     let events: Api<Event> = Api::all(client);
-    let lp = ListParams::default();
+    let wc = watcher::Config::default();
 
-    let ew = watcher(events, lp).applied_objects();
+    let ew = watcher(events, wc).applied_objects();
 
     pin_mut!(ew);
     while let Some(event) = ew.try_next().await? {

--- a/examples/multi_watcher.rs
+++ b/examples/multi_watcher.rs
@@ -4,7 +4,7 @@ use k8s_openapi::api::{
     core::v1::{ConfigMap, Secret},
 };
 use kube::{
-    api::{Api, ListParams, ResourceExt},
+    api::{Api, ResourceExt},
     runtime::{watcher, WatchStreamExt},
     Client,
 };
@@ -18,9 +18,9 @@ async fn main() -> anyhow::Result<()> {
     let deploys: Api<Deployment> = Api::default_namespaced(client.clone());
     let cms: Api<ConfigMap> = Api::default_namespaced(client.clone());
     let secret: Api<Secret> = Api::default_namespaced(client.clone());
-    let dep_watcher = watcher(deploys, ListParams::default());
-    let cm_watcher = watcher(cms, ListParams::default());
-    let sec_watcher = watcher(secret, ListParams::default());
+    let dep_watcher = watcher(deploys, watcher::Config::default());
+    let cm_watcher = watcher(cms, watcher::Config::default());
+    let sec_watcher = watcher(secret, watcher::Config::default());
 
     // select on applied events from all watchers
     let mut combo_stream = stream::select_all(vec![

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -1,7 +1,7 @@
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Node;
 use kube::{
-    api::{Api, ListParams, ResourceExt},
+    api::{Api, ResourceExt},
     runtime::{reflector, watcher, WatchStreamExt},
     Client,
 };
@@ -13,12 +13,12 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
 
     let nodes: Api<Node> = Api::all(client.clone());
-    let lp = ListParams::default()
+    let wc = watcher::Config::default()
         .labels("kubernetes.io/arch=amd64") // filter instances by label
         .timeout(10); // short watch timeout in this example
 
     let (reader, writer) = reflector::store();
-    let rf = reflector(writer, watcher(nodes, lp));
+    let rf = reflector(writer, watcher(nodes, wc));
 
     // Periodically read our state in the background
     tokio::spawn(async move {

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -15,8 +15,8 @@ async fn main() -> anyhow::Result<()> {
     let events: Api<Event> = Api::all(client.clone());
     let nodes: Api<Node> = Api::all(client.clone());
 
-    let lp = ListParams::default().labels("beta.kubernetes.io/arch=amd64");
-    let obs = watcher(nodes, lp)
+    let wc = watcher::Config::default().labels("beta.kubernetes.io/arch=amd64");
+    let obs = watcher(nodes, wc)
         .backoff(ExponentialBackoff::default())
         .applied_objects();
 

--- a/examples/pod_attach.rs
+++ b/examples/pod_attach.rs
@@ -6,7 +6,7 @@ use k8s_openapi::api::core::v1::Pod;
 
 use kube::{
     api::{
-        Api, AttachParams, AttachedProcess, DeleteParams, ListParams, PostParams, ResourceExt, WatchEvent,
+        Api, AttachParams, AttachedProcess, DeleteParams, PostParams, ResourceExt, WatchEvent, WatchParams,
     },
     Client,
 };
@@ -35,8 +35,8 @@ async fn main() -> anyhow::Result<()> {
     pods.create(&PostParams::default(), &p).await?;
 
     // Wait until the pod is running, otherwise we get 500 error.
-    let lp = ListParams::default().fields("metadata.name=example").timeout(10);
-    let mut stream = pods.watch(&lp, "0").await?.boxed();
+    let wp = WatchParams::default().fields("metadata.name=example").timeout(10);
+    let mut stream = pods.watch(&wp, "0").await?.boxed();
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {

--- a/examples/pod_cp.rs
+++ b/examples/pod_cp.rs
@@ -3,7 +3,7 @@ use k8s_openapi::api::core::v1::Pod;
 use tracing::*;
 
 use kube::{
-    api::{Api, AttachParams, DeleteParams, ListParams, PostParams, ResourceExt, WatchEvent},
+    api::{Api, AttachParams, DeleteParams, PostParams, ResourceExt, WatchEvent, WatchParams},
     Client,
 };
 use tokio::io::AsyncWriteExt;
@@ -34,8 +34,8 @@ async fn main() -> anyhow::Result<()> {
     pods.create(&PostParams::default(), &p).await?;
 
     // Wait until the pod is running, otherwise we get 500 error.
-    let lp = ListParams::default().fields("metadata.name=example").timeout(10);
-    let mut stream = pods.watch(&lp, "0").await?.boxed();
+    let wp = WatchParams::default().fields("metadata.name=example").timeout(10);
+    let mut stream = pods.watch(&wp, "0").await?.boxed();
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {

--- a/examples/pod_evict.rs
+++ b/examples/pod_evict.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 use tracing::*;
 
 use kube::{
-    api::{Api, EvictParams, ListParams, PostParams, ResourceExt, WatchEvent},
+    api::{Api, EvictParams, PostParams, ResourceExt, WatchEvent, WatchParams},
     Client,
 };
 
@@ -35,10 +35,10 @@ async fn main() -> anyhow::Result<()> {
     pods.create(&pp, &empty_pod).await?;
 
     // Wait until the pod is running, although it's not necessary
-    let lp = ListParams::default()
+    let wp = WatchParams::default()
         .fields("metadata.name=empty-pod")
         .timeout(10);
-    let mut stream = pods.watch(&lp, "0").await?.boxed();
+    let mut stream = pods.watch(&wp, "0").await?.boxed();
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {

--- a/examples/pod_exec.rs
+++ b/examples/pod_exec.rs
@@ -4,7 +4,7 @@ use tracing::*;
 
 use kube::{
     api::{
-        Api, AttachParams, AttachedProcess, DeleteParams, ListParams, PostParams, ResourceExt, WatchEvent,
+        Api, AttachParams, AttachedProcess, DeleteParams, PostParams, ResourceExt, WatchEvent, WatchParams,
     },
     Client,
 };
@@ -34,8 +34,8 @@ async fn main() -> anyhow::Result<()> {
     pods.create(&PostParams::default(), &p).await?;
 
     // Wait until the pod is running, otherwise we get 500 error.
-    let lp = ListParams::default().fields("metadata.name=example").timeout(10);
-    let mut stream = pods.watch(&lp, "0").await?.boxed();
+    let wp = WatchParams::default().fields("metadata.name=example").timeout(10);
+    let mut stream = pods.watch(&wp, "0").await?.boxed();
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {

--- a/examples/pod_reflector.rs
+++ b/examples/pod_reflector.rs
@@ -1,7 +1,7 @@
 use futures::TryStreamExt;
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
-    api::{Api, ListParams},
+    api::Api,
     runtime::{reflector, watcher, WatchStreamExt},
     Client, ResourceExt,
 };
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
-    let stream = watcher(api, ListParams::default()).map_ok(|ev| {
+    let stream = watcher(api, watcher::Config::default()).map_ok(|ev| {
         ev.modify(|pod| {
             // memory optimization for our store - we don't care about fields/annotations/status
             pod.managed_fields_mut().clear();

--- a/examples/pod_shell.rs
+++ b/examples/pod_shell.rs
@@ -3,7 +3,7 @@ use k8s_openapi::api::core::v1::Pod;
 use tracing::*;
 
 use kube::{
-    api::{Api, AttachParams, DeleteParams, ListParams, PostParams, ResourceExt, WatchEvent},
+    api::{Api, AttachParams, DeleteParams, PostParams, ResourceExt, WatchEvent, WatchParams},
     Client,
 };
 
@@ -31,8 +31,8 @@ async fn main() -> anyhow::Result<()> {
     pods.create(&PostParams::default(), &p).await?;
 
     // Wait until the pod is running, otherwise we get 500 error.
-    let lp = ListParams::default().fields("metadata.name=example").timeout(10);
-    let mut stream = pods.watch(&lp, "0").await?.boxed();
+    let wp = WatchParams::default().fields("metadata.name=example").timeout(10);
+    let mut stream = pods.watch(&wp, "0").await?.boxed();
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {

--- a/examples/pod_watcher.rs
+++ b/examples/pod_watcher.rs
@@ -1,7 +1,7 @@
 use futures::prelude::*;
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
-    api::{Api, ListParams, ResourceExt},
+    api::{Api, ResourceExt},
     runtime::{watcher, WatchStreamExt},
     Client,
 };
@@ -13,7 +13,7 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
     let api = Api::<Pod>::default_namespaced(client);
 
-    watcher(api, ListParams::default())
+    watcher(api, watcher::Config::default())
         .applied_objects()
         .try_for_each(|p| async move {
             info!("saw {}", p.name_any());

--- a/examples/secret_reflector.rs
+++ b/examples/secret_reflector.rs
@@ -1,7 +1,7 @@
 use futures::TryStreamExt;
 use k8s_openapi::api::core::v1::Secret;
 use kube::{
-    api::{Api, ListParams, ResourceExt},
+    api::{Api, ResourceExt},
     runtime::{reflector, reflector::Store, watcher, WatchStreamExt},
     Client,
 };
@@ -53,10 +53,10 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
 
     let secrets: Api<Secret> = Api::default_namespaced(client);
-    let lp = ListParams::default().timeout(10); // short watch timeout in this example
+    let wc = watcher::Config::default().timeout(10); // short watch timeout in this example
 
     let (reader, writer) = reflector::store::<Secret>();
-    let rf = reflector(writer, watcher(secrets, lp));
+    let rf = reflector(writer, watcher(secrets, wc));
 
     spawn_periodic_reader(reader); // read from a reader in the background
 

--- a/examples/secret_syncer.rs
+++ b/examples/secret_syncer.rs
@@ -6,11 +6,12 @@
 use futures::StreamExt;
 use k8s_openapi::api::core::v1::{ConfigMap, Secret};
 use kube::{
-    api::{Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, Resource},
+    api::{Api, DeleteParams, ObjectMeta, Patch, PatchParams, Resource},
     error::ErrorResponse,
     runtime::{
         controller::{Action, Controller},
         finalizer::{finalizer, Event},
+        watcher,
     },
 };
 use std::{sync::Arc, time::Duration};
@@ -78,7 +79,7 @@ async fn main() -> anyhow::Result<()> {
     let client = kube::Client::try_default().await?;
     Controller::new(
         Api::<ConfigMap>::all(client.clone()),
-        ListParams::default().labels("configmap-secret-syncer.nullable.se/sync=true"),
+        watcher::Config::default().labels("configmap-secret-syncer.nullable.se/sync=true"),
     )
     .run(
         |cm, _| {

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -423,20 +423,20 @@ where
     /// then you can stream the remaining buffered `WatchEvent` objects.
     ///
     /// Note that a `watch` call can terminate for many reasons (even before the specified
-    /// [`ListParams::timeout`] is triggered), and will have to be re-issued
+    /// [`WatchParams::timeout`] is triggered), and will have to be re-issued
     /// with the last seen resource version when or if it closes.
     ///
     /// Consider using a managed [`watcher`] to deal with automatic re-watches and error cases.
     ///
     /// ```no_run
-    /// use kube::api::{Api, ListParams, ResourceExt, WatchEvent};
+    /// use kube::api::{Api, WatchParams, ResourceExt, WatchEvent};
     /// use k8s_openapi::api::batch::v1::Job;
     /// use futures::{StreamExt, TryStreamExt};
     ///
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
     /// let jobs: Api<Job> = Api::namespaced(client, "apps");
-    /// let lp = ListParams::default()
+    /// let lp = WatchParams::default()
     ///     .fields("metadata.name=my_job")
     ///     .timeout(20); // upper bound of how long we watch for
     /// let mut stream = jobs.watch(&lp, "0").await?.boxed();
@@ -452,14 +452,14 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    /// [`ListParams::timeout`]: super::ListParams::timeout
+    /// [`WatchParams::timeout`]: super::WatchParams::timeout
     /// [`watcher`]: https://docs.rs/kube_runtime/*/kube_runtime/watcher/fn.watcher.html
     pub async fn watch(
         &self,
-        lp: &ListParams,
+        wp: &WatchParams,
         version: &str,
     ) -> Result<impl Stream<Item = Result<WatchEvent<K>>>> {
-        let mut req = self.request.watch(lp, version).map_err(Error::BuildRequest)?;
+        let mut req = self.request.watch(wp, version).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("watch");
         self.client.request_events::<K>(req).await
     }
@@ -470,14 +470,14 @@ where
     /// then you can stream the remaining buffered `WatchEvent` objects.
     ///
     /// Note that a `watch_metadata` call can terminate for many reasons (even
-    /// before the specified [`ListParams::timeout`] is triggered), and will
+    /// before the specified [`WatchParams::timeout`] is triggered), and will
     /// have to be re-issued with the last seen resource version when or if it
     /// closes.
     ///
     /// Consider using a managed [`metadata_watcher`] to deal with automatic re-watches and error cases.
     ///
     /// ```no_run
-    /// use kube::api::{Api, ListParams, ResourceExt, WatchEvent};
+    /// use kube::api::{Api, WatchParams, ResourceExt, WatchEvent};
     /// use k8s_openapi::api::batch::v1::Job;
     /// use futures::{StreamExt, TryStreamExt};
     ///
@@ -485,7 +485,7 @@ where
     /// # let client: kube::Client = todo!();
     /// let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///
-    /// let lp = ListParams::default()
+    /// let lp = WatchParams::default()
     ///     .fields("metadata.name=my_job")
     ///     .timeout(20); // upper bound of how long we watch for
     /// let mut stream = jobs.watch(&lp, "0").await?.boxed();
@@ -501,16 +501,16 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    /// [`ListParams::timeout`]: super::ListParams::timeout
+    /// [`WatchParams::timeout`]: super::WatchParams::timeout
     /// [`metadata_watcher`]: https://docs.rs/kube_runtime/*/kube_runtime/watcher/fn.metadata_watcher.html
     pub async fn watch_metadata(
         &self,
-        lp: &ListParams,
+        wp: &WatchParams,
         version: &str,
     ) -> Result<impl Stream<Item = Result<WatchEvent<PartialObjectMeta<K>>>>> {
         let mut req = self
             .request
-            .watch_metadata(lp, version)
+            .watch_metadata(wp, version)
             .map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("watch_metadata");
         self.client.request_events::<PartialObjectMeta<K>>(req).await

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -35,7 +35,7 @@ pub use kube_core::{
 use kube_core::{DynamicResourceScope, NamespaceResourceScope};
 pub use params::{
     DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions, PropagationPolicy,
-    ResourceVersionMatch, ValidationDirective, WatchParams,
+    ValidationDirective, VersionMatch, WatchParams,
 };
 
 use crate::Client;

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -1,13 +1,16 @@
 //! API helpers for structured interaction with the Kubernetes API
 
-
 mod core_methods;
-#[cfg(feature = "ws")] mod remote_command;
+#[cfg(feature = "ws")]
+mod remote_command;
 use std::fmt::Debug;
 
-#[cfg(feature = "ws")] pub use remote_command::{AttachedProcess, TerminalSize};
-#[cfg(feature = "ws")] mod portforward;
-#[cfg(feature = "ws")] pub use portforward::Portforwarder;
+#[cfg(feature = "ws")]
+pub use remote_command::{AttachedProcess, TerminalSize};
+#[cfg(feature = "ws")]
+mod portforward;
+#[cfg(feature = "ws")]
+pub use portforward::Portforwarder;
 
 mod subresource;
 #[cfg(feature = "ws")]
@@ -36,7 +39,7 @@ pub use kube_core::{
 use kube_core::{DynamicResourceScope, NamespaceResourceScope};
 pub use params::{
     DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions, PropagationPolicy,
-    ValidationDirective,
+    ResourceVersionMatch, ValidationDirective, WatchParams,
 };
 
 use crate::Client;
@@ -118,7 +121,6 @@ impl<K: Resource> Api<K> {
         &self.request.url_path
     }
 }
-
 
 /// Api constructors for Resource implementors with Default DynamicTypes
 ///

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -1,16 +1,12 @@
 //! API helpers for structured interaction with the Kubernetes API
 
 mod core_methods;
-#[cfg(feature = "ws")]
-mod remote_command;
+#[cfg(feature = "ws")] mod remote_command;
 use std::fmt::Debug;
 
-#[cfg(feature = "ws")]
-pub use remote_command::{AttachedProcess, TerminalSize};
-#[cfg(feature = "ws")]
-mod portforward;
-#[cfg(feature = "ws")]
-pub use portforward::Portforwarder;
+#[cfg(feature = "ws")] pub use remote_command::{AttachedProcess, TerminalSize};
+#[cfg(feature = "ws")] mod portforward;
+#[cfg(feature = "ws")] pub use portforward::Portforwarder;
 
 mod subresource;
 #[cfg(feature = "ws")]

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -139,7 +139,7 @@ mod test {
     use futures::{StreamExt, TryStreamExt};
     use k8s_openapi::api::core::v1::Pod;
     use kube_core::{
-        params::{DeleteParams, Patch},
+        params::{DeleteParams, Patch, WatchParams},
         response::StatusSummary,
     };
     use serde_json::json;
@@ -227,10 +227,10 @@ mod test {
 
         // Manual watch-api for it to become ready
         // NB: don't do this; using conditions (see pod_api example) is easier and less error prone
-        let lp = ListParams::default()
+        let wp = WatchParams::default()
             .fields(&format!("metadata.name={}", "busybox-kube1"))
             .timeout(15);
-        let mut stream = pods.watch(&lp, "0").await?.boxed();
+        let mut stream = pods.watch(&wp, "0").await?.boxed();
         while let Some(ev) = stream.try_next().await? {
             // can debug format watch event
             let _ = format!("we: {ev:?}");
@@ -307,10 +307,10 @@ mod test {
 
         // Manual watch-api for it to become ready
         // NB: don't do this; using conditions (see pod_api example) is easier and less error prone
-        let lp = ListParams::default()
+        let wp = WatchParams::default()
             .fields(&format!("metadata.name={}", "busybox-kube2"))
             .timeout(15);
-        let mut stream = pods.watch(&lp, "0").await?.boxed();
+        let mut stream = pods.watch(&wp, "0").await?.boxed();
         while let Some(ev) = stream.try_next().await? {
             match ev {
                 WatchEvent::Modified(o) => {
@@ -421,10 +421,10 @@ mod test {
 
         // Manual watch-api for it to become ready
         // NB: don't do this; using conditions (see pod_api example) is easier and less error prone
-        let lp = ListParams::default()
+        let wp = WatchParams::default()
             .fields(&format!("metadata.name={}", "busybox-kube3"))
             .timeout(15);
-        let mut stream = pods.watch(&lp, "0").await?.boxed();
+        let mut stream = pods.watch(&wp, "0").await?.boxed();
         while let Some(ev) = stream.try_next().await? {
             match ev {
                 WatchEvent::Modified(o) => {

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -31,7 +31,7 @@ impl fmt::Display for VersionMatch {
 }
 
 /// Common query parameters used in list/delete calls on collections
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ListParams {
     /// A selector to restrict the list of returned objects by their labels.
     ///
@@ -64,20 +64,6 @@ pub struct ListParams {
     /// See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
     /// details.
     pub version_match: VersionMatch,
-}
-
-impl Default for ListParams {
-    /// Default `ListParams` without any constricting selectors
-    fn default() -> Self {
-        Self {
-            label_selector: None,
-            field_selector: None,
-            timeout: None,
-            limit: None,
-            continue_token: None,
-            version_match: VersionMatch::default(),
-        }
-    }
 }
 
 impl ListParams {

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -1,6 +1,29 @@
 //! A port of request parameter *Optionals from apimachinery/types.go
+use std::fmt;
+
 use crate::request::Error;
 use serde::Serialize;
+
+/// Specifies how the resourceVersion parameter is applied. resourceVersionMatch may only be set if resourceVersion is also set.
+/// "NotOlderThan" matches data at least as new as the provided resourceVersion. "Exact" matches data at the exact resourceVersion provided.
+///
+/// See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.
+#[derive(Clone, Debug)]
+pub enum ResourceVersionMatch {
+    /// Matches data at least as new as the provided resourceVersion.
+    NotOlderThan,
+    /// Matches data at the exact resourceVersion provided.
+    Exact,
+}
+
+impl fmt::Display for ResourceVersionMatch {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ResourceVersionMatch::NotOlderThan => write!(f, "NotOlderThan"),
+            ResourceVersionMatch::Exact => write!(f, "Exact"),
+        }
+    }
+}
 
 /// Common query parameters used in watch/list/delete calls on collections
 #[derive(Clone, Debug)]
@@ -44,6 +67,18 @@ pub struct ListParams {
     ///
     /// After listing results with a limit, a continue token can be used to fetch another page of results.
     pub continue_token: Option<String>,
+
+	/// Sets a constraint on what resource versions a request may be served from.
+	/// See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+	/// details.
+    pub resource_version: Option<String>,
+
+    /// Determines how resourceVersion is applied to list calls.
+	/// It is highly recommended that resourceVersionMatch be set for list calls where
+	/// resourceVersion is set
+	/// See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+	/// details.
+	pub resource_version_match: Option<ResourceVersionMatch>,
 }
 
 impl Default for ListParams {
@@ -58,6 +93,8 @@ impl Default for ListParams {
             timeout: None,
             limit: None,
             continue_token: None,
+            resource_version: None,
+            resource_version_match: None,
         }
     }
 }
@@ -136,6 +173,20 @@ impl ListParams {
     #[must_use]
     pub fn continue_token(mut self, token: &str) -> Self {
         self.continue_token = Some(token.to_string());
+        self
+    }
+
+    /// Sets a resource version.
+    #[must_use]
+    pub fn resource_version(mut self, version: &str) -> Self {
+        self.resource_version = Some(version.to_string());
+        self
+    }
+
+    /// Sets a continue token.
+    #[must_use]
+    pub fn resource_version_match(mut self, version_match: ResourceVersionMatch) -> Self {
+        self.resource_version_match = Some(version_match);
         self
     }
 }

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 /// "NotOlderThan" matches data at least as new as the provided resourceVersion. "Exact" matches data at the exact resourceVersion provided.
 ///
 /// See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ResourceVersionMatch {
     /// Matches data at least as new as the provided resourceVersion.
     NotOlderThan,

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -68,17 +68,17 @@ pub struct ListParams {
     /// After listing results with a limit, a continue token can be used to fetch another page of results.
     pub continue_token: Option<String>,
 
-	/// Sets a constraint on what resource versions a request may be served from.
-	/// See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
-	/// details.
+    /// Sets a constraint on what resource versions a request may be served from.
+    /// See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+    /// details.
     pub resource_version: Option<String>,
 
     /// Determines how resourceVersion is applied to list calls.
-	/// It is highly recommended that resourceVersionMatch be set for list calls where
-	/// resourceVersion is set
-	/// See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
-	/// details.
-	pub resource_version_match: Option<ResourceVersionMatch>,
+    /// It is highly recommended that resourceVersionMatch be set for list calls where
+    /// resourceVersion is set
+    /// See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+    /// details.
+    pub resource_version_match: Option<ResourceVersionMatch>,
 }
 
 impl Default for ListParams {

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -550,7 +550,7 @@ mod test {
         assert_eq!(
             req.uri(),
             "/api/v1/namespaces/ns/pods?&watch=true&resourceVersion=0&timeoutSeconds=290"
-            );
+        );
         assert_eq!(
             req.headers().get(http::header::CONTENT_TYPE).unwrap(),
             super::JSON_MIME

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -770,4 +770,27 @@ mod test {
         assert!(format!("{err}")
             .contains("resource_version cannot be equal to \"0\" if the resource_version_match is Exact"));
     }
+
+
+    #[test]
+    fn watch_params() {
+        let url = corev1::Pod::url_path(&(), Some("ns"));
+        let wp = WatchParams::default()
+            .disable_bookmarks()
+            .fields("metadata.name=pod=1")
+            .labels("app=web");
+        let req = Request::new(url).watch(&wp, "").unwrap();
+        assert_eq!(
+            req.uri(),
+            "/api/v1/namespaces/ns/pods?&watch=true&resourceVersion=&timeoutSeconds=290&fieldSelector=metadata.name%3Dpod%3D1&labelSelector=app%3Dweb"
+        );
+    }
+
+    #[test]
+    fn watch_timeout_error() {
+        let url = corev1::Pod::url_path(&(), Some("ns"));
+        let wp = WatchParams::default().timeout(100000);
+        let err = Request::new(url).watch(&wp, "").unwrap_err();
+        assert!(format!("{err}").contains("timeout must be < 295s"));
+    }
 }

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -764,8 +764,19 @@ mod test {
         let gp = ListParams::default().version_match(VersionMatch::Any);
         let req = Request::new(url).list(&gp).unwrap();
         assert_eq!(
-            req.uri(),
-            "/api/v1/namespaces/ns/pods?&resourceVersion=0&resourceVersionMatch=NotOlderThan"
+            req.uri().query().unwrap(),
+            "&resourceVersion=0&resourceVersionMatch=NotOlderThan"
+        );
+    }
+
+    #[test]
+    fn list_most_recent_pods() {
+        let url = corev1::Pod::url_path(&(), Some("ns"));
+        let gp = ListParams::default().version_match(VersionMatch::MostRecent);
+        let req = Request::new(url).list(&gp).unwrap();
+        assert_eq!(
+            req.uri().query().unwrap(),
+            "" // No options are required
         );
     }
 
@@ -778,14 +789,26 @@ mod test {
             .contains("version_match cannot be equal to \"0\" for Exact and NotOlderThan variants"));
     }
 
+
+    #[test]
+    fn list_not_older() {
+        let url = corev1::Pod::url_path(&(), Some("ns"));
+        let gp = ListParams::default().version_match(VersionMatch::NotOlderThan("20".to_string()));
+        let req = Request::new(url).list(&gp).unwrap();
+        assert_eq!(
+            req.uri().query().unwrap(),
+            "&resourceVersion=20&resourceVersionMatch=NotOlderThan"
+        );
+    }
+
     #[test]
     fn list_exact_match() {
         let url = corev1::Pod::url_path(&(), Some("ns"));
         let gp = ListParams::default().version_match(VersionMatch::Exact("500".to_string()));
         let req = Request::new(url).list(&gp).unwrap();
         assert_eq!(
-            req.uri(),
-            "/api/v1/namespaces/ns/pods?&resourceVersion=500&resourceVersionMatch=Exact"
+            req.uri().query().unwrap(),
+            "&resourceVersion=500&resourceVersionMatch=Exact"
         );
     }
 
@@ -798,8 +821,8 @@ mod test {
             .labels("app=web");
         let req = Request::new(url).watch(&wp, "").unwrap();
         assert_eq!(
-            req.uri(),
-            "/api/v1/namespaces/ns/pods?&watch=true&resourceVersion=&timeoutSeconds=290&fieldSelector=metadata.name%3Dpod%3D1&labelSelector=app%3Dweb"
+            req.uri().query().unwrap(),
+            "&watch=true&resourceVersion=&timeoutSeconds=290&fieldSelector=metadata.name%3Dpod%3D1&labelSelector=app%3Dweb"
         );
     }
 

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -790,9 +790,14 @@ mod test {
     #[test]
     fn list_pods_from_cache() {
         let url = corev1::Pod::url_path(&(), Some("ns"));
-        let gp = ListParams::default().resource_version("0").resource_version_match(ResourceVersionMatch::NotOlderThan);
+        let gp = ListParams::default()
+            .resource_version("0")
+            .resource_version_match(ResourceVersionMatch::NotOlderThan);
         let req = Request::new(url).list(&gp).unwrap();
-        assert_eq!(req.uri(), "/api/v1/namespaces/ns/pods?&resourceVersion=0&resourceVersionMatch=NotOlderThan");
+        assert_eq!(
+            req.uri(),
+            "/api/v1/namespaces/ns/pods?&resourceVersion=0&resourceVersionMatch=NotOlderThan"
+        );
     }
 
     #[test]

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -395,10 +395,9 @@ where
         State::Empty => match api.list(&wc.into()).await {
             Ok(list) => {
                 if let Some(resource_version) = list.metadata.resource_version {
-                    (
-                        Some(Ok(Event::Restarted(list.items))),
-                        State::InitListed { resource_version },
-                    )
+                    (Some(Ok(Event::Restarted(list.items))), State::InitListed {
+                        resource_version,
+                    })
                 } else {
                     (Some(Err(Error::NoResourceVersion)), State::Empty)
                 }
@@ -413,13 +412,10 @@ where
             }
         },
         State::InitListed { resource_version } => match api.watch(&wc.into(), &resource_version).await {
-            Ok(stream) => (
-                None,
-                State::Watching {
-                    resource_version,
-                    stream,
-                },
-            ),
+            Ok(stream) => (None, State::Watching {
+                resource_version,
+                stream,
+            }),
             Err(err) => {
                 if std::matches!(err, ClientErr::Api(ErrorResponse { code: 403, .. })) {
                     warn!("watch initlist error with 403: {err:?}");
@@ -438,31 +434,22 @@ where
         } => match stream.next().await {
             Some(Ok(WatchEvent::Added(obj) | WatchEvent::Modified(obj))) => {
                 let resource_version = obj.resource_version().unwrap();
-                (
-                    Some(Ok(Event::Applied(obj))),
-                    State::Watching {
-                        resource_version,
-                        stream,
-                    },
-                )
+                (Some(Ok(Event::Applied(obj))), State::Watching {
+                    resource_version,
+                    stream,
+                })
             }
             Some(Ok(WatchEvent::Deleted(obj))) => {
                 let resource_version = obj.resource_version().unwrap();
-                (
-                    Some(Ok(Event::Deleted(obj))),
-                    State::Watching {
-                        resource_version,
-                        stream,
-                    },
-                )
-            }
-            Some(Ok(WatchEvent::Bookmark(bm))) => (
-                None,
-                State::Watching {
-                    resource_version: bm.metadata.resource_version,
+                (Some(Ok(Event::Deleted(obj))), State::Watching {
+                    resource_version,
                     stream,
-                },
-            ),
+                })
+            }
+            Some(Ok(WatchEvent::Bookmark(bm))) => (None, State::Watching {
+                resource_version: bm.metadata.resource_version,
+                stream,
+            }),
             Some(Ok(WatchEvent::Error(err))) => {
                 // HTTP GONE, means we have desynced and need to start over and re-list :(
                 let new_state = if err.code == 410 {
@@ -486,13 +473,10 @@ where
                 } else {
                     debug!("watcher error: {err:?}");
                 }
-                (
-                    Some(Err(err).map_err(Error::WatchFailed)),
-                    State::Watching {
-                        resource_version,
-                        stream,
-                    },
-                )
+                (Some(Err(err).map_err(Error::WatchFailed)), State::Watching {
+                    resource_version,
+                    stream,
+                })
             }
             None => (None, State::InitListed { resource_version }),
         },
@@ -653,13 +637,10 @@ pub fn watch_object<K: Resource + Clone + DeserializeOwned + Debug + Send + 'sta
     api: Api<K>,
     name: &str,
 ) -> impl Stream<Item = Result<Option<K>>> + Send {
-    watcher(
-        api,
-        Config {
-            field_selector: Some(format!("metadata.name={name}")),
-            ..Config::default()
-        },
-    )
+    watcher(api, Config {
+        field_selector: Some(format!("metadata.name={name}")),
+        ..Config::default()
+    })
     .map(|event| match event? {
         Event::Deleted(_) => Ok(None),
         // We're filtering by object name, so getting more than one object means that either:

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -278,7 +278,7 @@ impl Config {
         self
     }
 
-    /// Converts generic watcher::Config structure to the instance of ListParams used for list requests.
+    /// Converts generic `watcher::Config` structure to the instance of `ListParams` used for list requests.
     fn to_list_params(&self) -> ListParams {
         ListParams {
             label_selector: self.label_selector.clone(),
@@ -293,7 +293,7 @@ impl Config {
         }
     }
 
-    /// Converts generic watcher::Config structure to the instance of WatchParams used for watch requests.
+    /// Converts generic `watcher::Config` structure to the instance of `WatchParams` used for watch requests.
     fn to_watch_params(&self) -> WatchParams {
         WatchParams {
             label_selector: self.label_selector.clone(),

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -52,7 +52,7 @@
 //! use futures::{StreamExt, TryStreamExt};
 //! use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 //! use kube::{
-//!     api::{Api, DeleteParams, ListParams, PatchParams, Patch, ResourceExt},
+//!     api::{Api, DeleteParams, PatchParams, Patch, ResourceExt},
 //!     core::CustomResourceExt,
 //!     Client, CustomResource,
 //!     runtime::{watcher, WatchStreamExt, wait::{conditions, await_condition}},
@@ -87,8 +87,8 @@
 //!
 //!     // Watch for changes to foos in the configured namespace
 //!     let foos: Api<Foo> = Api::default_namespaced(client.clone());
-//!     let lp = ListParams::default();
-//!     let mut apply_stream = watcher(foos, lp).applied_objects().boxed();
+//!     let wc = watcher::Config::default();
+//!     let mut apply_stream = watcher(foos, wc).applied_objects().boxed();
 //!     while let Some(f) = apply_stream.try_next().await? {
 //!         println!("saw apply to {}", f.name_any());
 //!     }


### PR DESCRIPTION
## Motivation

### Split list and watch params

In client-go, some list options only work for watch requests, and some only for list requests. It is not convenient to validate such structures.

To add new field only for lists, it is required to add validations to watch calls to deny them.

### Add resource version to ListParams
Speaking from experience, resource version options are helpful. My case is to reduce the Kubernetes API server load by providing the `resourceVersion=0` to avoid etcd hits and getting data from the cache.

The full explanation of the resource version semantic can be found [here](https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list).

Some issues to show the usefulness of the option
https://github.com/vectordotdev/vector/issues/7943
https://github.com/kubernetes/kube-state-metrics/pull/1548

## Solution

1. Add resourceVersion and resourceVersionMatch options for ListParams (inspired by [client-go](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListOptions))

    * The list is the most expensive type of request in Kubernetes because it loads all keys for the kind and namespace from etcd
    * Adding `resourceVersion` for get requests will be a breaking change, so I decided to go with just lists for now

2. Split list and watch params:
    * Split options
    * Add a new structure for watcher configuration
    * Convert watcher configuration to list params for list requests and watch params to watch requests