### PR TITLE
Bump MSRV from 1.63 to 1.64

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.63.0-bullseye
+FROM docker.io/rust:1.64.0-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kube-rs
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
-[![Rust 1.63](https://img.shields.io/badge/MSRV-1.63-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.63.0)
+[![Rust 1.64](https://img.shields.io/badge/MSRV-1.64-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.64.0)
 [![Tested against Kubernetes v1_21 and above](https://img.shields.io/badge/MK8SV-v1_21-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)

--- a/deny.toml
+++ b/deny.toml
@@ -109,6 +109,19 @@ name = "syn"
 name = "base64"
 
 [[bans.skip]]
+# used by h2->hyper->hyper-openssl (we have latest)
+# newer used by serde_json
+name = "indexmap"
+[[bans.skip]]
+# via indexmap - have to also skip this
+name = "hashbrown"
+
+[[bans.skip]]
+# latest via openssl->hyper-openssl (we have latest)
+# newer via tower-http (we have latest)
+name = "bitflags"
+
+[[bans.skip]]
 # deep in dependency tree, only dual use via dev dependency
 name = "redox_syscall"
 

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 keywords = ["kubernetes", "client",]
 categories = ["web-programming::http-client", "configuration", "network-programming", "api-bindings"]
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 edition = "2021"
 
 [features]

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "kazk <kazk.dev@gmail.com>",
 ]
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 license = "Apache-2.0"
 keywords = ["kubernetes", "apimachinery"]
 categories = ["api-bindings", "encoding", "parser-implementations"]

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "kazk <kazk.dev@gmail.com>",
 ]
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 license = "Apache-2.0"
 repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 keywords = ["kubernetes", "runtime", "reflector", "watcher", "controller"]
 categories = ["web-programming::http-client", "caching", "network-programming"]
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 edition = "2021"
 
 [features]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 keywords = ["kubernetes", "client", "runtime", "cncf"]
 categories = ["network-programming", "caching", "api-bindings", "configuration", "encoding"]
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
Due to msrv from `serde_yaml`. Has started failing in neighbouring PRs. Still far behind latest.

Also fixes CI issues around `cargo deny` where we are getting duplicate dependencies. Nothing really we can do about these yet.