### PR TITLE
Fix ```apply```  Action within Example ```kubectl```

### DIFF
--- a/examples/kubectl.rs
+++ b/examples/kubectl.rs
@@ -163,7 +163,7 @@ impl App {
             std::fs::read_to_string(&pth).with_context(|| format!("Failed to read {}", pth.display()))?;
         for doc in multidoc_deserialize(&yaml)? {
             let obj: DynamicObject = serde_yaml::from_value(doc)?;
-            let namespace = obj.metadata.namespace.clone().or_else(|| self.namespace.clone();
+            let namespace = obj.metadata.namespace.clone().or_else(|| self.namespace.clone());
             let gvk = if let Some(tm) = &obj.types {
                 GroupVersionKind::try_from(tm)?
             } else {

--- a/examples/kubectl.rs
+++ b/examples/kubectl.rs
@@ -163,13 +163,7 @@ impl App {
             std::fs::read_to_string(&pth).with_context(|| format!("Failed to read {}", pth.display()))?;
         for doc in multidoc_deserialize(&yaml)? {
             let obj: DynamicObject = serde_yaml::from_value(doc)?;
-            let namespace = {
-                if let Some(ns) = obj.metadata.namespace.clone() {
-                    Some(ns)
-                } else {
-                    self.namespace.clone()
-                }
-            };
+            let namespace = obj.metadata.namespace.clone().or_else(|| self.namespace.clone();
             let gvk = if let Some(tm) = &obj.types {
                 GroupVersionKind::try_from(tm)?
             } else {


### PR DESCRIPTION
## Motivation
Fix the example of ```kubectl```,
When used ```apply```  action, it will not inference the ```metadata.namespace``` within user provided resource yaml file,
So, it will got the mismatch namespace, error message below here

```
Error: ApiError: the namespace of the provided object does not match the namespace sent on the request: BadRequest (ErrorResponse { status: "Failure", message: "the namespace of the provided object does not match the namespace sent on the request", reason: "BadRequest", code: 400 })
```
Exactly says, the Api<K> is link Namespace with ```default```, but deploy resource is used  ```metadata.namespace``` Field, which designed in yaml file, to deploy/apply resource to target ```Namespace```.

## Solution

Adding the ```namespace``` with ```DynamicObject``` Type Namespace, whole depacked with field ```metadata.namespace``` has value ```Option<String>```, use it  to inference ```Api<K>``` used which namespace.

When user provided yaml file of setting namespace, will used Field of ```metadate.namespace```, if not setting (got ```None``` Type) will use the```kubectl -n <Namespace>``` within ```kubectl``` APP.