### PR TITLE
Avoid special `Config::incluster` behavior for `rustls`

### DIFF
--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -208,20 +208,8 @@ impl Config {
 
     /// Load an in-cluster Kubernetes client configuration using
     /// [`Config::incluster_env`].
-    ///
-    /// # Rustls-specific behavior
-    /// Rustls does not support validating IP addresses (see
-    /// <https://github.com/kube-rs/kube/issues/1003>).
-    /// To work around this, when rustls is configured, this function automatically appends
-    /// `tls-server-name = "kubernetes.default.svc"` to the resulting configuration.
-    /// Overriding or unsetting `Config::tls_server_name` will avoid this behaviour.
     pub fn incluster() -> Result<Self, InClusterError> {
-        let mut cfg = Self::incluster_env()?;
-        if cfg!(all(not(feature = "openssl-tls"), feature = "rustls-tls")) {
-            // openssl takes precedence when both features present, so only do it when only rustls is there
-            cfg.tls_server_name = Some("kubernetes.default.svc".to_string());
-        }
-        Ok(cfg)
+        Self::incluster_env()
     }
 
     /// Load an in-cluster config using the `KUBERNETES_SERVICE_HOST` and

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -57,7 +57,7 @@ pub struct Action {
 }
 
 impl Action {
-    /// Action to to the reconciliation at this time even if no external watch triggers hit
+    /// Action to the reconciliation at this time even if no external watch triggers hit
     ///
     /// This is the best-practice action that ensures eventual consistency of your controller
     /// even in the case of missed changes (which can happen).


### PR DESCRIPTION
Changes `rustls` to not have speculative override behaviour since it should work in all cases after #1183 and linked changes.

Closes #1003 plus #1109 (the [last open `rustls` issues](https://github.com/kube-rs/kube/issues?q=label%3Arustls+))