### PR TITLE
Make `Controller::owns` use `metadata_watcher` internally

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     scheduler::{scheduler, ScheduleRequest},
     utils::{trystream_try_via, CancelableJoinHandle, KubeRuntimeStreamExt, StreamBackoff, WatchStreamExt},
-    watcher::{self, watcher, Config, DefaultBackoff},
+    watcher::{self, metadata_watcher, watcher, Config, DefaultBackoff},
 };
 use backoff::backoff::Backoff;
 use derivative::Derivative;
@@ -688,7 +688,11 @@ where
         Child::DynamicType: Debug + Eq + Hash + Clone,
     {
         // TODO: call owns_stream_with when it's stable
-        let child_watcher = trigger_owners(watcher(api, wc).touched_objects(), self.dyntype.clone(), dyntype);
+        let child_watcher = trigger_owners(
+            metadata_watcher(api, wc).touched_objects(),
+            self.dyntype.clone(),
+            dyntype,
+        );
         self.trigger_selector.push(child_watcher.boxed());
         self
     }


### PR DESCRIPTION
There shouldn't be a good reason for it to do a full watch, because it is only remapping from `.metadata.onwerReferences` to the parent object.

This is an optimization spotted while writing the https://github.com/kube-rs/website/pull/35