### PR TITLE
Swap `dirs-next` dependency to cargo-team maintained `home` crate

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -25,7 +25,7 @@ gzip = ["client", "tower-http/decompression-gzip"]
 client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath_lib", "bytes", "futures", "tokio", "tokio-util", "either"]
 jsonpatch = ["kube-core/jsonpatch"]
 admission = ["kube-core/admission"]
-config = ["__non_core", "pem", "dirs"]
+config = ["__non_core", "pem", "home"]
 
 # private feature sets; do not use
 __non_core = ["tracing", "serde_yaml", "base64"]
@@ -38,7 +38,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 base64 = { version = "0.20.0", optional = true }
 chrono = { version = "0.4.23", optional = true, default-features = false }
-dirs = { package = "dirs-next", optional = true, version = "2.0.0" }
+home = { version = "0.5.4", optional = true }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = { version = "0.9.19", optional = true }

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -555,8 +555,7 @@ fn ensure_trailing_newline(mut data: Vec<u8>) -> Vec<u8> {
 
 /// Returns kubeconfig path from `$HOME/.kube/config`.
 fn default_kube_path() -> Option<PathBuf> {
-    use dirs::home_dir;
-    home_dir().map(|h| h.join(".kube").join("config"))
+    home::home_dir().map(|h| h.join(".kube").join("config"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

`dirs` is an unnecessarily big dependency for a single function

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Use the smaller, cargo-team maintained `home` crate

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
