### PR TITLE
fix: `#[kube(crates(serde = "some_crate::serde"))]` was not working

### DIFF
--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -1,5 +1,6 @@
 use darling::{FromDeriveInput, FromMeta};
-use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro2::{Ident, Literal, Span, TokenStream};
+use quote::ToTokens;
 use syn::{parse_quote, Data, DeriveInput, Path, Visibility};
 
 /// Values we can parse from #[kube(attrs)]
@@ -239,12 +240,14 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
     }
 
     let docstr = format!(" Auto-generated derived type for {ident} via `CustomResource`");
+    let quoted_serde = Literal::string(&serde.to_token_stream().to_string());
     let root_obj = quote! {
         #[doc = #docstr]
         #[automatically_derived]
         #[allow(missing_docs)]
         #[derive(#(#derive_paths),*)]
         #[serde(rename_all = "camelCase")]
+        #[serde(crate = #quoted_serde)]
         #visibility struct #rootident {
             #schemars_skip
             #visibility metadata: #k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

`#[kube(crates(serde = "some_crate::serde"))]`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

<del> - Usage of `serde` should be interpolated as `#serde` </del>
- `#[serde(crate = "some_crate::serde")]` should be added to generated struct

Not sure how to add a test becaues `kube-derive` already depends on `serde`.

We can probably add another crate just for testing. Not sure if that's overshoot.