### PR TITLE
Add Controller::reconcile_on

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -15,10 +15,11 @@ rust-version = "1.63.0"
 edition = "2021"
 
 [features]
-unstable-runtime = ["unstable-runtime-subscribe", "unstable-runtime-predicates", "unstable-runtime-stream-control"]
+unstable-runtime = ["unstable-runtime-subscribe", "unstable-runtime-predicates", "unstable-runtime-stream-control", "unstable-runtime-reconcile-on"]
 unstable-runtime-subscribe = []
 unstable-runtime-predicates = []
 unstable-runtime-stream-control = []
+unstable-runtime-reconcile-on = []
 
 [package.metadata.docs.rs]
 features = ["k8s-openapi/v1_26", "unstable-runtime"]

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1022,17 +1022,16 @@ where
     /// # async {
     /// use futures::{StreamExt, TryStreamExt};
     /// use k8s_openapi::api::core::v1::{ConfigMap, Pod};
-    /// use kube::api::ListParams;
-    /// use kube::runtime::controller::Action;
-    /// use kube::runtime::reflector::ObjectRef;
-    /// use kube::runtime::{reflector, watcher, Controller, WatchStreamExt};
-    /// use kube::ResourceExt;
-    /// use kube::{Api, Client};
+    /// # use kube::api::{Api, ListParams};
+    /// # use kube::runtime::controller::Action;
+    /// # use kube::runtime::reflector::ObjectRef;
+    /// # use kube::runtime::{reflector, watcher, Controller, WatchStreamExt};
+    /// # use kube::{Client, ResourceExt};
     /// use std::convert::Infallible;
     /// use std::future;
     /// use std::sync::Arc;
     ///
-    /// // let client = Client::try_default().await.unwrap();
+    /// # let client: Client = todo!();
     ///
     /// // Store can be used in the reconciler instead of querying Kube
     /// let (pod_store, writer) = reflector::store();
@@ -1046,14 +1045,8 @@ where
     ///
     /// Controller::new(Api::<ConfigMap>::all(client), ListParams::default())
     ///     .reconcile_on(pod_stream)
-    ///     .run(
-    ///         |_obj, _pod_store| async move {
-    ///             // `pod_store` can be used there instead of querying Kubernetes
-    ///             Ok(Action::await_change())
-    ///         },
-    ///         |_object: Arc<ConfigMap>, err: &Infallible, _| Err(err).unwrap(),
-    ///         Arc::new(pod_store),
-    ///     )
+    ///     // The store can be re-used between controllers and even inspected from the reconciler through [Context]
+    ///     .run(reconcile, error_policy, Arc::new(pod_store))
     ///     .for_each(|_| future::ready(()))
     ///     .await;
     /// # };

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1011,6 +1011,22 @@ where
         self
     }
 
+    #[must_use]
+    pub fn reconcile_on(
+        mut self,
+        trigger: impl Stream<Item = Result<ObjectRef<K>, watcher::Error>> + Send + 'static,
+    ) -> Self {
+        self.trigger_selector.push(
+            trigger
+                .map_ok(move |obj| ReconcileRequest {
+                    obj_ref: obj,
+                    reason: ReconcileReason::Unknown,
+                })
+                .boxed(),
+        );
+        self
+    }
+
     /// Start a graceful shutdown when `trigger` resolves. Once a graceful shutdown has been initiated:
     ///
     /// - No new reconciliations are started from the scheduler

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1016,16 +1016,17 @@ where
     /// For example, this can be used to watch resources once and use the stream to trigger reconciliation and also keep a cache of those objects.
     /// That way it's possible to use this up to date cache instead of querying Kubernetes to access those resources
     ///
-    /// Example:
+    /// # Example:
     ///
     /// ```no_run
     /// # async {
     /// # use futures::{StreamExt, TryStreamExt};
     /// # use k8s_openapi::api::core::v1::{ConfigMap, Pod};
-    /// # use kube::api::{Api, ListParams};
+    /// # use kube::api::Api;
     /// # use kube::runtime::controller::Action;
     /// # use kube::runtime::reflector::{ObjectRef, Store};
     /// # use kube::runtime::{reflector, watcher, Controller, WatchStreamExt};
+    /// # use kube::runtime::watcher::Config;
     /// # use kube::{Client, Error, ResourceExt};
     /// # use std::future;
     /// # use std::sync::Arc;
@@ -1038,13 +1039,13 @@ where
     /// let (pod_store, writer) = reflector::store();
     /// let pod_stream = reflector(
     ///     writer,
-    ///     watcher(Api::<Pod>::all(client.clone()), ListParams::default()),
+    ///     watcher(Api::<Pod>::all(client.clone()), Config::default()),
     /// )
     /// .applied_objects()
     /// // Map to the relevant `ObjectRef<K>` to reconcile
     /// .map_ok(|pod| ObjectRef::new(&format!("{}-cm", pod.name_any())).within(&pod.namespace().unwrap()));
     ///
-    /// Controller::new(Api::<ConfigMap>::all(client), ListParams::default())
+    /// Controller::new(Api::<ConfigMap>::all(client), Config::default())
     ///     .reconcile_on(pod_stream)
     ///     // The store can be re-used between controllers and even inspected from the reconciler through [Context]
     ///     .run(reconcile, error_policy, Arc::new(pod_store))
@@ -1052,6 +1053,7 @@ where
     ///     .await;
     /// # };
     /// ```
+    #[cfg(feature = "unstable-runtime-reconcile-on")]
     #[must_use]
     pub fn reconcile_on(
         mut self,

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1020,19 +1020,20 @@ where
     ///
     /// ```no_run
     /// # async {
-    /// use futures::{StreamExt, TryStreamExt};
-    /// use k8s_openapi::api::core::v1::{ConfigMap, Pod};
+    /// # use futures::{StreamExt, TryStreamExt};
+    /// # use k8s_openapi::api::core::v1::{ConfigMap, Pod};
     /// # use kube::api::{Api, ListParams};
     /// # use kube::runtime::controller::Action;
-    /// # use kube::runtime::reflector::ObjectRef;
+    /// # use kube::runtime::reflector::{ObjectRef, Store};
     /// # use kube::runtime::{reflector, watcher, Controller, WatchStreamExt};
-    /// # use kube::{Client, ResourceExt};
-    /// use std::convert::Infallible;
-    /// use std::future;
-    /// use std::sync::Arc;
-    ///
+    /// # use kube::{Client, Error, ResourceExt};
+    /// # use std::future;
+    /// # use std::sync::Arc;
+    /// #
     /// # let client: Client = todo!();
-    ///
+    /// # async fn reconcile(_: Arc<ConfigMap>, _: Arc<Store<Pod>>) -> Result<Action, Error> { Ok(Action::await_change()) }
+    /// # fn error_policy(_: Arc<ConfigMap>, _: &kube::Error, _: Arc<Store<Pod>>) -> Action { Action::await_change() }
+    /// #
     /// // Store can be used in the reconciler instead of querying Kube
     /// let (pod_store, writer) = reflector::store();
     /// let pod_stream = reflector(
@@ -1041,7 +1042,7 @@ where
     /// )
     /// .applied_objects()
     /// // Map to the relevant `ObjectRef<K>` to reconcile
-    /// .map_ok(|pod| ObjectRef::new(&format!("{}-cm", pod.name_any())));
+    /// .map_ok(|pod| ObjectRef::new(&format!("{}-cm", pod.name_any())).within(&pod.namespace().unwrap()));
     ///
     /// Controller::new(Api::<ConfigMap>::all(client), ListParams::default())
     ///     .reconcile_on(pod_stream)

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1011,6 +1011,53 @@ where
         self
     }
 
+    /// Trigger the reconciliation process for a managed object `ObjectRef<K>` whenever `trigger` emits a value
+    ///
+    /// For example, this can be used to watch resources once and use the stream to trigger reconciliation and also keep a cache of those objects.
+    /// That way it's possible to use this up to date cache instead of querying Kubernetes to access those resources
+    ///
+    /// Example:
+    ///
+    /// ```no_run
+    /// # async {
+    /// use futures::{StreamExt, TryStreamExt};
+    /// use k8s_openapi::api::core::v1::{ConfigMap, Pod};
+    /// use kube::api::ListParams;
+    /// use kube::runtime::controller::Action;
+    /// use kube::runtime::reflector::ObjectRef;
+    /// use kube::runtime::{reflector, watcher, Controller, WatchStreamExt};
+    /// use kube::ResourceExt;
+    /// use kube::{Api, Client};
+    /// use std::convert::Infallible;
+    /// use std::future;
+    /// use std::sync::Arc;
+    ///
+    /// // let client = Client::try_default().await.unwrap();
+    ///
+    /// // Store can be used in the reconciler instead of querying Kube
+    /// let (pod_store, writer) = reflector::store();
+    /// let pod_stream = reflector(
+    ///     writer,
+    ///     watcher(Api::<Pod>::all(client.clone()), ListParams::default()),
+    /// )
+    /// .applied_objects()
+    /// // Map to the relevant `ObjectRef<K>` to reconcile
+    /// .map_ok(|pod| ObjectRef::new(&format!("{}-cm", pod.name_any())));
+    ///
+    /// Controller::new(Api::<ConfigMap>::all(client), ListParams::default())
+    ///     .reconcile_on(pod_stream)
+    ///     .run(
+    ///         |_obj, _pod_store| async move {
+    ///             // `pod_store` can be used there instead of querying Kubernetes
+    ///             Ok(Action::await_change())
+    ///         },
+    ///         |_object: Arc<ConfigMap>, err: &Infallible, _| Err(err).unwrap(),
+    ///         Arc::new(pod_store),
+    ///     )
+    ///     .for_each(|_| future::ready(()))
+    ///     .await;
+    /// # };
+    /// ```
     #[must_use]
     pub fn reconcile_on(
         mut self,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

Allow to feed the controller with a stream of `ObjectRef<K>` to reconcile.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

When creating a controller which watches some pods I wanted to be able to cache them with a reflector, and use the cache later in the reconcile function.
I does nos seems to be possible right now. Some PRs and issues related : #824 #1080.
This solution allow to do it with only one watch, which ensure that resources in the store are up to date when queried within the reconcile function.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

Add a function `Controller::reconcile_on` which take a stream of `ObjectRef<K>` as parameter.

```rust
        let (pod_store, writer) = reflector::store();
        // Store can be used in the reconcile loop instead of querying Kube
        ctx.pod_store = pod_store;
        let stream = reflector(writer, watcher(pod_api.clone(), ListParams::default()))
            .applied_objects()
            .try_filter_map(|pod| future::ready(Ok(pod_mapper(pod))))
            .boxed();

        info!("Operator ready");
        let drainer = Controller::new(crd_api, ListParams::default())
            .shutdown_on_signal()
            // NEW FUNCTION
            .reconcile_on(stream)
            .run(reconcile, error_policy, Arc::new(ctx))
            .for_each(|_result| async move {})
            .boxed();
```

If the design is accepted I'll add documentation and tests