### PR TITLE
Change `Api::log_stream` to return `AsyncBufRead`

### DIFF
--- a/examples/log_stream.rs
+++ b/examples/log_stream.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use futures::{StreamExt, TryStreamExt};
+use futures::{AsyncBufReadExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{Api, LogParams},
@@ -26,10 +26,10 @@ async fn main() -> Result<()> {
             ..LogParams::default()
         })
         .await?
-        .boxed();
+        .lines();
 
     while let Some(line) = logs.try_next().await? {
-        info!("{:?}", String::from_utf8_lossy(&line));
+        info!("{}", line);
     }
     Ok(())
 }

--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -7,9 +7,8 @@
 //!
 //! The [`Client`] can also be used with [`Discovery`](crate::Discovery) to dynamically
 //! retrieve the resources served by the kubernetes API.
-use bytes::Bytes;
 use either::{Either, Left, Right};
-use futures::{self, Stream, StreamExt, TryStream, TryStreamExt};
+use futures::{self, AsyncBufRead, StreamExt, TryStream, TryStreamExt};
 use http::{self, Request, Response, StatusCode};
 use hyper::Body;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as k8s_meta_v1;
@@ -238,15 +237,18 @@ impl Client {
         Ok(text)
     }
 
-    /// Perform a raw HTTP request against the API and get back the response
-    /// as a stream of bytes
-    pub async fn request_text_stream(
-        &self,
-        request: Request<Vec<u8>>,
-    ) -> Result<impl Stream<Item = Result<Bytes>>> {
+    /// Perform a raw HTTP request against the API and stream the response body.
+    ///
+    /// The response can be processed using [`AsyncReadExt`](futures::AsyncReadExt)
+    /// and [`AsyncBufReadExt`](futures::AsyncBufReadExt).
+    pub async fn request_stream(&self, request: Request<Vec<u8>>) -> Result<impl AsyncBufRead> {
         let res = self.send(request.map(Body::from)).await?;
-        // trace!("Status = {:?} for {}", res.status(), res.url());
-        Ok(res.into_body().map_err(Error::HyperError))
+        // Map the error, since we want to convert this into an `AsyncBufReader` using
+        // `into_async_read` which specifies `std::io::Error` as the stream's error type.
+        let body = res
+            .into_body()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+        Ok(body.into_async_read())
     }
 
     /// Perform a raw HTTP request against the API and get back either an object


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
The current log_stream implementation returns a stream of bytes that aren't newline buffered. This can cause a visual mess, when for example, there are multiple log lines in one chunk of the stream.
<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution
Modify `kube_client::api::subresource::Api::log_stream()` to return an async buf reader (`futures::io::AsyncBufRead`) that can read logs asynchronously. Users can call call `.lines()` on it to get a newline buffered stream of logs.
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

Fixes #1160 
