### PR TITLE
Add `WatchStreamExt::modify()` to modify events

### DIFF
--- a/examples/pod_reflector.rs
+++ b/examples/pod_reflector.rs
@@ -28,13 +28,11 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
-    let stream = watcher(api, watcher::Config::default()).map_ok(|ev| {
-        ev.modify(|pod| {
-            // memory optimization for our store - we don't care about fields/annotations/status
-            pod.managed_fields_mut().clear();
-            pod.annotations_mut().clear();
-            pod.status = None;
-        })
+    let stream = watcher(api, watcher::Config::default()).modify(|pod| {
+        // memory optimization for our store - we don't care about managed fields/annotations/status
+        pod.managed_fields_mut().clear();
+        pod.annotations_mut().clear();
+        pod.status = None;
     });
 
     let rf = reflector(writer, stream)

--- a/kube-runtime/src/utils/event_modify.rs
+++ b/kube-runtime/src/utils/event_modify.rs
@@ -1,0 +1,85 @@
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use std::task::ready;
+
+use futures::{Stream, TryStream};
+use pin_project::pin_project;
+
+use crate::watcher::{Error, Event};
+
+#[pin_project]
+/// Stream returned by the [`modify`](super::WatchStreamExt::modify) method.
+/// Modifies the [`Event`] item returned by the inner stream by calling
+/// [`modify`](Event::modify()) on it.
+pub struct EventModify<St, F> {
+    #[pin]
+    stream: St,
+    f: F,
+}
+
+impl<St, F, K> EventModify<St, F>
+where
+    St: TryStream<Ok = Event<K>>,
+    F: FnMut(&mut K),
+{
+    pub(super) fn new(stream: St, f: F) -> EventModify<St, F> {
+        Self { stream, f }
+    }
+}
+
+impl<St, F, K> Stream for EventModify<St, F>
+where
+    St: Stream<Item = Result<Event<K>, Error>>,
+    F: FnMut(&mut K),
+{
+    type Item = Result<Event<K>, Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut me = self.project();
+        me.stream
+            .as_mut()
+            .poll_next(cx)
+            .map_ok(|event| event.modify(me.f))
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use std::{task::Poll, vec};
+
+    use super::{Error, Event, EventModify};
+    use futures::{pin_mut, poll, stream, Stream, StreamExt};
+
+    #[tokio::test]
+    async fn eventmodify_modifies_innner_value_of_event() {
+        let st = stream::iter([
+            Ok(Event::Applied(0)),
+            Err(Error::TooManyObjects),
+            Ok(Event::Restarted(vec![10])),
+        ]);
+        let ev_modify = EventModify::new(st, |x| {
+            *x += 1;
+        });
+        pin_mut!(ev_modify);
+
+        assert!(matches!(
+            poll!(ev_modify.next()),
+            Poll::Ready(Some(Ok(Event::Applied(1))))
+        ));
+
+        assert!(matches!(
+            poll!(ev_modify.next()),
+            Poll::Ready(Some(Err(Error::TooManyObjects)))
+        ));
+
+        let restarted = poll!(ev_modify.next());
+        assert!(matches!(
+            restarted,
+            Poll::Ready(Some(Ok(Event::Restarted(vec)))) if vec == [11]
+        ));
+
+        assert!(matches!(poll!(ev_modify.next()), Poll::Ready(None)));
+    }
+}

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -3,6 +3,7 @@
 mod backoff_reset_timer;
 pub(crate) mod delayed_init;
 mod event_flatten;
+mod event_modify;
 #[cfg(feature = "unstable-runtime-predicates")] mod predicate;
 mod stream_backoff;
 #[cfg(feature = "unstable-runtime-subscribe")] pub mod stream_subscribe;
@@ -10,6 +11,7 @@ mod watch_ext;
 
 pub use backoff_reset_timer::ResetTimerBackoff;
 pub use event_flatten::EventFlatten;
+pub use event_modify::EventModify;
 #[cfg(feature = "unstable-runtime-predicates")]
 pub use predicate::{predicates, Predicate, PredicateFilter};
 pub use stream_backoff::StreamBackoff;


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
Atm, we need to resort to nested maps if we want to modify the resource directly present in the `Event`s returned by the `watcher()` stream.
```rust
let stream = watcher(api, watcher::Config::default()).map_ok(|ev| {
    ev.modify(|pod| {
        pod.managed_fields_mut().clear();
        pod.annotations_mut().clear();
        pod.status = None;
    })
});
```
<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution
Add `WatchStreamExt::modify()` which returns an `EventModify` stream. This allows for users to directly modify the inner value of an `Event` returned by the watcher stream, thus avoiding the usage of nested maps.

Example usage:

```rust
let stream = watcher(api, watcher::Config::default()).modify(|pod| {
    pod.managed_fields_mut().clear();
    pod.annotations_mut().clear();
    pod.status = None;
});
```

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
Fixes #1245 
