### PR TITLE
Command Pattern

### DIFF
--- a/kube-client/src/command/command.rs
+++ b/kube-client/src/command/command.rs
@@ -1,0 +1,257 @@
+use k8s_openapi::serde_value::Value;
+use kube_core::params::{DeleteParams, Patch, PatchParams, PostParams};
+use kube_core::{ApiResource, DynamicObject, Resource};
+use serde::Serialize;
+use std::fmt::{Display, Formatter};
+use std::option::Option::None;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct KubeCommand {
+    pub namespace: Option<String>,
+    pub verb: KubeCommandVerb,
+}
+
+impl KubeCommand {
+    pub fn cluster(command: KubeCommandVerb) -> KubeCommand {
+        Self {
+            namespace: None,
+            verb: command,
+        }
+    }
+
+    pub fn namespaced(namespace: &str, command: KubeCommandVerb) -> KubeCommand {
+        Self {
+            namespace: Some(namespace.to_string()),
+            verb: command,
+        }
+    }
+
+    pub fn api_resource(&self) -> ApiResource {
+        self.verb.api_resource()
+    }
+
+    pub fn kind(&self) -> String {
+        self.verb.kind()
+    }
+
+    pub fn name(&self) -> String {
+        self.verb.name()
+    }
+
+    pub fn namespace(&self) -> Option<String> {
+        self.namespace.clone()
+    }
+
+    pub fn verb_name(&self) -> String {
+        self.verb.verb_name()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum KubeCommandVerb {
+    Create {
+        name: String,
+        object: Box<DynamicObject>,
+        resource: ApiResource,
+        params: PostParams,
+    },
+    Replace {
+        name: String,
+        object: Box<DynamicObject>,
+        resource: ApiResource,
+        params: PostParams,
+    },
+    ReplaceStatus {
+        name: String,
+        data: Vec<u8>,
+        resource: ApiResource,
+        params: PostParams,
+    },
+    Patch {
+        name: String,
+        patch: Patch<Value>,
+        resource: ApiResource,
+        params: PatchParams,
+    },
+    PatchStatus {
+        name: String,
+        patch: Patch<Value>,
+        resource: ApiResource,
+        params: PatchParams,
+    },
+    Delete {
+        name: String,
+        resource: ApiResource,
+        params: DeleteParams,
+    },
+}
+
+impl Display for KubeCommandVerb {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!("{}: {}/{}", self.verb_name(), self.kind(), self.name()))
+    }
+}
+
+impl KubeCommandVerb {
+    pub fn create<K: Resource + Serialize>(
+        name: String,
+        resource: K,
+        params: PostParams,
+    ) -> Result<KubeCommandVerb, serde_json::Error>
+    where
+        K::DynamicType: Default,
+    {
+        let mut dynamic_object = DynamicObject::new(&name, &ApiResource::erase::<K>(&Default::default()));
+
+        dynamic_object.metadata = resource.meta().clone();
+        dynamic_object.data = serde_json::to_value(resource)?;
+
+        Ok(KubeCommandVerb::Create {
+            name,
+            object: Box::new(dynamic_object),
+            resource: ApiResource::erase::<K>(&Default::default()),
+            params,
+        })
+    }
+
+    pub fn replace<K: Resource + Serialize>(
+        name: String,
+        resource: K,
+        params: PostParams,
+    ) -> Result<KubeCommandVerb, serde_json::Error>
+    where
+        K::DynamicType: Default,
+    {
+        let mut dynamic_object = DynamicObject::new(&name, &ApiResource::erase::<K>(&Default::default()));
+
+        dynamic_object.metadata = resource.meta().clone();
+        dynamic_object.data = serde_json::to_value(resource)?;
+
+        Ok(KubeCommandVerb::Replace {
+            name,
+            object: Box::new(dynamic_object),
+            resource: ApiResource::erase::<K>(&Default::default()),
+            params,
+        })
+    }
+
+    pub fn replace_status<K: Resource + Serialize>(
+        name: String,
+        resource: K,
+        params: PostParams,
+    ) -> Result<KubeCommandVerb, serde_json::Error>
+    where
+        K::DynamicType: Default,
+    {
+        Ok(KubeCommandVerb::ReplaceStatus {
+            name,
+            data: serde_json::to_vec(&resource)?,
+            resource: ApiResource::erase::<K>(&Default::default()),
+            params,
+        })
+    }
+
+    pub fn patch<K: Resource>(name: String, patch: Patch<Value>, params: PatchParams) -> KubeCommandVerb
+    where
+        K::DynamicType: Default,
+    {
+        KubeCommandVerb::Patch {
+            name,
+            patch: patch,
+            resource: ApiResource::erase::<K>(&Default::default()),
+            params,
+        }
+    }
+
+    pub fn patch_status<K: Resource>(
+        name: String,
+        patch: Patch<Value>,
+        params: PatchParams,
+    ) -> KubeCommandVerb
+    where
+        K::DynamicType: Default,
+    {
+        KubeCommandVerb::PatchStatus {
+            name,
+            patch,
+            resource: ApiResource::erase::<K>(&Default::default()),
+            params,
+        }
+    }
+
+    pub fn delete<K: Resource>(name: String, params: DeleteParams) -> KubeCommandVerb
+    where
+        K::DynamicType: Default,
+    {
+        KubeCommandVerb::Delete {
+            name,
+            resource: ApiResource::erase::<K>(&Default::default()),
+            params,
+        }
+    }
+
+    pub fn in_scope(self, namespace: Option<String>) -> KubeCommand {
+        KubeCommand {
+            namespace,
+            verb: self,
+        }
+    }
+
+    pub fn in_cluster(self) -> KubeCommand {
+        KubeCommand {
+            namespace: None,
+            verb: self,
+        }
+    }
+
+    pub fn in_namespace(self, namespace: String) -> KubeCommand {
+        KubeCommand {
+            namespace: Some(namespace),
+            verb: self,
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match self {
+            KubeCommandVerb::Create { name, .. }
+            | KubeCommandVerb::Replace { name, .. }
+            | KubeCommandVerb::ReplaceStatus { name, .. }
+            | KubeCommandVerb::Patch { name, .. }
+            | KubeCommandVerb::PatchStatus { name, .. }
+            | KubeCommandVerb::Delete { name, .. } => name.to_string(),
+        }
+    }
+
+    pub fn kind(&self) -> String {
+        match self {
+            KubeCommandVerb::Create { resource, .. }
+            | KubeCommandVerb::Replace { resource, .. }
+            | KubeCommandVerb::ReplaceStatus { resource, .. }
+            | KubeCommandVerb::Patch { resource, .. }
+            | KubeCommandVerb::PatchStatus { resource, .. }
+            | KubeCommandVerb::Delete { resource, .. } => resource.kind.to_string(),
+        }
+    }
+
+    pub fn verb_name(&self) -> String {
+        match self {
+            KubeCommandVerb::Create { .. } => "Create".to_string(),
+            KubeCommandVerb::Replace { .. } => "Replace".to_string(),
+            KubeCommandVerb::ReplaceStatus { .. } => "ReplaceStatus".to_string(),
+            KubeCommandVerb::Patch { .. } => "Patch".to_string(),
+            KubeCommandVerb::PatchStatus { .. } => "PatchStatus".to_string(),
+            KubeCommandVerb::Delete { .. } => "Delete".to_string(),
+        }
+    }
+
+    pub fn api_resource(&self) -> ApiResource {
+        match self {
+            KubeCommandVerb::Create { resource, .. }
+            | KubeCommandVerb::Replace { resource, .. }
+            | KubeCommandVerb::ReplaceStatus { resource, .. }
+            | KubeCommandVerb::Patch { resource, .. }
+            | KubeCommandVerb::PatchStatus { resource, .. }
+            | KubeCommandVerb::Delete { resource, .. } => resource.clone(),
+        }
+    }
+}

--- a/kube-client/src/command/command.rs
+++ b/kube-client/src/command/command.rs
@@ -5,13 +5,17 @@ use serde::Serialize;
 use std::fmt::{Display, Formatter};
 use std::option::Option::None;
 
+/// TODO
 #[derive(Clone, Debug, PartialEq)]
 pub struct KubeCommand {
+    /// TODO
     pub namespace: Option<String>,
+    /// TODO
     pub verb: KubeCommandVerb,
 }
 
 impl KubeCommand {
+    /// TODO
     pub fn cluster(command: KubeCommandVerb) -> KubeCommand {
         Self {
             namespace: None,
@@ -19,6 +23,7 @@ impl KubeCommand {
         }
     }
 
+    /// TODO
     pub fn namespaced(namespace: &str, command: KubeCommandVerb) -> KubeCommand {
         Self {
             namespace: Some(namespace.to_string()),
@@ -26,27 +31,33 @@ impl KubeCommand {
         }
     }
 
+    /// TODO
     pub fn api_resource(&self) -> ApiResource {
         self.verb.api_resource()
     }
 
+    /// TODO
     pub fn kind(&self) -> String {
         self.verb.kind()
     }
 
+    /// TODO
     pub fn name(&self) -> String {
         self.verb.name()
     }
 
+    /// TODO
     pub fn namespace(&self) -> Option<String> {
         self.namespace.clone()
     }
 
+    /// TODO
     pub fn verb_name(&self) -> String {
         self.verb.verb_name()
     }
 }
 
+/// TODO
 #[derive(Clone, Debug, PartialEq)]
 pub enum KubeCommandVerb {
     Create {

--- a/kube-client/src/command/mod.rs
+++ b/kube-client/src/command/mod.rs
@@ -1,0 +1,61 @@
+mod command;
+
+pub use command::*;
+
+use crate::api::DynamicObject;
+use crate::client::Status;
+use crate::command::command::KubeCommandVerb;
+use crate::Api;
+use crate::Client;
+use crate::Error;
+use either::Either;
+
+pub struct Dispatcher {
+    client: Client,
+}
+
+impl Dispatcher {
+    pub fn new(client: Client) -> Dispatcher {
+        Dispatcher { client }
+    }
+
+    pub async fn dispatch_command(
+        &self,
+        command: KubeCommand,
+    ) -> Result<Either<DynamicObject, Status>, Error> {
+        let api = match &command.namespace {
+            None => Api::<DynamicObject>::all_with(self.client.clone(), &command.api_resource()),
+            Some(namespace) => {
+                Api::<DynamicObject>::namespaced_with(self.client.clone(), namespace, &command.api_resource())
+            }
+        };
+
+        api.dispatch_command(command.verb).await
+    }
+}
+
+impl Api<DynamicObject> {
+    pub async fn dispatch_command(
+        &self,
+        command: KubeCommandVerb,
+    ) -> Result<Either<DynamicObject, Status>, Error> {
+        match command {
+            KubeCommandVerb::Create { object, params, .. } => {
+                self.create(&params, &object).await.map(Either::Left)
+            }
+            KubeCommandVerb::Replace {
+                name, object, params, ..
+            } => self.replace(&name, &params, &object).await.map(Either::Left),
+            KubeCommandVerb::ReplaceStatus {
+                name, data, params, ..
+            } => self.replace_status(&name, &params, data).await.map(Either::Left),
+            KubeCommandVerb::Patch {
+                name, patch, params, ..
+            } => self.patch(&name, &params, &patch).await.map(Either::Left),
+            KubeCommandVerb::PatchStatus {
+                name, patch, params, ..
+            } => self.patch_status(&name, &params, &patch).await.map(Either::Left),
+            KubeCommandVerb::Delete { name, params, .. } => self.delete(&name, &params).await,
+        }
+    }
+}

--- a/kube-client/src/command/mod.rs
+++ b/kube-client/src/command/mod.rs
@@ -1,3 +1,5 @@
+//! TODO
+
 mod command;
 
 pub use command::*;
@@ -10,15 +12,18 @@ use crate::Client;
 use crate::Error;
 use either::Either;
 
+/// TODO
 pub struct Dispatcher {
     client: Client,
 }
 
 impl Dispatcher {
+    /// TODO
     pub fn new(client: Client) -> Dispatcher {
         Dispatcher { client }
     }
 
+    /// TODO
     pub async fn dispatch_command(
         &self,
         command: KubeCommand,
@@ -35,6 +40,7 @@ impl Dispatcher {
 }
 
 impl Api<DynamicObject> {
+    /// TODO
     pub async fn dispatch_command(
         &self,
         command: KubeCommandVerb,

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -99,6 +99,7 @@ cfg_client! {
     pub mod api;
     pub mod discovery;
     pub mod client;
+    pub mod command;
 
     #[doc(inline)]
     pub use api::Api;

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -141,7 +141,7 @@ impl ListParams {
 }
 
 /// The validation directive to use for `fieldValidation` when using server-side apply.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ValidationDirective {
     /// Strict mode will fail any invalid manifests.
     ///
@@ -174,7 +174,7 @@ impl ValidationDirective {
 }
 
 /// Common query parameters for put/post calls
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, PartialEq)]
 pub struct PostParams {
     /// Whether to run this as a dry run
     pub dry_run: bool,
@@ -303,7 +303,7 @@ impl<T: Serialize> Patch<T> {
 }
 
 /// Common query parameters for patch calls
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, PartialEq)]
 pub struct PatchParams {
     /// Whether to run this as a dry run
     pub dry_run: bool,
@@ -401,7 +401,7 @@ impl PatchParams {
 }
 
 /// Common query parameters for delete calls
-#[derive(Default, Clone, Serialize, Debug)]
+#[derive(Default, Clone, Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteParams {
     /// When present, indicates that modifications should not be persisted.
@@ -569,7 +569,7 @@ mod test {
 }
 
 /// Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.
-#[derive(Default, Clone, Serialize, Debug)]
+#[derive(Default, Clone, Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Preconditions {
     /// Specifies the target ResourceVersion
@@ -581,7 +581,7 @@ pub struct Preconditions {
 }
 
 /// Propagation policy when deleting single objects
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 pub enum PropagationPolicy {
     /// Orphan dependents
     Orphan,

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -3,6 +3,9 @@
 mod object_ref;
 pub mod store;
 
+// TODO - this belongs behind a test util feature flag of some sort
+mod test_utils;
+
 pub use self::object_ref::{Extra as ObjectRefExtra, ObjectRef};
 use crate::watcher;
 use futures::{Stream, TryStreamExt};

--- a/kube-runtime/src/reflector/test_utils.rs
+++ b/kube-runtime/src/reflector/test_utils.rs
@@ -1,0 +1,56 @@
+use crate::reflector::store::Writer;
+use crate::reflector::Store;
+use crate::watcher;
+use kube_client::{Resource, ResourceExt};
+use std::collections::HashSet;
+use std::hash::Hash;
+
+pub trait ToStore<K>
+where
+    K: 'static + Resource + Clone,
+    K::DynamicType: Eq + Clone + Default + Hash,
+{
+    fn to_store(self) -> Store<K>;
+}
+
+impl<K> ToStore<K> for Vec<K>
+where
+    K: 'static + Resource + Clone,
+    K::DynamicType: Eq + Clone + Default + Hash,
+{
+    fn to_store(self) -> Store<K> {
+        check_for_duplicates(&self);
+
+        let mut store_writer = Writer::default();
+        store_writer.apply_watcher_event(&watcher::Event::Restarted(self));
+        store_writer.as_reader()
+    }
+}
+
+/// A Store converts the Vec into a HashMap with a key based on the resource's name and namespace
+/// so they must be unique. We check for bad test data here to ensure we aren't trying to put
+/// duplicate resources into the Store (which would cause any duplicates to disappear).
+fn check_for_duplicates<K>(to_store: &[K])
+where
+    K: 'static + Resource + Clone,
+    K::DynamicType: Default + Eq + Clone + Hash,
+{
+    let mut seen = HashSet::new();
+    let mut duplicates = Vec::new();
+
+    for item in to_store {
+        let key = (item.name_unchecked(), item.meta().namespace.clone());
+
+        if seen.contains(&key) {
+            duplicates.push(key);
+        } else {
+            seen.insert(key);
+        }
+    }
+
+    assert!(
+        duplicates.is_empty(),
+        "Attempted .to_store() on a vec with with duplicate resources: {:?}",
+        duplicates
+    );
+}


### PR DESCRIPTION
## Motivation

We've adopted a few best practices within our Controllers that help us deal with a couple of different problems:

1. Concurrency - Any time we take a mutating action in a controller there is a potential that any other changes we would make are no longer valid. If they are still valid that's fine because we can just immediately re-reconcile and take the next action.
2. Testing - Our reconciliation is some of our most complicated code, we want it all to be as testable as possible. Unit tests are the cheapest form of test so we want our reconciliation to be unit testable.

## Solution

> N.B. - This is a relatively quick hack and slash job of a library we've been using in our codebase on top of KubeRS for a few years. If the approach is deemed worth pursuing I'll clean this PR up.

We use a command pattern so that our functions can state the action they want to take, but without taking the action. This is encoded in a `KubeCommand` enum which contains the context and the action (verb) to perform. We strip away the strong typing as part of the command so that we don't have to encode the types of mutation we want to perform in the type system

This means that we can run unit tests against the code at various levels and just assert that the command (the "mutation") we get back is the one that's expected. 

The other best practice we've adopted within our project is to only ever perform a single action in any given reconciliation. This best practice is codified here in the `run_via_dispatch` (possibly needs a better name) method on the Controller. It also plays into the improved testability once again because it's easy to just assert on a returned value.

Finally I've included a `.to_store` method we use a lot in our testing which lets us turn a vector of resources into a `Store`, allowing us to easily setup test fixtures for our reconciles.