### PR TITLE
Create APIResource from ApiResource for extension an APIService

### DIFF
--- a/kube-core/src/discovery.rs
+++ b/kube-core/src/discovery.rs
@@ -61,10 +61,11 @@ impl ApiResource {
 impl Into<APIResource> for ApiResource {
     fn into(self) -> APIResource {
         APIResource {
-            group: Option::from(self.group),
+            group: Some(self.group),
             kind: self.kind,
             version: Option::from(self.api_version),
             namespaced: true,
+            name: self.plural,
             verbs: vec!["list".to_string(), "get".to_string()],
             ..Default::default()
         }
@@ -217,4 +218,30 @@ fn test_to_plural_native() {
     for (kind, plural) in native_kinds {
         assert_eq!(to_plural(&kind.to_ascii_lowercase()), plural);
     }
+}
+
+#[test]
+fn api_resource_into_k8s_open_api_api_resource() {
+    let api_resource = ApiResource {
+        group: "apps".to_string(),
+        version: "v1".to_string(),
+        api_version: "apps/v1".to_string(),
+        kind: "Deployment".to_string(),
+        plural: "deployments".to_string(),
+    };
+    assert_eq!(
+        k8s_openapi::apimachinery::pkg::apis::meta::v1::APIResource {
+            categories: None,
+            group: Some("apps".to_string()),
+            kind: "Deployment".to_string(),
+            name: "deployments".to_string(),
+            namespaced: true,
+            short_names: None,
+            singular_name: "".to_string(),
+            storage_version_hash: None,
+            verbs: vec!["list".to_string(), "get".to_string()],
+            version: Some("apps/v1".to_string())
+        },
+        api_resource.into()
+    );
 }

--- a/kube-core/src/discovery.rs
+++ b/kube-core/src/discovery.rs
@@ -1,5 +1,6 @@
 //! Type information structs for API discovery
 use crate::{gvk::GroupVersionKind, resource::Resource};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::APIResource;
 use serde::{Deserialize, Serialize};
 
 /// Information about a Kubernetes API resource
@@ -54,6 +55,19 @@ impl ApiResource {
     /// to explicitly set the plural, or run api discovery on it via `kube::discovery`.
     pub fn from_gvk(gvk: &GroupVersionKind) -> Self {
         ApiResource::from_gvk_with_plural(gvk, &to_plural(&gvk.kind.to_ascii_lowercase()))
+    }
+}
+
+impl Into<APIResource> for ApiResource {
+    fn into(self) -> APIResource {
+        APIResource {
+            group: Option::from(self.group),
+            kind: self.kind,
+            version: Option::from(self.api_version),
+            namespaced: true,
+            verbs: vec!["list".to_string(), "get".to_string()],
+            ..Default::default()
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
Tries to address https://github.com/kube-rs/kube/issues/1194
 This seems too easy that I am sure this is not what you had in mind. What did you have in mind?

1. they have one version, while kube-rs has api_version and version.   I am guessing we need to match `version` with kube-rs’s `api-version`.
2. hard coding `verbs` with `vec!["list".to_string(), "get".to_string()],` feels wrong, is that okay?
> The example above is converting using the Resource trait, but that is actually insufficient (hence the manually supplied verbs).

So, I guess it's okay

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
