### PR TITLE
Add `WatchStreamExt::default_backoff` shorthand

### DIFF
--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -1,4 +1,3 @@
-use backoff::ExponentialBackoff;
 use futures::{pin_mut, TryStreamExt};
 use k8s_openapi::api::core::v1::{Event, Node};
 use kube::{
@@ -16,9 +15,7 @@ async fn main() -> anyhow::Result<()> {
     let nodes: Api<Node> = Api::all(client.clone());
 
     let wc = watcher::Config::default().labels("beta.kubernetes.io/arch=amd64");
-    let obs = watcher(nodes, wc)
-        .backoff(ExponentialBackoff::default())
-        .applied_objects();
+    let obs = watcher(nodes, wc).default_backoff().applied_objects();
 
     pin_mut!(obs);
     while let Some(n) = obs.try_next().await? {

--- a/examples/pod_watcher.rs
+++ b/examples/pod_watcher.rs
@@ -15,6 +15,7 @@ async fn main() -> anyhow::Result<()> {
 
     watcher(api, watcher::Config::default())
         .applied_objects()
+        .default_backoff()
         .try_for_each(|p| async move {
             info!("saw {}", p.name_any());
             if let Some(unready_reason) = pod_unready(&p) {

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -710,14 +710,14 @@ where
     /// # use k8s_openapi::api::core::v1::ConfigMap;
     /// # use k8s_openapi::api::apps::v1::StatefulSet;
     /// # use kube::runtime::controller::Action;
-    /// # use kube::runtime::{predicates, watcher, Controller, WatchStreamExt};
+    /// # use kube::runtime::{predicates, metadata_watcher, watcher, Controller, WatchStreamExt};
     /// # use kube::{Api, Client, Error, ResourceExt};
     /// # use std::sync::Arc;
     /// # type CustomResource = ConfigMap;
     /// # async fn reconcile(_: Arc<CustomResource>, _: Arc<()>) -> Result<Action, Error> { Ok(Action::await_change()) }
     /// # fn error_policy(_: Arc<CustomResource>, _: &kube::Error, _: Arc<()>) -> Action { Action::await_change() }
     /// # async fn doc(client: kube::Client) {
-    /// let sts_stream = watcher(Api::<StatefulSet>::all(client.clone()), watcher::Config::default())
+    /// let sts_stream = metadata_watcher(Api::<StatefulSet>::all(client.clone()), watcher::Config::default())
     ///     .touched_objects()
     ///     .predicate_filter(predicates::generation);
     ///

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     scheduler::{scheduler, ScheduleRequest},
     utils::{trystream_try_via, CancelableJoinHandle, KubeRuntimeStreamExt, StreamBackoff, WatchStreamExt},
-    watcher::{self, watcher, Config},
+    watcher::{self, watcher, Config, DefaultBackoff},
 };
 use backoff::backoff::Backoff;
 use derivative::Derivative;
@@ -541,7 +541,7 @@ where
         trigger_selector.push(self_watcher);
         Self {
             trigger_selector,
-            trigger_backoff: Box::new(watcher::DefaultBackoff::default()),
+            trigger_backoff: Box::<DefaultBackoff>::default(),
             graceful_shutdown_selector: vec![
                 // Fallback future, ensuring that we never terminate if no additional futures are added to the selector
                 future::pending().boxed(),
@@ -624,7 +624,7 @@ where
         trigger_selector.push(self_watcher);
         Self {
             trigger_selector,
-            trigger_backoff: Box::new(watcher::DefaultBackoff::default()),
+            trigger_backoff: Box::<DefaultBackoff>::default(),
             graceful_shutdown_selector: vec![
                 // Fallback future, ensuring that we never terminate if no additional futures are added to the selector
                 future::pending().boxed(),

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -541,7 +541,7 @@ where
         trigger_selector.push(self_watcher);
         Self {
             trigger_selector,
-            trigger_backoff: Box::new(watcher::default_backoff()),
+            trigger_backoff: Box::new(watcher::DefaultBackoff::default()),
             graceful_shutdown_selector: vec![
                 // Fallback future, ensuring that we never terminate if no additional futures are added to the selector
                 future::pending().boxed(),
@@ -624,7 +624,7 @@ where
         trigger_selector.push(self_watcher);
         Self {
             trigger_selector,
-            trigger_backoff: Box::new(watcher::default_backoff()),
+            trigger_backoff: Box::new(watcher::DefaultBackoff::default()),
             graceful_shutdown_selector: vec![
                 // Fallback future, ensuring that we never terminate if no additional futures are added to the selector
                 future::pending().boxed(),

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -8,24 +8,20 @@ use crate::{
 };
 #[cfg(feature = "unstable-runtime-predicates")] use kube_client::Resource;
 
-use crate::{
-    utils::ResetTimerBackoff,
-    watcher::{default_exponential_backoff, DEFAULT_RESET_DURATION},
-};
-use backoff::{backoff::Backoff, ExponentialBackoff};
+use crate::watcher::DefaultBackoff;
+use backoff::backoff::Backoff;
 use futures::{Stream, TryStream};
 
 /// Extension trait for streams returned by [`watcher`](watcher()) or [`reflector`](crate::reflector::reflector)
 pub trait WatchStreamExt: Stream {
-    /// Apply the [`default_backoff`](crate::watcher::default_backoff) watcher [`Backoff`] policy
+    /// Apply the [`DefaultBackoff`] watcher [`Backoff`] policy
     ///
     /// This is recommended for controllers that want to play nicely with the apiserver.
-    fn default_backoff(self) -> StreamBackoff<Self, ResetTimerBackoff<ExponentialBackoff>>
+    fn default_backoff(self) -> StreamBackoff<Self, DefaultBackoff>
     where
         Self: TryStream + Sized,
     {
-        let bo = default_exponential_backoff();
-        StreamBackoff::new(self, ResetTimerBackoff::new(bo, DEFAULT_RESET_DURATION))
+        StreamBackoff::new(self, DefaultBackoff::default())
     }
 
     /// Apply a specific [`Backoff`] policy to a [`Stream`] using [`StreamBackoff`]

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -8,10 +8,12 @@ use crate::{
 };
 #[cfg(feature = "unstable-runtime-predicates")] use kube_client::Resource;
 
-use crate::{utils::ResetTimerBackoff, watcher::default_exponential_backoff};
+use crate::{
+    utils::ResetTimerBackoff,
+    watcher::{default_exponential_backoff, DEFAULT_RESET_DURATION},
+};
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use futures::{Stream, TryStream};
-use std::time::Duration;
 
 /// Extension trait for streams returned by [`watcher`](watcher()) or [`reflector`](crate::reflector::reflector)
 pub trait WatchStreamExt: Stream {
@@ -23,7 +25,7 @@ pub trait WatchStreamExt: Stream {
         Self: TryStream + Sized,
     {
         let bo = default_exponential_backoff();
-        StreamBackoff::new(self, ResetTimerBackoff::new(bo, Duration::from_secs(120)))
+        StreamBackoff::new(self, ResetTimerBackoff::new(bo, DEFAULT_RESET_DURATION))
     }
 
     /// Apply a specific [`Backoff`] policy to a [`Stream`] using [`StreamBackoff`]

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -646,13 +646,18 @@ pub fn watch_object<K: Resource + Clone + DeserializeOwned + Debug + Send + 'sta
 /// for more details.
 #[must_use]
 pub fn default_backoff() -> impl Backoff + Send + Sync {
-    let expo = backoff::ExponentialBackoff {
+    let bo = default_exponential_backoff();
+    ResetTimerBackoff::new(bo, Duration::from_secs(120))
+}
+
+// ideally should be a const var but Default for ExponentialBackoff is not const
+pub(crate) fn default_exponential_backoff() -> backoff::ExponentialBackoff {
+    backoff::ExponentialBackoff {
         initial_interval: Duration::from_millis(800),
         max_interval: Duration::from_secs(30),
         randomization_factor: 1.0,
         multiplier: 2.0,
         max_elapsed_time: None,
         ..ExponentialBackoff::default()
-    };
-    ResetTimerBackoff::new(expo, Duration::from_secs(120))
+    }
 }

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -647,7 +647,7 @@ pub fn watch_object<K: Resource + Clone + DeserializeOwned + Debug + Send + 'sta
 #[must_use]
 pub fn default_backoff() -> impl Backoff + Send + Sync {
     let bo = default_exponential_backoff();
-    ResetTimerBackoff::new(bo, Duration::from_secs(120))
+    ResetTimerBackoff::new(bo, DEFAULT_RESET_DURATION)
 }
 
 // ideally should be a const var but Default for ExponentialBackoff is not const
@@ -661,3 +661,4 @@ pub(crate) fn default_exponential_backoff() -> backoff::ExponentialBackoff {
         ..ExponentialBackoff::default()
     }
 }
+pub(crate) const DEFAULT_RESET_DURATION: Duration = Duration::from_secs(120);


### PR DESCRIPTION
This change adds a simplified recommended backoff construction for watcher streams:

```diff
-let stream = watcher(api, config).backoff(watcher::default_backoff()).
+let stream =  watcher(api, config).default_backoff();
```

This is advantageous because it's hard to advocate that users use backoff (fundamentally a good behaviour action) when the usage is verbose. So this makes it less verbose.

To do this properly we have made a new `DefaultBackoff` struct that encapsulates the type. This is slightly more verbose than relying on `impl Backoff` from `watcher::default_backoff`, but it has the benefit of working in the stream setting where we are limited by existential type constraints.

This also **deprecates** the `watcher::default_backoff` fn due to it now generally being more easily invoked elsewhere, and by the explicit type. This could be debated.

<details><summary>old, now irrelevant commentary, left in a collapsible</summary>
<p>
The slight downside here is that `watcher::default_backoff()` returns an opaque type and cannot be used in the shortcut stream ext method so have exposed just our `ExponentialBackoff` default as an internal fn (which cannot be const), along with a const reset timeout and re-implemented the function in `WatchStreamExt::default_backoff` referencing our parameters.

An alternative could be doing the defaulting in the generally opaque type that most users don't interact with:

```rust
// convenience for watchstreamext users
impl Default for ResetTimerBackoff<backoff::ExponentialBackoff> {
    fn default() -> Self {
        use crate::watcher::{default_exponential_backoff, DEFAULT_RESET_DURATION};
        let bo = default_exponential_backoff();
        Self::new(bo, DEFAULT_RESET_DURATION)
    }
}
```

but i think that doesn't really help much. we still end up with an implementation in `WatchStreamExt` that is almost as big (except  without the internal imports) and it's an awkward inversion of utils depending on core stuff. I'd probably rather keep the backoff parameters somewhere prominent.
</p>
</details>
