### PR TITLE
Fix `WatchParams` bookmarks for `watch_metadata`

### DIFF
--- a/kube-core/src/admission.rs
+++ b/kube-core/src/admission.rs
@@ -77,7 +77,7 @@ impl<T: Resource> TryInto<AdmissionRequest<T>> for AdmissionReview<T> {
 /// In an admission controller scenario, this is extracted from an [`AdmissionReview`] via [`TryInto`]
 ///
 /// ```no_run
-/// use kube::api::{admission::{AdmissionRequest, AdmissionReview}, DynamicObject};
+/// use kube::core::{admission::{AdmissionRequest, AdmissionReview}, DynamicObject};
 ///
 /// // The incoming AdmissionReview received by the controller.
 /// let body: AdmissionReview<DynamicObject> = todo!();
@@ -205,9 +205,9 @@ pub enum Operation {
 /// An outgoing [`AdmissionReview`] response. Constructed from the corresponding
 /// [`AdmissionRequest`].
 /// ```no_run
-/// use kube::api::{
-///         admission::{AdmissionRequest, AdmissionResponse, AdmissionReview},
-///         DynamicObject,
+/// use kube::core::{
+///     admission::{AdmissionRequest, AdmissionResponse, AdmissionReview},
+///     DynamicObject,
 /// };
 ///
 /// // The incoming AdmissionReview received by the controller.

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -89,6 +89,7 @@ impl ListParams {
         }
         Ok(())
     }
+
     // Partially populate query parameters (needs resourceVersion out of band)
     pub(crate) fn populate_qp(&self, qp: &mut form_urlencoded::Serializer<String>) {
         if let Some(fields) = &self.field_selector {

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -89,6 +89,34 @@ impl ListParams {
         }
         Ok(())
     }
+    // Partially populate query parameters (needs resourceVersion out of band)
+    pub(crate) fn populate_qp(&self, qp: &mut form_urlencoded::Serializer<String>) {
+        if let Some(fields) = &self.field_selector {
+            qp.append_pair("fieldSelector", fields);
+        }
+        if let Some(labels) = &self.label_selector {
+            qp.append_pair("labelSelector", labels);
+        }
+        if let Some(limit) = &self.limit {
+            qp.append_pair("limit", &limit.to_string());
+        }
+        if let Some(continue_token) = &self.continue_token {
+            qp.append_pair("continue", continue_token);
+        }
+
+        if let Some(rv) = &self.resource_version {
+            qp.append_pair("resourceVersion", rv.as_str());
+        }
+        match &self.version_match {
+            None => {}
+            Some(VersionMatch::NotOlderThan) => {
+                qp.append_pair("resourceVersionMatch", "NotOlderThan");
+            }
+            Some(VersionMatch::Exact) => {
+                qp.append_pair("resourceVersionMatch", "Exact");
+            }
+        }
+    }
 }
 
 /// Builder interface to ListParams
@@ -252,6 +280,24 @@ impl WatchParams {
             }
         }
         Ok(())
+    }
+
+    // Partially populate query parameters (needs resourceVersion out of band)
+    pub(crate) fn populate_qp(&self, qp: &mut form_urlencoded::Serializer<String>) {
+        qp.append_pair("watch", "true");
+
+        // https://github.com/kubernetes/kubernetes/issues/6513
+        qp.append_pair("timeoutSeconds", &self.timeout.unwrap_or(290).to_string());
+
+        if let Some(fields) = &self.field_selector {
+            qp.append_pair("fieldSelector", fields);
+        }
+        if let Some(labels) = &self.label_selector {
+            qp.append_pair("labelSelector", labels);
+        }
+        if self.bookmarks {
+            qp.append_pair("allowWatchBookmarks", "true");
+        }
     }
 }
 


### PR DESCRIPTION
Intended to factor out `populate_qp` from `ListParams` and do the same in `WatchParams`, but accidentally found a place where the duplication caused a split.

This brings the query param serialization in line for all variants of list, and does the same for all variants of watch (where the inconsistency was wound).