### PR TITLE
Watcher pagination handle empty string continue token

### DIFF
--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -420,8 +420,7 @@ where
             match api.list(&lp).await {
                 Ok(list) => {
                     objects.extend(list.items);
-                    let continue_token = list.metadata.continue_.unwrap_or_default();
-                    if !continue_token.is_empty() {
+                    if let Some(continue_token) = list.metadata.continue_.filter(|s| !s.is_empty()) {
                         (None, State::Empty {
                             continue_token: Some(continue_token),
                             objects,

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -420,7 +420,8 @@ where
             match api.list(&lp).await {
                 Ok(list) => {
                     objects.extend(list.items);
-                    if let Some(continue_token) = list.metadata.continue_ {
+                    let continue_token = list.metadata.continue_.unwrap_or_default();
+                    if ! continue_token.is_empty() {
                         (None, State::Empty {
                             continue_token: Some(continue_token),
                             objects,

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -425,9 +425,7 @@ where
                             continue_token: Some(continue_token),
                             objects,
                         })
-                    } else if let Some(resource_version) =
-                        list.metadata.resource_version.filter(|rv| !rv.is_empty())
-                    {
+                    } else if let Some(resource_version) = list.metadata.resource_version {
                         (Some(Ok(Event::Restarted(objects))), State::InitListed {
                             resource_version,
                         })

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -421,7 +421,7 @@ where
                 Ok(list) => {
                     objects.extend(list.items);
                     let continue_token = list.metadata.continue_.unwrap_or_default();
-                    if ! continue_token.is_empty() {
+                    if !continue_token.is_empty() {
                         (None, State::Empty {
                             continue_token: Some(continue_token),
                             objects,

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -425,7 +425,9 @@ where
                             continue_token: Some(continue_token),
                             objects,
                         })
-                    } else if let Some(resource_version) = list.metadata.resource_version {
+                    } else if let Some(resource_version) =
+                        list.metadata.resource_version.filter(|rv| !rv.is_empty())
+                    {
                         (Some(Ok(Event::Restarted(objects))), State::InitListed {
                             resource_version,
                         })

--- a/kube/src/mock_tests.rs
+++ b/kube/src/mock_tests.rs
@@ -112,6 +112,7 @@ impl ApiServerVerifier {
             assert!(req_uri.contains("&continue=first"));
             let respdata = json!({
                 "metadata": {
+                    "continue": "",
                     "resourceVersion": "2"
                 },
                 "items": [Hack::test(2)]


### PR DESCRIPTION
Missed a case, that was only spotted during sanity check in https://github.com/kube-rs/controller-rs/pull/52

k3d responds with an empty continue token when everything fits in the page, causing us to loop in the initial list case forever (because we see a continue token and try to continue with an empty token - equivalent to a full list). To fix this we now treat an empty continue token as invalid because it's the empty string. This matches [upstream usage of continue tokens](https://github.com/kubernetes/client-go/blob/560efb3b8995da3adcec09865ca78c1ddc917cc9/tools/pager/pager.go#L120).