### PR TITLE
Add `predicates::resource_version`

### DIFF
--- a/kube-client/src/api/util/mod.rs
+++ b/kube-client/src/api/util/mod.rs
@@ -60,7 +60,7 @@ impl Api<ServiceAccount> {
 // Tests that require a cluster and the complete feature set
 // Can be run with `cargo test -p kube-client --lib -- --ignored`
 #[cfg(test)]
-#[cfg(all(feature = "client"))]
+#[cfg(feature = "client")]
 mod test {
     use crate::{
         api::{Api, DeleteParams, ListParams, PostParams},

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -149,7 +149,7 @@ mod test {
     #[cfg(feature = "when_rustls_works_with_k3d")]
     #[tokio::test]
     #[ignore = "needs cluster (lists pods)"]
-    #[cfg(all(feature = "rustls-tls"))]
+    #[cfg(feature = "rustls-tls")]
     async fn custom_client_rustls_configuration() -> Result<(), Box<dyn std::error::Error>> {
         let config = Config::infer().await?;
         let https = config.rustls_https_connector()?;
@@ -164,7 +164,7 @@ mod test {
 
     #[tokio::test]
     #[ignore = "needs cluster (lists pods)"]
-    #[cfg(all(feature = "openssl-tls"))]
+    #[cfg(feature = "openssl-tls")]
     async fn custom_client_openssl_tls_configuration() -> Result<(), Box<dyn std::error::Error>> {
         let config = Config::infer().await?;
         let https = config.openssl_https_connector()?;
@@ -179,7 +179,7 @@ mod test {
 
     #[tokio::test]
     #[ignore = "needs cluster (lists api resources)"]
-    #[cfg(all(feature = "discovery"))]
+    #[cfg(feature = "discovery")]
     async fn group_discovery_oneshot() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{core::DynamicObject, discovery};
         let client = Client::try_default().await?;
@@ -273,7 +273,7 @@ mod test {
 
     #[tokio::test]
     #[ignore = "needs cluster (will create and attach to a pod)"]
-    #[cfg(all(feature = "ws"))]
+    #[cfg(feature = "ws")]
     async fn pod_can_exec_and_write_to_stdin() -> Result<(), Box<dyn std::error::Error>> {
         use crate::api::{DeleteParams, ListParams, Patch, PatchParams, WatchEvent};
 

--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -99,6 +99,11 @@ pub mod predicates {
         obj.meta().generation.map(|g| hash(&g))
     }
 
+    /// Hash the resource version of a Resource K
+    pub fn resource_version<K: Resource>(obj: &K) -> Option<u64> {
+        obj.meta().resource_version.as_ref().map(|rv| hash(rv))
+    }
+
     /// Hash the labels of a Resource K
     pub fn labels<K: Resource>(obj: &K) -> Option<u64> {
         Some(hash(obj.labels()))

--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -101,7 +101,7 @@ pub mod predicates {
 
     /// Hash the resource version of a Resource K
     pub fn resource_version<K: Resource>(obj: &K) -> Option<u64> {
-        obj.meta().resource_version.as_ref().map(|rv| hash(rv))
+        obj.meta().resource_version.as_ref().map(hash)
     }
 
     /// Hash the labels of a Resource K

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -56,17 +56,17 @@ pub trait WatchStreamExt: Stream {
     /// # use futures::{pin_mut, Stream, StreamExt, TryStreamExt};
     /// use kube::{Api, Client, ResourceExt};
     /// use kube_runtime::{watcher, WatchStreamExt, predicates};
-    /// use k8s_openapi::api::core::v1::Pod;
+    /// use k8s_openapi::api::apps::v1::Deployment;
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
-    /// let pods: Api<Pod> = Api::default_namespaced(client);
-    /// let changed_pods = watcher(pods, watcher::Config::default())
+    /// let deploys: Api<Deployment> = Api::default_namespaced(client);
+    /// let changed_deploys = watcher(deploys, watcher::Config::default())
     ///     .applied_objects()
     ///     .predicate_filter(predicates::generation);
-    /// pin_mut!(changed_pods);
+    /// pin_mut!(changed_deploys);
     ///
-    /// while let Some(pod) = changed_pods.try_next().await? {
-    ///    println!("saw Pod '{} with hitherto unseen generation", pod.name_any());
+    /// while let Some(d) = changed_deploys.try_next().await? {
+    ///    println!("saw Deployment '{} with hitherto unseen generation", d.name_any());
     /// }
     /// # Ok(())
     /// # }

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -356,7 +356,7 @@ mod test {
 
     #[tokio::test]
     #[ignore = "needs cluster (fetches api resources, and lists all)"]
-    #[cfg(all(feature = "derive"))]
+    #[cfg(feature = "derive")]
     async fn derived_resources_discoverable() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{
             core::{DynamicObject, GroupVersion, GroupVersionKind},
@@ -432,7 +432,7 @@ mod test {
 
     #[tokio::test]
     #[ignore = "needs cluster (will create await a pod)"]
-    #[cfg(all(feature = "runtime"))]
+    #[cfg(feature = "runtime")]
     async fn pod_can_await_conditions() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{
             api::{DeleteParams, PostParams},


### PR DESCRIPTION
This adds a resource_version predicate helper for things that cannot use `predicates::generation` like pods (which do not set the .medata.generation).

This predicate also exists upstream in https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/predicate/predicate.go#L127

We also change the default example to use deployments, as these can make use of the `predicates::generation` fn by default.