### PR TITLE
Fixes new clippy lints

### DIFF
--- a/kube-client/src/api/portforward.rs
+++ b/kube-client/src/api/portforward.rs
@@ -319,7 +319,7 @@ where
             Message::ToPod(ch, bytes) => {
                 let mut bin = Vec::with_capacity(bytes.len() + 1);
                 bin.push(ch);
-                bin.extend(bytes.into_iter());
+                bin.extend(bytes);
                 ws_sink
                     .send(ws::Message::binary(bin))
                     .await

--- a/kube-client/src/client/auth/oidc.rs
+++ b/kube-client/src/client/auth/oidc.rs
@@ -162,8 +162,7 @@ impl Oidc {
             .id_token
             .expose_secret()
             .split('.')
-            .skip(1)
-            .next()
+            .nth(1)
             .ok_or(errors::IdTokenError::InvalidFormat)?;
         let payload = base64::decode_engine(part, &BASE64_ENGINE)?;
         let expiry = serde_json::from_slice::<Claims>(&payload)?.expiry;
@@ -397,7 +396,7 @@ impl Refresher {
     async fn id_token(&mut self) -> Result<String, errors::RefreshError> {
         let token_endpoint = self.token_endpoint().await?;
 
-        let response = match self.auth_style.clone() {
+        let response = match self.auth_style {
             Some(style) => {
                 let request = self.token_request(&token_endpoint, style)?;
                 self.https_client.request(request).await?

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -112,6 +112,8 @@ where
     S::Ok: Debug,
     S::Error: Debug,
 {
+    // `arc_with_non_send_sync` false positive: https://github.com/rust-lang/rust-clippy/issues/11076
+    #[allow(clippy::arc_with_non_send_sync)]
     let stream = Arc::new(Mutex::new(stream.into_stream().peekable()));
     (
         SplitCase {

--- a/kube-runtime/src/utils/stream_subscribe.rs
+++ b/kube-runtime/src/utils/stream_subscribe.rs
@@ -62,6 +62,8 @@ impl<S: Stream> Stream for StreamSubscribe<S> {
 
         match item {
             Poll::Ready(Some(item)) => {
+                // `arc_with_non_send_sync` false positive: https://github.com/rust-lang/rust-clippy/issues/11076
+                #[allow(clippy::arc_with_non_send_sync)]
                 let item = Arc::new(item);
                 this.sender.send(Some(item.clone())).ok();
                 Poll::Ready(Some(item))

--- a/kube-runtime/src/wait.rs
+++ b/kube-runtime/src/wait.rs
@@ -46,6 +46,7 @@ pub enum Error {
 /// # Ok(())
 /// # }
 /// ```
+#[allow(clippy::missing_panics_doc)] // watch never actually terminates, expect cannot fail
 pub async fn await_condition<K>(api: Api<K>, name: &str, cond: impl Condition<K>) -> Result<Option<K>, Error>
 where
     K: Clone + Debug + Send + DeserializeOwned + Resource + 'static,


### PR DESCRIPTION
Nightly clippy has more lints now or fixed some lints. 

The `missing_panics_doc` is a bit awkward, as far as I can see the expect should never panic (because the watch stream should never just terminate).

The Arc lint is a false positive from https://github.com/rust-lang/rust-clippy/issues/11076 in generic code.