### PR TITLE
`watcher::Config`: Derive `Clone` + `Debug` + `PartialEq`

### DIFF
--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -181,6 +181,7 @@ pub enum ListSemantic {
 }
 
 /// Accumulates all options that can be used on the watcher invocation.
+#[derive(Clone, Debug, PartialEq)]
 pub struct Config {
     /// A selector to restrict the list of returned objects by their labels.
     ///


### PR DESCRIPTION
fixes #1205
`Default` is manually implemented from before.