### PR TITLE
Introduce `GetParams` support

### DIFF
--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -32,9 +32,7 @@ where
     /// This function assumes that the object is expected to always exist, and returns [`Error`] if it does not.
     /// Consider using [`Api::get_opt`] if you need to handle missing objects.
     pub async fn get(&self, name: &str) -> Result<K> {
-        let mut req = self.request.get(name).map_err(Error::BuildRequest)?;
-        req.extensions_mut().insert("get");
-        self.client.request::<K>(req).await
+        self.get_with(name, &GetParams::default()).await
     }
 
     ///  Get only the metadata for a named resource as [`PartialObjectMeta`]
@@ -58,7 +56,64 @@ where
     /// This function assumes that the object is expected to always exist, and returns [`Error`] if it does not.
     /// Consider using [`Api::get_metadata_opt`] if you need to handle missing objects.
     pub async fn get_metadata(&self, name: &str) -> Result<PartialObjectMeta<K>> {
-        let mut req = self.request.get_metadata(name).map_err(Error::BuildRequest)?;
+        self.get_metadata_with(name, &GetParams::default()).await
+    }
+
+    /// [Get](`Api::get`) a named resource with an explicit resourceVersion
+    ///
+    /// This function allows the caller to pass in a [`GetParams`](`kube::api::GetParams`) type containing
+    /// a `resourceVersion` to a [Get](`Api::get`) call.
+    /// For example
+    ///
+    /// ```no_run
+    /// # use kube::{Api, api::GetParams};
+    /// use k8s_openapi::api::core::v1::Pod;
+    ///
+    /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let client: kube::Client = todo!();
+    /// let pods: Api<Pod> = Api::namespaced(client, "apps");
+    /// let p: Pod = pods.get_with("blog", &GetParams::any()).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// This function assumes that the object is expected to always exist, and returns [`Error`] if it does not.
+    /// Consider using [`Api::get_opt`] if you need to handle missing objects.
+    pub async fn get_with(&self, name: &str, gp: &GetParams) -> Result<K> {
+        let mut req = self.request.get(name, gp).map_err(Error::BuildRequest)?;
+        req.extensions_mut().insert("get");
+        self.client.request::<K>(req).await
+    }
+
+    ///  [Get](`Api::get_metadata`) the metadata of an object using an explicit `resourceVersion`
+    ///
+    /// This function allows the caller to pass in a [`GetParams`](`kube::api::GetParams`) type containing
+    /// a resourceVersion to a [Get](`Api::get_metadata`) call.
+    /// For example
+    ///
+    ///
+    /// ```no_run
+    /// use kube::{Api, api::GetParams, core::PartialObjectMeta};
+    /// use k8s_openapi::api::core::v1::Pod;
+    ///
+    /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let client: kube::Client = todo!();
+    /// let pods: Api<Pod> = Api::namespaced(client, "apps");
+    /// let p: PartialObjectMeta<Pod> = pods.get_metadata("blog", &GetParams::any()).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// Note that the type may be converted to `ObjectMeta` through the usual
+    /// conversion traits.
+    ///
+    /// # Errors
+    ///
+    /// This function assumes that the object is expected to always exist, and returns [`Error`] if it does not.
+    /// Consider using [`Api::get_metadata_opt`] if you need to handle missing objects.
+    pub async fn get_metadata_with(&self, name: &str, gp: &GetParams) -> Result<PartialObjectMeta<K>> {
+        let mut req = self.request.get_metadata(name, gp).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("get_metadata");
         self.client.request::<PartialObjectMeta<K>>(req).await
     }

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -101,7 +101,7 @@ where
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
     /// let pods: Api<Pod> = Api::namespaced(client, "apps");
-    /// let p: PartialObjectMeta<Pod> = pods.get_metadata("blog", &GetParams::any()).await?;
+    /// let p: PartialObjectMeta<Pod> = pods.get_metadata_with("blog", &GetParams::any()).await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -61,7 +61,7 @@ where
 
     /// [Get](`Api::get`) a named resource with an explicit resourceVersion
     ///
-    /// This function allows the caller to pass in a [`GetParams`](`kube::api::GetParams`) type containing
+    /// This function allows the caller to pass in a [`GetParams`](`super::GetParams`) type containing
     /// a `resourceVersion` to a [Get](`Api::get`) call.
     /// For example
     ///
@@ -89,8 +89,8 @@ where
 
     ///  [Get](`Api::get_metadata`) the metadata of an object using an explicit `resourceVersion`
     ///
-    /// This function allows the caller to pass in a [`GetParams`](`kube::api::GetParams`) type containing
-    /// a resourceVersion to a [Get](`Api::get_metadata`) call.
+    /// This function allows the caller to pass in a [`GetParams`](`super::GetParams`) type containing
+    /// a `resourceVersion` to a [Get](`Api::get_metadata`) call.
     /// For example
     ///
     ///

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -34,7 +34,7 @@ pub use kube_core::{
 };
 use kube_core::{DynamicResourceScope, NamespaceResourceScope};
 pub use params::{
-    DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions, PropagationPolicy,
+    DeleteParams, GetParams, ListParams, Patch, PatchParams, PostParams, Preconditions, PropagationPolicy,
     ValidationDirective, VersionMatch, WatchParams,
 };
 

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -207,6 +207,41 @@ impl ListParams {
     }
 }
 
+/// Common query parameters used in get calls
+#[derive(Clone, Debug, Default)]
+pub struct GetParams {
+    /// An explicit resourceVersion with implicit version matching strategies
+    ///
+    /// Default (unset) gives the most recent version. "0" gives a less
+    /// consistent, but more performant "Any" version. Specifing a version is
+    /// like providing a `VersionMatch::NotOlderThan`.
+    /// See <https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions> for details.
+    pub resource_version: Option<String>,
+}
+
+/// Helper interface to GetParams
+///
+/// Usage:
+/// ```
+/// use kube::api::GetParams;
+/// let gp = GetParams::at("6664");
+/// ```
+impl GetParams {
+    /// Sets the resource version, implicitly applying a 'NotOlderThan' match
+    #[must_use]
+    pub fn at(resource_version: &str) -> Self {
+        Self {
+            resource_version: Some(resource_version.into()),
+        }
+    }
+
+    /// Sets the resource version to "0"
+    #[must_use]
+    pub fn any() -> Self {
+        Self::at("0")
+    }
+}
+
 /// The validation directive to use for `fieldValidation` when using server-side apply.
 #[derive(Clone, Debug)]
 pub enum ValidationDirective {


### PR DESCRIPTION
<!-- 
Commit message if yall are squashing and checking this out:

As part of a larger change to support version matching strategies (to reduce I/O pressure), ListParams were separated into List and Watch params. To complete the feature set, this change adds support for `GetParams`, mirroing the upstream client-go layout for the type.

In the context of this change, we added a GetParams struct that does implicit version matching (semantics are quite easy, any = "0", NotOlderThan = specific, non-zero version, and unspecified is most recent). We use the struct in all request methods and in Api core methods. `ListParams` with version matching semantics is used for list_metadata, so the same was done here (extended GetParams to get_metadata and all other asssociated methods) even if it was outside of the scope of the issue.

As part of the change, we also had to change the examples and tests. Since the version was (largely) unspecified, we use the default derived implementation; for tests and examples, this change should be non-functional (unspecified is the same as unset).

This is mostly _not_ a breaking change, however, it does result in a breaking change for the lower level `Request` API.

Fixes #1174
-->

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

As part of a larger change to support version matching strategies (to reduce I/O pressure), ListParams were separated into List and Watch params. To complete the feature set, this change adds support for `GetParams`, mirroing the upstream client-go layout for the type.


<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

In the context of this change, we added a GetParams struct that does implicit version matching (semantics are quite easy, any = "0", NotOlderThan = specific, non-zero version, and unspecified is most recent). We use the struct in all request methods and in Api core methods. `ListParams` with version matching semantics is used for list_metadata, so the same was done here (extended GetParams to get_metadata and all other asssociated methods) even if it was outside of the scope of the issue.

As part of the change, we also had to change the examples and tests. Since the version was (largely) unspecified, we use the default derived implementation; for tests and examples, this change should be non-functional (unspecified is the same as unset).

This is a breaking change.

Fixes #1174
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->


---

I didn't see any other way than changing the method signatures (`get`, `get_opt`, `entry` and all other metadata methods). It's a pity it's a breaking change but better than duplicating everything imo.