### PR TITLE
Make `VersionMatch` follow upstream + configure list semantics in `watcher::Config`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -99,3 +99,7 @@ name = "syn"
 # waiting for pem to bump base64
 # https://github.com/jcreekmore/pem-rs/blob/master/Cargo.toml#L16
 name = "base64"
+
+[[bans.skip]]
+# deep in dependency tree, only dual use via dev dependency
+name = "redox_syscall"

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -65,7 +65,7 @@ pub struct ListParams {
     /// After listing results with a limit, a continue token can be used to fetch another page of results.
     pub continue_token: Option<String>,
 
-    /// Determines how resourceVersion is matched  applied to list calls.
+    /// Determines how resourceVersion is matched applied to list calls.
     pub version_match: Option<VersionMatch>,
 
     /// An explicit resourceVersion using the given `VersionMatch` strategy

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -169,7 +169,7 @@ impl ListParams {
     /// A non-default strategy such as `VersionMatch::Exact` or `VersionMatch::NotGreaterThan`
     /// requires an explicit `resource_version` set to pass request validation.
     #[must_use]
-    pub fn version_match(mut self, version_match: VersionMatch) -> Self {
+    pub fn matching(mut self, version_match: VersionMatch) -> Self {
         self.version_match = version_match;
         self
     }
@@ -184,7 +184,7 @@ impl ListParams {
     /// Clients that cannot tolerate this should not use this semantic.
     #[must_use]
     pub fn match_any(self) -> Self {
-        self.version_match(VersionMatch::NotOlderThan).at("0")
+        self.matching(VersionMatch::NotOlderThan).at("0")
     }
 }
 

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -183,10 +183,8 @@ impl ListParams {
     /// has previously observed, particularly in high availability configurations, due to partitions or stale caches.
     /// Clients that cannot tolerate this should not use this semantic.
     #[must_use]
-    pub fn match_any(mut self) -> Self {
-        self.resource_version = Some("0".into());
-        self.version_match = VersionMatch::NotOlderThan;
-        self
+    pub fn match_any(self) -> Self {
+        self.version_match(VersionMatch::NotOlderThan).at("0")
     }
 }
 

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -14,8 +14,8 @@ pub enum VersionMatch {
     ///
     /// This is the default option.
     ///
-    /// Note that unless you have strong consistency requirements, using `NotOlderThan`
-    /// and a known resource version is preferable since it can achieve better performance and scalability
+    /// Note that if you have weak consistency requirements, using `NotOlderThan`
+    /// may be preferable since it can achieve better performance and scalability
     /// of your cluster than leaving resource version  and resource version Match unset, which requires quorum read to be served.
     #[default]
     Unset,
@@ -89,7 +89,7 @@ impl ListParams {
         if let Some(rv) = &self.resource_version {
             if self.version_match == VersionMatch::Exact && rv == "0" {
                 return Err(Error::Validation(
-                    "A zero resource_version is required when using an Exact match".into(),
+                    "A non-zero resource_version is required when using an Exact match".into(),
                 ));
             }
         } else if self.version_match != VersionMatch::Unset {

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -4,22 +4,12 @@ use serde::Serialize;
 
 /// Controls how the resource version parameter is applied for list calls
 ///
-/// This enum is by default `Unset` and results in a slow (but consistent) quorum read from etcd.
+/// Not specifying a `VersionMatch` strategy will give you different semantics
+/// depending on what `resource_version`, `limit`, `continue_token` you include with the list request.
+///
 /// See <https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list> for details.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum VersionMatch {
-    /// Return data at the most recent resource version.
-    ///
-    /// The returned data must be consistent and is served straight from etcd via a quorum read.
-    ///
-    /// This is the default option.
-    ///
-    /// Note that if you have weak consistency requirements, using `NotOlderThan`
-    /// may be preferable since it can achieve better performance and scalability
-    /// of your cluster than leaving resource version  and resource version Match unset, which requires quorum read to be served.
-    #[default]
-    Unset,
-
     /// Returns data at least as new as the provided resource version.
     ///
     /// The newest available data is preferred, but any data not older than the provided resource version may be served.
@@ -76,7 +66,7 @@ pub struct ListParams {
     pub continue_token: Option<String>,
 
     /// Determines how resourceVersion is matched  applied to list calls.
-    pub version_match: VersionMatch,
+    pub version_match: Option<VersionMatch>,
 
     /// An explicit resourceVersion using the given `VersionMatch` strategy
     ///
@@ -87,12 +77,12 @@ pub struct ListParams {
 impl ListParams {
     pub(crate) fn validate(&self) -> Result<(), Error> {
         if let Some(rv) = &self.resource_version {
-            if self.version_match == VersionMatch::Exact && rv == "0" {
+            if self.version_match == Some(VersionMatch::Exact) && rv == "0" {
                 return Err(Error::Validation(
                     "A non-zero resource_version is required when using an Exact match".into(),
                 ));
             }
-        } else if self.version_match != VersionMatch::Unset {
+        } else if self.version_match.is_some() {
             return Err(Error::Validation(
                 "A resource_version is required when using an explicit match".into(),
             ));
@@ -170,7 +160,7 @@ impl ListParams {
     /// requires an explicit `resource_version` set to pass request validation.
     #[must_use]
     pub fn matching(mut self, version_match: VersionMatch) -> Self {
-        self.version_match = version_match;
+        self.version_match = Some(version_match);
         self
     }
 

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -75,10 +75,14 @@ impl Request {
         if let Some(rv) = &lp.resource_version {
             qp.append_pair("resourceVersion", rv.as_str());
         }
-        if std::matches!(&lp.version_match, VersionMatch::NotOlderThan) {
-            qp.append_pair("resourceVersionMatch", "NotOlderThan");
-        } else if std::matches!(&lp.version_match, VersionMatch::Exact) {
-            qp.append_pair("resourceVersionMatch", "Exact");
+        match &lp.version_match {
+            VersionMatch::MostRecent => {}
+            VersionMatch::NotOlderThan => {
+                qp.append_pair("resourceVersionMatch", "NotOlderThan");
+            }
+            VersionMatch::Exact => {
+                qp.append_pair("resourceVersionMatch", "Exact");
+            }
         }
 
         let urlstr = qp.finish();
@@ -315,10 +319,14 @@ impl Request {
         if let Some(rv) = &lp.resource_version {
             qp.append_pair("resourceVersion", rv.as_str());
         }
-        if std::matches!(&lp.version_match, VersionMatch::NotOlderThan) {
-            qp.append_pair("resourceVersionMatch", "NotOlderThan");
-        } else if std::matches!(&lp.version_match, VersionMatch::Exact) {
-            qp.append_pair("resourceVersionMatch", "Exact");
+        match &lp.version_match {
+            VersionMatch::MostRecent => {}
+            VersionMatch::NotOlderThan => {
+                qp.append_pair("resourceVersionMatch", "NotOlderThan");
+            }
+            VersionMatch::Exact => {
+                qp.append_pair("resourceVersionMatch", "Exact");
+            }
         }
 
         let urlstr = qp.finish();

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -76,7 +76,7 @@ impl Request {
             qp.append_pair("resourceVersion", rv.as_str());
         }
         match &lp.version_match {
-            VersionMatch::MostRecent => {}
+            VersionMatch::Unset => {}
             VersionMatch::NotOlderThan => {
                 qp.append_pair("resourceVersionMatch", "NotOlderThan");
             }
@@ -320,7 +320,7 @@ impl Request {
             qp.append_pair("resourceVersion", rv.as_str());
         }
         match &lp.version_match {
-            VersionMatch::MostRecent => {}
+            VersionMatch::Unset => {}
             VersionMatch::NotOlderThan => {
                 qp.append_pair("resourceVersionMatch", "NotOlderThan");
             }
@@ -759,7 +759,7 @@ mod test {
         let url = corev1::Pod::url_path(&(), Some("ns"));
         let gp = ListParams::default().at("0").matching(VersionMatch::Exact);
         let err = Request::new(url).list(&gp).unwrap_err();
-        assert!(format!("{err}").contains("A zero resource_version is required when using an Exact match"));
+        assert!(format!("{err}").contains("non-zero resource_version is required when using an Exact match"));
     }
 
 

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -76,11 +76,11 @@ impl Request {
             qp.append_pair("resourceVersion", rv.as_str());
         }
         match &lp.version_match {
-            VersionMatch::Unset => {}
-            VersionMatch::NotOlderThan => {
+            None => {}
+            Some(VersionMatch::NotOlderThan) => {
                 qp.append_pair("resourceVersionMatch", "NotOlderThan");
             }
-            VersionMatch::Exact => {
+            Some(VersionMatch::Exact) => {
                 qp.append_pair("resourceVersionMatch", "Exact");
             }
         }
@@ -320,11 +320,11 @@ impl Request {
             qp.append_pair("resourceVersion", rv.as_str());
         }
         match &lp.version_match {
-            VersionMatch::Unset => {}
-            VersionMatch::NotOlderThan => {
+            None => {}
+            Some(VersionMatch::NotOlderThan) => {
                 qp.append_pair("resourceVersionMatch", "NotOlderThan");
             }
-            VersionMatch::Exact => {
+            Some(VersionMatch::Exact) => {
                 qp.append_pair("resourceVersionMatch", "Exact");
             }
         }
@@ -746,7 +746,7 @@ mod test {
     #[test]
     fn list_most_recent_pods() {
         let url = corev1::Pod::url_path(&(), Some("ns"));
-        let gp = ListParams::default().matching(VersionMatch::Unset);
+        let gp = ListParams::default();
         let req = Request::new(url).list(&gp).unwrap();
         assert_eq!(
             req.uri().query().unwrap(),

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -521,9 +521,7 @@ mod test {
     #[test]
     fn list_metadata_path() {
         let url = appsv1::Deployment::url_path(&(), Some("ns"));
-        let lp = ListParams::default()
-            .version_match(VersionMatch::NotOlderThan)
-            .at("5");
+        let lp = ListParams::default().matching(VersionMatch::NotOlderThan).at("5");
         let req = Request::new(url).list_metadata(&lp).unwrap();
         assert_eq!(
             req.uri(),
@@ -740,7 +738,7 @@ mod test {
     #[test]
     fn list_most_recent_pods() {
         let url = corev1::Pod::url_path(&(), Some("ns"));
-        let gp = ListParams::default().version_match(VersionMatch::Unset);
+        let gp = ListParams::default().matching(VersionMatch::Unset);
         let req = Request::new(url).list(&gp).unwrap();
         assert_eq!(
             req.uri().query().unwrap(),
@@ -751,7 +749,7 @@ mod test {
     #[test]
     fn list_invalid_resource_version_combination() {
         let url = corev1::Pod::url_path(&(), Some("ns"));
-        let gp = ListParams::default().at("0").version_match(VersionMatch::Exact);
+        let gp = ListParams::default().at("0").matching(VersionMatch::Exact);
         let err = Request::new(url).list(&gp).unwrap_err();
         assert!(format!("{err}").contains("A zero resource_version is required when using an Exact match"));
     }
@@ -762,7 +760,7 @@ mod test {
         let url = corev1::Pod::url_path(&(), Some("ns"));
         let gp = ListParams::default()
             .at("20")
-            .version_match(VersionMatch::NotOlderThan);
+            .matching(VersionMatch::NotOlderThan);
         let req = Request::new(url).list(&gp).unwrap();
         assert_eq!(
             req.uri().query().unwrap(),
@@ -773,7 +771,7 @@ mod test {
     #[test]
     fn list_exact_match() {
         let url = corev1::Pod::url_path(&(), Some("ns"));
-        let gp = ListParams::default().at("500").version_match(VersionMatch::Exact);
+        let gp = ListParams::default().at("500").matching(VersionMatch::Exact);
         let req = Request::new(url).list(&gp).unwrap();
         let query = req.uri().query().unwrap();
         assert_eq!(query, "&resourceVersion=500&resourceVersionMatch=Exact");

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -265,7 +265,7 @@ impl Config {
 
     /// Sets list semantic to `Any` to reduce cluster load
     #[must_use]
-    pub fn cached(self) -> Self {
+    pub fn any_semantic(self) -> Self {
         self.list_semantic(ListSemantic::Any)
     }
 

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -282,8 +282,8 @@ impl Config {
     /// Converts generic `watcher::Config` structure to the instance of `ListParams` used for list requests.
     fn to_list_params(&self) -> ListParams {
         let version_match = match self.list_semantic {
-            ListSemantic::Cached => VersionMatch::NotOlderThan,
-            ListSemantic::MostRecent => VersionMatch::Unset,
+            ListSemantic::Cached => Some(VersionMatch::NotOlderThan),
+            ListSemantic::MostRecent => None,
         };
         ListParams {
             label_selector: self.label_selector.clone(),

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -161,6 +161,11 @@ pub enum ListSemantic {
     ///
     /// Prefer this if you have strong consistency requirements. Note that this
     /// is more taxing for the apiserver and can be less scalable for the cluster.
+    ///
+    /// If you are observing large resource sets (such as congested `Controller` cases),
+    /// you typically have a delay between the list call completing, and all the events
+    /// getting processed. In such cases, it is probably worth picking `Any` over `MostRecent`,
+    /// as your events are not guaranteed to be up-to-date by the time you get to them anyway.
     #[default]
     MostRecent,
 
@@ -169,6 +174,9 @@ pub enum ListSemantic {
     /// This is faster and much less taxing on the apiserver, but can result
     /// in much older results than has previously observed for `Restarted` events,
     /// particularly in HA configurations, due to partitions or stale caches.
+    ///
+    /// This option makes the most sense for controller usage where events have
+    /// some delay between being seen by the runtime, and it being sent to the reconciler.
     Any,
 }
 
@@ -263,7 +271,7 @@ impl Config {
         self
     }
 
-    /// Sets list semantic to `Any` to reduce cluster load
+    /// Sets list semantic to `Any` to improve list performance
     #[must_use]
     pub fn any_semantic(self) -> Self {
         self.list_semantic(ListSemantic::Any)

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -157,11 +157,11 @@ struct FullObject<'a, K> {
 /// Allowable list semantics
 #[derive(Clone, Default, Debug, PartialEq)]
 pub enum Semantic {
-    /// List calls perform a full quorum read
+    /// List calls perform a full quorum read for most recent results
     ///
-    /// Prefer this only if you have strong consistency requirements as it is less
-    /// scalable for the cluster.
-    Strong,
+    /// Prefer this if you have strong consistency requirements. Note that this
+    /// is more taxing for the apiserver and can be less scalable for the cluster.
+    MostRecent,
 
     /// List calls returns cached results from apiserver
     ///
@@ -169,7 +169,7 @@ pub enum Semantic {
     /// in much older results than has previously observed for `Restarted` events,
     /// particularly in HA configurations, due to partitions or stale caches.
     #[default]
-    Cache,
+    Cached,
 }
 
 /// Accumulates all options that can be used on the watcher invocation.
@@ -276,8 +276,8 @@ impl Config {
     /// Converts generic `watcher::Config` structure to the instance of `ListParams` used for list requests.
     fn to_list_params(&self) -> ListParams {
         let version_match = match self.semantic {
-            Semantic::Cache => VersionMatch::NotOlderThan,
-            Semantic::Strong => VersionMatch::Unset,
+            Semantic::Cached => VersionMatch::NotOlderThan,
+            Semantic::MostRecent => VersionMatch::Unset,
         };
         ListParams {
             label_selector: self.label_selector.clone(),

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -161,6 +161,7 @@ pub enum ListSemantic {
     ///
     /// Prefer this if you have strong consistency requirements. Note that this
     /// is more taxing for the apiserver and can be less scalable for the cluster.
+    #[default]
     MostRecent,
 
     /// List calls returns cached results from apiserver
@@ -168,8 +169,7 @@ pub enum ListSemantic {
     /// This is faster and much less taxing on the apiserver, but can result
     /// in much older results than has previously observed for `Restarted` events,
     /// particularly in HA configurations, due to partitions or stale caches.
-    #[default]
-    Cached,
+    Any,
 }
 
 /// Accumulates all options that can be used on the watcher invocation.
@@ -263,10 +263,10 @@ impl Config {
         self
     }
 
-    /// Sets list semantic to the strongly consistent `MostRecent`
+    /// Sets list semantic to `Any` to reduce cluster load
     #[must_use]
-    pub fn most_recent(self) -> Self {
-        self.list_semantic(ListSemantic::MostRecent)
+    pub fn cached(self) -> Self {
+        self.list_semantic(ListSemantic::Any)
     }
 
     /// Disables watch bookmarks to simplify watch handling
@@ -282,7 +282,7 @@ impl Config {
     /// Converts generic `watcher::Config` structure to the instance of `ListParams` used for list requests.
     fn to_list_params(&self) -> ListParams {
         let version_match = match self.list_semantic {
-            ListSemantic::Cached => Some(VersionMatch::NotOlderThan),
+            ListSemantic::Any => Some(VersionMatch::NotOlderThan),
             ListSemantic::MostRecent => None,
         };
         ListParams {


### PR DESCRIPTION
Effectively makes the `VersionMatch` an exact duplicate of the upstream, and adds some builders here and there to compensate for the missing `Any`.

Have changed the watcher interface and made a new enum that maps onto `VersionMatch` instead, because it does not make sense to run a watcher against a pinned resource version; it will always use 0.

(at least unless/until we build pagination into it).

We could keep the enum that wraps resource version, but this is awkward; it would be the only one that bundles resourceVersion that way;

- watch api calls get it as a str (outside watchparams)
- get api calls (in a follow-up pr) will also not use the enum

so altogether we are just making it awkward for ourselves by trying to make it nice :(

Follow-up to #1162 before releasing.


### Questions
Q: should we make `NotOlderThan("0")` a new default for `ListParams`? we want people to use the new-faster/less-taxing variant, although it is also slightly less consistent. I feel the people who want strong consistency guarantees should opt-in rather than people who don't want strong consistency to opt-out.

A: `ListParams` should follow the api. Opt-in is up to the user. This avoids breaking changes.

Q: should `watcher` default to a less consistent listsemantic for relists? it's much less of an issue because a few extra events will eventually get cleaned up anyway due to the nature of it being an infinite watch stream. Given the reports that people are passing on upstream complaining about our default watch semantics, it might better to provide a stronger opinion here so that we are not seen as a "taxing runtime to use"

A: Not changing defaults. While it makes sense for `Controller` use where things are eventually consistent and meant to deal with a few redundant reconciles anyway, it's a little more iffy for `watcher`. We emphasise this in the docs, in particular for `Semantic`. People like opting into performance a lot more than they have to debug less consistency (if that happens).