### PR TITLE
Add `Controller::for_stream` + `Controller::watches_stream`

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -15,10 +15,10 @@ rust-version = "1.63.0"
 edition = "2021"
 
 [features]
-unstable-runtime = ["unstable-runtime-subscribe", "unstable-runtime-predicates", "unstable-runtime-stream-share"]
+unstable-runtime = ["unstable-runtime-subscribe", "unstable-runtime-predicates", "unstable-runtime-stream-control"]
 unstable-runtime-subscribe = []
 unstable-runtime-predicates = []
-unstable-runtime-stream-share = []
+unstable-runtime-stream-control = []
 
 [package.metadata.docs.rs]
 features = ["k8s-openapi/v1_26", "unstable-runtime"]

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -15,10 +15,10 @@ rust-version = "1.63.0"
 edition = "2021"
 
 [features]
-unstable-runtime = ["unstable-runtime-subscribe", "unstable-runtime-predicates", "unstable-runtime-owns-stream"]
+unstable-runtime = ["unstable-runtime-subscribe", "unstable-runtime-predicates", "unstable-runtime-stream-share"]
 unstable-runtime-subscribe = []
 unstable-runtime-predicates = []
-unstable-runtime-owns-stream = []
+unstable-runtime-stream-share = []
 
 [package.metadata.docs.rs]
 features = ["k8s-openapi/v1_26", "unstable-runtime"]

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -564,7 +564,7 @@ where
     /// ```
     ///
     /// Prefer [`Controller::new`] if you do not need to share the stream, or do not need pre-filtering.
-    #[cfg(feature = "unstable-runtime-stream-share")]
+    #[cfg(feature = "unstable-runtime-stream-control")]
     pub fn for_stream(
         trigger: impl Stream<Item = Result<K, watcher::Error>> + Send + 'static,
         reader: Store<K>,
@@ -588,9 +588,9 @@ where
     /// This variant constructor is for [`dynamic`] types found through discovery. Prefer [`Controller::for_stream`] for static types.
     ///
     /// [`dynamic`]: kube_client::core::dynamic
-    #[cfg(feature = "unstable-runtime-stream-share")]
+    #[cfg(feature = "unstable-runtime-stream-control")]
     pub fn for_stream_with(
-        trigger: impl Stream<Item = Result<K, watcher::Error>> + Send + 'static,
+        trigger: impl Stream<Item = Result<Arc<K>, watcher::Error>> + Send + 'static,
         reader: Store<K>,
         dyntype: K::DynamicType,
     ) -> Self {
@@ -703,7 +703,7 @@ where
     ///     .await;
     /// # }
     /// ```
-    #[cfg(feature = "unstable-runtime-stream-share")]
+    #[cfg(feature = "unstable-runtime-stream-control")]
     #[must_use]
     pub fn owns_stream<Child: Resource<DynamicType = ()> + Send + 'static>(
         self,
@@ -721,7 +721,7 @@ where
     /// **NB**: This is constructor requires an [`unstable`](https://github.com/kube-rs/kube/blob/main/kube-runtime/Cargo.toml#L17-L21) feature.
     ///
     /// Same as [`Controller::owns_stream`], but accepts a `DynamicType` so it can be used with dynamic resources.
-    #[cfg(feature = "unstable-runtime-stream-share")]
+    #[cfg(feature = "unstable-runtime-stream-control")]
     #[must_use]
     pub fn owns_stream_with<Child: Resource + Send + 'static>(
         mut self,
@@ -886,7 +886,7 @@ where
     ///     .await;
     /// # }
     /// ```
-    #[cfg(feature = "unstable-runtime-stream-share")]
+    #[cfg(feature = "unstable-runtime-stream-control")]
     #[must_use]
     pub fn watches_stream<Other, I>(
         self,
@@ -911,7 +911,7 @@ where
     /// **NB**: This is constructor requires an [`unstable`](https://github.com/kube-rs/kube/blob/main/kube-runtime/Cargo.toml#L17-L21) feature.
     ///
     /// Same as [`Controller::watches_stream`], but accepts a `DynamicType` so it can be used with dynamic resources.
-    #[cfg(feature = "unstable-runtime-stream-share")]
+    #[cfg(feature = "unstable-runtime-stream-control")]
     #[must_use]
     pub fn watches_stream_with<Other, I>(
         mut self,

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -590,7 +590,7 @@ where
     /// [`dynamic`]: kube_client::core::dynamic
     #[cfg(feature = "unstable-runtime-stream-control")]
     pub fn for_stream_with(
-        trigger: impl Stream<Item = Result<Arc<K>, watcher::Error>> + Send + 'static,
+        trigger: impl Stream<Item = Result<K, watcher::Error>> + Send + 'static,
         reader: Store<K>,
         dyntype: K::DynamicType,
     ) -> Self {

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -162,22 +162,16 @@ where
     KOwner: Resource,
     KOwner::DynamicType: Clone,
 {
-    trigger_with(stream, move |obj| {
+    let mapper = move |obj: S::Ok| {
         let meta = obj.meta().clone();
         let ns = meta.namespace;
         let owner_type = owner_type.clone();
-        let child_ref = ObjectRef::from_obj_with(&obj, child_type.clone()).erase();
         meta.owner_references
             .into_iter()
             .flatten()
             .filter_map(move |owner| ObjectRef::from_owner_ref(ns.as_deref(), &owner, owner_type.clone()))
-            .map(move |owner_ref| ReconcileRequest {
-                obj_ref: owner_ref,
-                reason: ReconcileReason::RelatedObjectUpdated {
-                    obj_ref: Box::new(child_ref.clone()),
-                },
-            })
-    })
+    };
+    trigger_others(stream, mapper, child_type)
 }
 
 /// A request to reconcile an object, annotated with why that request was made.

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -808,11 +808,12 @@ where
         mapper: impl Fn(Other) -> I + Sync + Send + 'static,
     ) -> Self
     where
-        Other: Clone + Resource<DynamicType = ()> + DeserializeOwned + Debug + Send + 'static,
+        Other: Clone + Resource + DeserializeOwned + Debug + Send + 'static,
+        Other::DynamicType: Default + Debug + Clone + Eq + Hash,
         I: 'static + IntoIterator<Item = ObjectRef<K>>,
         I::IntoIter: Send,
     {
-        self.watches_with(api, (), wc, mapper)
+        self.watches_with(api, Default::default(), wc, mapper)
     }
 
     /// Specify `Watched` object which `K` has a custom relation to and should be watched
@@ -830,7 +831,7 @@ where
         Other: Clone + Resource + DeserializeOwned + Debug + Send + 'static,
         I: 'static + IntoIterator<Item = ObjectRef<K>>,
         I::IntoIter: Send,
-        Other::DynamicType: Clone,
+        Other::DynamicType: Debug + Clone + Eq + Hash,
     {
         let other_watcher = trigger_with(watcher(api, wc).touched_objects(), move |obj| {
             let watched_obj_ref = ObjectRef::from_obj_with(&obj, dyntype.clone()).erase();
@@ -847,7 +848,7 @@ where
         self
     }
 
-    /// Trigger the reconciliation process for a stream of `Other` objects of the owner `K`
+    /// Trigger the reconciliation process for a stream of `Other` objects related to a `K`
     ///
     /// Same as [`Controller::watches`], but instead of an `Api`, a stream of resources is used.
     /// This allows for customized and pre-filtered watch streams to be used as a trigger,
@@ -893,14 +894,15 @@ where
         mapper: impl Fn(Other) -> I + Sync + Send + 'static,
     ) -> Self
     where
-        Other: Clone + Resource<DynamicType = ()> + DeserializeOwned + Debug + Send + 'static,
+        Other: Clone + Resource + DeserializeOwned + Debug + Send + 'static,
+        Other::DynamicType: Default + Debug + Clone,
         I: 'static + IntoIterator<Item = ObjectRef<K>>,
         I::IntoIter: Send,
     {
-        self.watches_stream_with(trigger, mapper, ())
+        self.watches_stream_with(trigger, mapper, Default::default())
     }
 
-    /// Trigger the reconciliation process for a stream of `Child` objects of the owner `K`
+    /// Trigger the reconciliation process for a stream of `Other` objects related to a `K`
     ///
     /// Same as [`Controller::owns`], but instead of an `Api`, a stream of resources is used.
     /// This allows for customized and pre-filtered watch streams to be used as a trigger,
@@ -918,8 +920,8 @@ where
         dyntype: Other::DynamicType,
     ) -> Self
     where
-        Other: Clone + Resource<DynamicType = ()> + DeserializeOwned + Debug + Send + 'static,
-        Other::DynamicType: Debug + Eq + Hash + Clone,
+        Other: Clone + Resource + DeserializeOwned + Debug + Send + 'static,
+        Other::DynamicType: Debug + Clone,
         I: 'static + IntoIterator<Item = ObjectRef<K>>,
         I::IntoIter: Send,
     {

--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -75,14 +75,18 @@ where
     }
 }
 
+/// Predicate functions for [`WatchStreamExt::predicate_filter`](crate::WatchStreamExt::predicate_filter)
+///
+/// These functions return a hash of commonly compared values to hel decide
+/// whether to pass a watch event along or not.
+///
+/// Functional rewrite of the [controller-runtime/predicate module](https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/predicate/predicate.go).
 pub mod predicates {
     use kube_client::{Resource, ResourceExt};
     use std::{
         collections::hash_map::DefaultHasher,
         hash::{Hash, Hasher},
     };
-
-    // See: https://github.com/kubernetes-sigs/controller-runtime/blob/v0.12.0/pkg/predicate/predicate.go
 
     fn hash<T: Hash>(t: &T) -> u64 {
         let mut hasher = DefaultHasher::new();

--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -77,8 +77,8 @@ where
 
 /// Predicate functions for [`WatchStreamExt::predicate_filter`](crate::WatchStreamExt::predicate_filter)
 ///
-/// These functions return a hash of commonly compared values to hel decide
-/// whether to pass a watch event along or not.
+/// These functions just return a hash of commonly compared values,
+/// to help decide whether to pass a watch event along or not.
 ///
 /// Functional rewrite of the [controller-runtime/predicate module](https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/predicate/predicate.go).
 pub mod predicates {

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -47,7 +47,9 @@ pub trait WatchStreamExt: Stream {
     ///
     /// This will filter out repeat calls where the predicate returns the same result.
     /// Common use case for this is to avoid repeat events for status updates
-    /// by filtering on []`predicates::generation`].
+    /// by filtering on [`predicates::generation`](crate::predicates::generation).
+    ///
+    /// **NB**: This is constructor requires an [`unstable`](https://github.com/kube-rs/kube/blob/main/kube-runtime/Cargo.toml#L17-L21) feature.
     ///
     /// ## Usage
     /// ```no_run
@@ -84,11 +86,13 @@ pub trait WatchStreamExt: Stream {
     /// The [`StreamSubscribe::subscribe()`] method which allows additional consumers
     /// of events from a stream without consuming the stream itself.
     ///
-    /// If a subscriber begins to lag behind the stream, it will receive an [`Error::Lagged`]
+    /// If a subscriber begins to lag behind the stream, it will receive an [`Error::Lagged`](crate::utils::stream_subscribe::Error::Lagged)
     /// error. The subscriber can then decide to abort its task or tolerate the lost events.
     ///
     /// If the [`Stream`] is dropped or ends, any [`StreamSubscribe::subscribe()`] streams
     /// will also end.
+    ///
+    /// **NB**: This is constructor requires an [`unstable`](https://github.com/kube-rs/kube/blob/main/kube-runtime/Cargo.toml#L17-L21) feature.
     ///
     /// ## Warning
     ///

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -508,7 +508,7 @@ where
 ///   runtime::{watcher, WatchStreamExt}
 /// };
 /// use k8s_openapi::api::core::v1::Pod;
-/// use futures::{StreamExt, TryStreamExt};
+/// use futures::TryStreamExt;
 /// #[tokio::main]
 /// async fn main() -> Result<(), watcher::Error> {
 ///     let client = Client::try_default().await.unwrap();
@@ -571,7 +571,7 @@ pub fn watcher<K: Resource + Clone + DeserializeOwned + Debug + Send + 'static>(
 ///   runtime::{watcher, metadata_watcher, WatchStreamExt}
 /// };
 /// use k8s_openapi::api::core::v1::Pod;
-/// use futures::{StreamExt, TryStreamExt};
+/// use futures::TryStreamExt;
 /// #[tokio::main]
 /// async fn main() -> Result<(), watcher::Error> {
 ///     let client = Client::try_default().await.unwrap();


### PR DESCRIPTION
This adds a stream interface analogue for `Controller::new`, that allows the user to create the root `watcher` and `reflector`, outside, and pass in the reader + flattened stream. This is for #1180 as a building block for stream sharing #1080.

In a similar vein, we also add `Controller::watches_stream` as an analogue for `Controller::watches`. That name should be less controversial given we have `Controller::owns_stream`.

### Naming
For now, have named it along the lines of `Controller::for` and highlighted the terminology (noting that `Controller::For` is the [controller-runtime equivalent](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/builder#Builder.For)).

However, there may be some better alternatives. Previously suggested:

- `Controller::from_stream` - original plan, but that was before we needed to pass in the `reader` - so not a clean `From`
- `Controller::new_stream` - awkward, suggests we are creating a new stream?
- `Controller::new_from_stream` - very long, and leads to the obscene `::new_from_stream_with`
- `Controller::new_with` - taken by the dynamic variant
- `Controller::new_via` - also awkward in combination with `::new_via_with`

Feel like realistically it's between `Controller::for_stream` and `Controller::from_stream`.

### Docs Fixes + Unstable Feature Consolidation

Also fixes up bad doc setups and ensures unstable features are highlighted, even though they appear in the middle of a trait (i am not convinced it will show up correctly on docs.rs so being a little careful first time).

The owns-stream unstable flagged is moved to `unstable-runtime-stream-share`, which now also contains this new method.

### Consequences
When using `unstable-runtime`, we can actually use `metadata_watcher` with all `Controller` input interfaces.
Tested on a controller running several controller loops on a large cluster with thousands of pods and saw a >2x memory drop (449MB -> 210MB from a smaller core controller reflector passed in), and significant bandwidth reduction as well (230kB/s -> 30kB/s TX, 20kB/s -> 13kB/s RX but that's partially from using predicates).

### Stream Sharing
Currently this interface does not work with `WatchStreamExt::stream_subscribe` because of the lack of `Arc<K>` in our interfaces. I want to change this long term, but this also involves adding `Arc` on everything internal to `Controller`, but I think that's OK. These new interfaces are unstable, and streams are otherwise constructed internally and could be arc'd up therein.

We already `Arc`-wrap before calling out to `reconcile` and `error_policy` so it would be nice to just have `watcher` (or a method in `WatchStreamExt` do this. Leaving this for a separate PR though.