### PR TITLE
Swap `validator` for `garde`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,7 +25,7 @@ latest = ["k8s-openapi/v1_26"]
 [dev-dependencies]
 tokio-util = "0.7.0"
 assert-json-diff = "2.0.1"
-validator = { version = "0.16.0", features = ["derive"] }
+garde = { version = "0.11.2", features = ["derive"] }
 anyhow = "1.0.44"
 futures = "0.3.17"
 jsonpath_lib = "0.3.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,7 +25,7 @@ latest = ["k8s-openapi/v1_26"]
 [dev-dependencies]
 tokio-util = "0.7.0"
 assert-json-diff = "2.0.1"
-garde = { version = "0.11.2", features = ["derive"] }
+garde = { version = "0.11.2", default-features = false, features = ["derive"] }
 anyhow = "1.0.44"
 futures = "0.3.17"
 jsonpath_lib = "0.3.0"

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -22,7 +22,7 @@ use kube::{
 #[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
 #[kube(printcolumn = r#"{"name":"Team", "jsonPath": ".spec.metadata.team", "type": "string"}"#)]
 pub struct FooSpec {
-    #[validate(length(min = 3))]
+    #[schemars(length(min = 3))]
     #[garde(length(min = 3))]
     name: String,
     #[garde(skip)]

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -1,12 +1,12 @@
 use anyhow::{bail, Result};
 use either::Either::{Left, Right};
+use garde::Validate;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::*;
-use validator::Validate;
 
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::{
@@ -23,8 +23,11 @@ use kube::{
 #[kube(printcolumn = r#"{"name":"Team", "jsonPath": ".spec.metadata.team", "type": "string"}"#)]
 pub struct FooSpec {
     #[validate(length(min = 3))]
+    #[garde(length(min = 3))]
     name: String,
+    #[garde(skip)]
     info: String,
+    #[garde(skip)]
     replicas: i32,
 }
 
@@ -201,7 +204,7 @@ async fn main() -> Result<()> {
         replicas: 1,
     });
     // using derived Validate rules locally:
-    assert!(fx.spec.validate().is_err());
+    assert!(fx.spec.validate(&()).is_err());
     // check rejection from apiserver (validation rules embedded in JsonSchema)
     match foos.create(&pp, &fx).await {
         Err(kube::Error::Api(ae)) => {

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -31,7 +31,7 @@ serde_yaml = "0.9.19"
 kube = { path = "../kube", version = "<1.0.0, >=0.61.0", features = ["derive", "client"] }
 k8s-openapi = { version = "0.18.0", default-features = false, features = ["v1_26"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
-garde = { version = "0.11.2", features = ["derive"] }
+garde = { version = "0.11.2", default-features = false, features = ["derive"] }
 chrono = { version = "0.4.19", default-features = false }
 trybuild = "1.0.48"
 assert-json-diff = "2.0.2"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -31,7 +31,6 @@ serde_yaml = "0.9.19"
 kube = { path = "../kube", version = "<1.0.0, >=0.61.0", features = ["derive", "client"] }
 k8s-openapi = { version = "0.18.0", default-features = false, features = ["v1_26"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
-garde = { version = "0.11.2", default-features = false, features = ["derive"] }
 chrono = { version = "0.4.19", default-features = false }
 trybuild = "1.0.48"
 assert-json-diff = "2.0.2"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -31,7 +31,7 @@ serde_yaml = "0.9.19"
 kube = { path = "../kube", version = "<1.0.0, >=0.61.0", features = ["derive", "client"] }
 k8s-openapi = { version = "0.18.0", default-features = false, features = ["v1_26"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
-validator = { version = "0.16.0", features = ["derive"] }
+garde = { version = "0.11.2", features = ["derive"] }
 chrono = { version = "0.4.19", default-features = false }
 trybuild = "1.0.48"
 assert-json-diff = "2.0.2"

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -147,9 +147,8 @@ mod custom_resource;
 /// use serde::{Serialize, Deserialize};
 /// use kube_derive::CustomResource;
 /// use schemars::JsonSchema;
-/// use garde::Validate;
 ///
-/// #[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone, Validate, JsonSchema)]
+/// #[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
 /// #[kube(
 ///     group = "clux.dev",
 ///     version = "v1",
@@ -166,10 +165,8 @@ mod custom_resource;
 /// )]
 /// #[serde(rename_all = "camelCase")]
 /// struct FooSpec {
-///     #[validate(length(min = 3))]
-///     #[garde(length(min = 3))]
+///     #[schemars(length(min = 3))]
 ///     data: String,
-///     #[garde(skip)]
 ///     replicas_count: i32
 /// }
 ///
@@ -215,7 +212,6 @@ mod custom_resource;
 /// - [Serde/Schemars Attributes](https://graham.cool/schemars/examples/3-schemars_attrs/) (no need to duplicate serde renames)
 /// - [`#[schemars(schema_with = "func")]`](https://graham.cool/schemars/examples/7-custom_serialization/) (e.g. like in the [`crd_derive` example](https://github.com/kube-rs/kube/blob/main/examples/crd_derive.rs))
 /// - `impl JsonSchema` on a type / newtype around external type. See [#129](https://github.com/kube-rs/kube/issues/129#issuecomment-750852916)
-/// - [`#[validate(...)]` field attributes based on the validator crate](https://github.com/Keats/validator) for kubebuilder style validation rules (see [`crd_api` example](https://github.com/kube-rs/kube/blob/main/examples/crd_api.rs))
 /// - [`#[garde(...)]` field attributes for client-side validation](https://github.com/jprochazk/garde) (see [`crd_api`
 /// example](https://github.com/kube-rs/kube/blob/main/examples/crd_api.rs))
 ///
@@ -233,8 +229,8 @@ mod custom_resource;
 /// - **adding validation** via [validator crate](https://github.com/Keats/validator) is supported from `schemars` >= [`0.8.5`](https://github.com/GREsau/schemars/blob/master/CHANGELOG.md#085---2021-09-20)
 /// - **generating rust code from schemas** can be done via [kopium](https://github.com/kube-rs/kopium) and is supported on stable crds (> 1.16 kubernetes)
 ///
-/// ## Validation Caveats
-/// There are two main ways of doing validation; **server-side** (embedding validation attributes into the schema for the apiserver to respect), and **client-side** (provides validate() methods in your code).
+/// ## Schema Validation
+/// There are two main ways of doing validation; **server-side** (embedding validation attributes into the schema for the apiserver to respect), and **client-side** (provides `validate()` methods in your code).
 ///
 /// Client side validation of structs can be achieved by hooking up `#[garde]` attributes in your struct and is a replacement of the now unmaintained [`validator`](https://github.com/Keats/validator/issues/201) crate.
 /// Server-side validation require mutation of your generated schema, and can in the basic cases be achieved through the use of `schemars`'s [validation attributes](https://graham.cool/schemars/deriving/attributes/#supported-validator-attributes).
@@ -242,8 +238,9 @@ mod custom_resource;
 ///
 /// When using `garde` directly, you must add it to your dependencies (with the `derive` feature).
 ///
+/// ### Validation Caveats
 /// Make sure your validation rules are static and handled by `schemars`:
-/// - validations from `#[validate(custom = "some_fn")]` will not show up in the schema.
+/// - validations from `#[garde(custom(my_func))]` will not show up in the schema.
 /// - similarly; [nested / must_match / credit_card were unhandled by schemars at time of writing](https://github.com/GREsau/schemars/pull/78)
 /// - encoding validations specified through garde (i.e. #[garde(ascii)]), are currently not supported by schemars
 /// - to validate required attributes client-side, garde requires a custom validation function (`#[garde(custom(my_required_check))]`)

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -50,7 +50,6 @@ default-features = false
 [dev-dependencies]
 tokio = { version = "1.14.0", features = ["full"] }
 futures = "0.3.17"
-garde = { version = "0.11.2", default-features = false, features = ["derive"] }
 serde_json = "1.0.68"
 serde = { version = "1.0.130", features = ["derive"] }
 schemars = "0.8.6"

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -50,8 +50,8 @@ default-features = false
 [dev-dependencies]
 tokio = { version = "1.14.0", features = ["full"] }
 futures = "0.3.17"
+garde = { version = "0.11.2", features = ["derive"] }
 serde_json = "1.0.68"
-validator = { version = "0.16.0", features = ["derive"] }
 serde = { version = "1.0.130", features = ["derive"] }
 schemars = "0.8.6"
 

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -50,7 +50,7 @@ default-features = false
 [dev-dependencies]
 tokio = { version = "1.14.0", features = ["full"] }
 futures = "0.3.17"
-garde = { version = "0.11.2", features = ["derive"] }
+garde = { version = "0.11.2", default-features = false, features = ["derive"] }
 serde_json = "1.0.68"
 serde = { version = "1.0.130", features = ["derive"] }
 schemars = "0.8.6"

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -48,7 +48,6 @@
 //! use schemars::JsonSchema;
 //! use serde::{Deserialize, Serialize};
 //! use serde_json::json;
-//! use garde::Validate;
 //! use futures::{StreamExt, TryStreamExt};
 //! use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 //! use kube::{
@@ -59,15 +58,12 @@
 //! };
 //!
 //! // Our custom resource
-//! #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, Validate, JsonSchema)]
+//! #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
 //! #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 //! pub struct FooSpec {
-//!     #[garde(skip)]
 //!     info: String,
-//!     #[validate(length(min = 3))]
-//!     #[garde(length(min = 3))]
+//!     #[schemars(length(min = 3))]
 //!     name: String,
-//!     #[garde(skip)]
 //!     replicas: i32,
 //! }
 //!

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -48,7 +48,7 @@
 //! use schemars::JsonSchema;
 //! use serde::{Deserialize, Serialize};
 //! use serde_json::json;
-//! use validator::Validate;
+//! use garde::Validate;
 //! use futures::{StreamExt, TryStreamExt};
 //! use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 //! use kube::{
@@ -62,9 +62,12 @@
 //! #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, Validate, JsonSchema)]
 //! #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 //! pub struct FooSpec {
+//!     #[garde(skip)]
 //!     info: String,
 //!     #[validate(length(min = 3))]
+//!     #[garde(length(min = 3))]
 //!     name: String,
+//!     #[garde(skip)]
 //!     replicas: i32,
 //! }
 //!


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

The validator crate used in the derive docs and in the crd example is no longer actively maintained. It has been superseded by garde which offers similar functionality.

Fixes #1197 (check issue for additional context)
<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

This change replaces validator with garde in dev dependencies (and in the crd_api example dependency). Although garde has the same derive macro, its attribute differs from validator, and it additionally requires fields to be explictly skipped from validation, and does not offer a built-in way to validate required fields.

Changes have been made to the kube_derive crate's docs to both replace existing mentions of validator, and inform on the caveats mentioned above.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
