### PR TITLE
Add `predicates::resource_version`

### DIFF
--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -99,6 +99,11 @@ pub mod predicates {
         obj.meta().generation.map(|g| hash(&g))
     }
 
+    /// Hash the resource version of a Resource K
+    pub fn resource_version<K: Resource>(obj: &K) -> Option<u64> {
+        obj.meta().resource_version.as_ref().map(|rv| hash(rv))
+    }
+
     /// Hash the labels of a Resource K
     pub fn labels<K: Resource>(obj: &K) -> Option<u64> {
         Some(hash(obj.labels()))

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -56,17 +56,17 @@ pub trait WatchStreamExt: Stream {
     /// # use futures::{pin_mut, Stream, StreamExt, TryStreamExt};
     /// use kube::{Api, Client, ResourceExt};
     /// use kube_runtime::{watcher, WatchStreamExt, predicates};
-    /// use k8s_openapi::api::core::v1::Pod;
+    /// use k8s_openapi::api::apps::v1::Deployment;
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
-    /// let pods: Api<Pod> = Api::default_namespaced(client);
-    /// let changed_pods = watcher(pods, watcher::Config::default())
+    /// let deploys: Api<Deployment> = Api::default_namespaced(client);
+    /// let changed_deploys = watcher(deploys, watcher::Config::default())
     ///     .applied_objects()
     ///     .predicate_filter(predicates::generation);
-    /// pin_mut!(changed_pods);
+    /// pin_mut!(changed_deploys);
     ///
-    /// while let Some(pod) = changed_pods.try_next().await? {
-    ///    println!("saw Pod '{} with hitherto unseen generation", pod.name_any());
+    /// while let Some(d) = changed_deploys.try_next().await? {
+    ///    println!("saw Deployment '{} with hitherto unseen generation", d.name_any());
     /// }
     /// # Ok(())
     /// # }


### PR DESCRIPTION
This adds a resource_version predicate helper for things that cannot use `predicates::generation` like pods (which do not set the .medata.generation).

We also change the default example to use deployments, as these can make use of the `predicates::generation` fn by default.