### PR TITLE
Bump rustls,hyper-rustls - for #1181

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -111,3 +111,8 @@ name = "base64"
 [[bans.skip]]
 # deep in dependency tree, only dual use via dev dependency
 name = "redox_syscall"
+
+[[bans.skip-tree]]
+name = "windows-sys"
+[[bans.skip-tree]]
+name = "windows"

--- a/deny.toml
+++ b/deny.toml
@@ -69,6 +69,14 @@ license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
 ]
 
+# rustls' webpki fork uses same license https://github.com/rustls/webpki
+[[licenses.clarify]]
+name = "rustls-webpki"
+expression = "LicenseRef-webpki"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -47,7 +47,7 @@ http-body = { version = "0.4.2", optional = true }
 either = { version = "1.6.1", optional = true }
 thiserror = "1.0.29"
 futures = { version = "0.3.17", optional = true }
-pem = { version = "2.0.0", optional = true }
+pem = { version = "1.1.0", optional = true }
 openssl = { version = "0.10.36", optional = true }
 rustls = { version = "0.21.0", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "1.0.0", optional = true }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -47,9 +47,9 @@ http-body = { version = "0.4.2", optional = true }
 either = { version = "1.6.1", optional = true }
 thiserror = "1.0.29"
 futures = { version = "0.3.17", optional = true }
-pem = { version = "1.1.0", optional = true }
+pem = { version = "2.0.0", optional = true }
 openssl = { version = "0.10.36", optional = true }
-rustls = { version = "0.20.3", features = ["dangerous_configuration"], optional = true }
+rustls = { version = "0.21.0", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "1.0.0", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
@@ -57,7 +57,7 @@ kube-core = { path = "../kube-core", version = "=0.80.0" }
 jsonpath_lib = { version = "0.3.0", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
-hyper-rustls = { version = "0.23.2", optional = true }
+hyper-rustls = { version = "0.24.0", optional = true }
 tokio-tungstenite = { version = "0.18.0", optional = true }
 tower = { version = "0.4.6", optional = true, features = ["buffer", "filter", "util"] }
 tower-http = { version = "0.4.0", optional = true, features = ["auth", "map-response-body", "trace"] }

--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -4,8 +4,7 @@ pub mod rustls_tls {
     use rustls::{
         self,
         client::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
-        internal::msgs::handshake::DigitallySignedStruct,
-        Certificate, ClientConfig, PrivateKey,
+        Certificate, ClientConfig, DigitallySignedStruct, PrivateKey,
     };
     use thiserror::Error;
 

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -377,8 +377,8 @@ fn certs(data: &[u8]) -> Result<Vec<Vec<u8>>, pem::PemError> {
     Ok(pem::parse_many(data)?
         .into_iter()
         .filter_map(|p| {
-            if p.tag() == "CERTIFICATE" {
-                Some(p.into_contents())
+            if p.tag == "CERTIFICATE" {
+                Some(p.contents)
             } else {
                 None
             }

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -377,8 +377,8 @@ fn certs(data: &[u8]) -> Result<Vec<Vec<u8>>, pem::PemError> {
     Ok(pem::parse_many(data)?
         .into_iter()
         .filter_map(|p| {
-            if p.tag == "CERTIFICATE" {
-                Some(p.contents)
+            if p.tag() == "CERTIFICATE" {
+                Some(p.into_contents())
             } else {
                 None
             }


### PR DESCRIPTION
Dependency upgrades for rustls:

- rustls 0.20 -> 0.21 - original pr with commit links to changes: https://github.com/kube-rs/kube/pull/1179
- hyper-rustls 0.23 -> 0.24 - original pr with commit links to changes: https://github.com/kube-rs/kube/pull/1177
- ~~pem 1.1 -> 2~~ <- abandoned because of strict MSRV requirements

A few things to note:
- handling `windows*` duplicate dependency failures from `deny` aggressively (since there were tons)
- whitelists the same license that `webpki` used (`rustls-webpki` fork now included)
- possibly solves rustls ip issue: https://github.com/kube-rs/kube/issues/153#issuecomment-1447803720 due to the fork inclusion