### PR TITLE
Add `WatchStreamExt::reflect` to allow chaining on a reflector 

### DIFF
--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -18,12 +18,15 @@ async fn main() -> anyhow::Result<()> {
         .timeout(10); // short watch timeout in this example
 
     let (reader, writer) = reflector::store();
-    let rf = reflector(writer, watcher(nodes, wc))
+    let stream = watcher(nodes, wc)
+        .default_backoff()
+        .reflect(writer)
         .applied_objects()
         .predicate_filter(predicates::labels.combine(predicates::annotations)); // NB: requires an unstable feature
 
     // Periodically read our state in the background
     tokio::spawn(async move {
+        reader.wait_until_ready().await.unwrap();
         loop {
             let nodes = reader.state().iter().map(|r| r.name_any()).collect::<Vec<_>>();
             info!("Current {} nodes: {:?}", nodes.len(), nodes);
@@ -32,8 +35,8 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Log applied events with changes from the reflector
-    pin_mut!(rf);
-    while let Some(node) = rf.try_next().await? {
+    pin_mut!(stream);
+    while let Some(node) = stream.try_next().await? {
         info!("saw node {} with new labels/annots", node.name_any());
     }
 

--- a/examples/pod_reflector.rs
+++ b/examples/pod_reflector.rs
@@ -18,6 +18,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move {
         // Show state every 5 seconds of watching
         loop {
+            reader.wait_until_ready().await.unwrap();
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             info!("Current pod count: {}", reader.state().len());
             // full information with debug logs
@@ -28,19 +29,20 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
-    let stream = watcher(api, watcher::Config::default()).modify(|pod| {
-        // memory optimization for our store - we don't care about managed fields/annotations/status
-        pod.managed_fields_mut().clear();
-        pod.annotations_mut().clear();
-        pod.status = None;
-    });
-
-    let rf = reflector(writer, stream)
+    let stream = watcher(api, watcher::Config::default().any_semantic())
+        .default_backoff()
+        .modify(|pod| {
+            // memory optimization for our store - we don't care about managed fields/annotations/status
+            pod.managed_fields_mut().clear();
+            pod.annotations_mut().clear();
+            pod.status = None;
+        })
+        .reflect(writer)
         .applied_objects()
         .predicate_filter(predicates::resource_version); // NB: requires an unstable feature
-    futures::pin_mut!(rf);
+    futures::pin_mut!(stream);
 
-    while let Some(pod) = rf.try_next().await? {
+    while let Some(pod) = stream.try_next().await? {
         info!("saw {}", pod.name_any());
     }
     Ok(())

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod delayed_init;
 mod event_flatten;
 mod event_modify;
 #[cfg(feature = "unstable-runtime-predicates")] mod predicate;
+mod reflect;
 mod stream_backoff;
 #[cfg(feature = "unstable-runtime-subscribe")] pub mod stream_subscribe;
 mod watch_ext;
@@ -14,6 +15,7 @@ pub use event_flatten::EventFlatten;
 pub use event_modify::EventModify;
 #[cfg(feature = "unstable-runtime-predicates")]
 pub use predicate::{predicates, Predicate, PredicateFilter};
+pub use reflect::Reflect;
 pub use stream_backoff::StreamBackoff;
 #[cfg(feature = "unstable-runtime-subscribe")]
 pub use stream_subscribe::StreamSubscribe;

--- a/kube-runtime/src/utils/reflect.rs
+++ b/kube-runtime/src/utils/reflect.rs
@@ -1,0 +1,105 @@
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{Stream, TryStream};
+use pin_project::pin_project;
+
+use crate::{
+    reflector::store::Writer,
+    watcher::{Error, Event},
+};
+use kube_client::Resource;
+
+#[pin_project]
+/// Stream returned by the [`reflect`](super::WatchStreamExt::reflect) method.
+pub struct Reflect<St, K>
+where
+    K: Resource + Clone + 'static,
+    K::DynamicType: Eq + std::hash::Hash + Clone,
+{
+    #[pin]
+    stream: St,
+    writer: Writer<K>,
+}
+
+impl<St, K> Reflect<St, K>
+where
+    St: TryStream<Ok = Event<K>>,
+    K: Resource + Clone,
+    K::DynamicType: Eq + std::hash::Hash + Clone,
+{
+    pub(super) fn new(stream: St, writer: Writer<K>) -> Reflect<St, K> {
+        Self { stream, writer }
+    }
+}
+
+impl<St, K> Stream for Reflect<St, K>
+where
+    K: Resource + Clone,
+    K::DynamicType: Eq + std::hash::Hash + Clone,
+    St: Stream<Item = Result<Event<K>, Error>>,
+{
+    type Item = Result<Event<K>, Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut me = self.project();
+        //stream.inspect_ok(move |event| writer.apply_watcher_event(event))
+        me.stream.as_mut().poll_next(cx).map_ok(move |event| {
+            me.writer.apply_watcher_event(&event);
+            event
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use std::{task::Poll, vec};
+
+    use super::{Error, Event, Reflect};
+    use crate::reflector;
+    use futures::{pin_mut, poll, stream, StreamExt};
+    use k8s_openapi::api::core::v1::Pod;
+
+    fn testpod(name: &str) -> Pod {
+        let mut pod = Pod::default();
+        pod.metadata.name = Some(name.to_string());
+        pod
+    }
+
+    #[tokio::test]
+    async fn reflect_passes_events_through() {
+        let foo = testpod("foo");
+        let bar = testpod("bar");
+        let st = stream::iter([
+            Ok(Event::Applied(foo.clone())),
+            Err(Error::TooManyObjects),
+            Ok(Event::Restarted(vec![foo, bar])),
+        ]);
+        let (reader, writer) = reflector::store();
+
+        let reflect = Reflect::new(st, writer);
+        pin_mut!(reflect);
+        assert_eq!(reader.len(), 0);
+
+        assert!(matches!(
+            poll!(reflect.next()),
+            Poll::Ready(Some(Ok(Event::Applied(_))))
+        ));
+        assert_eq!(reader.len(), 1);
+
+        assert!(matches!(
+            poll!(reflect.next()),
+            Poll::Ready(Some(Err(Error::TooManyObjects)))
+        ));
+        assert_eq!(reader.len(), 1);
+
+        let restarted = poll!(reflect.next());
+        assert!(matches!(restarted, Poll::Ready(Some(Ok(Event::Restarted(_))))));
+        assert_eq!(reader.len(), 2);
+
+        assert!(matches!(poll!(reflect.next()), Poll::Ready(None)));
+        assert_eq!(reader.len(), 2);
+    }
+}

--- a/kube-runtime/src/utils/reflect.rs
+++ b/kube-runtime/src/utils/reflect.rs
@@ -12,8 +12,8 @@ use crate::{
 };
 use kube_client::Resource;
 
+/// Stream returned by the [`reflect`](super::WatchStreamExt::reflect) method
 #[pin_project]
-/// Stream returned by the [`reflect`](super::WatchStreamExt::reflect) method.
 pub struct Reflect<St, K>
 where
     K: Resource + Clone + 'static,
@@ -45,7 +45,6 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut me = self.project();
-        //stream.inspect_ok(move |event| writer.apply_watcher_event(event))
         me.stream.as_mut().poll_next(cx).map_ok(move |event| {
             me.writer.apply_watcher_event(&event);
             event

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -199,7 +199,7 @@ pub trait WatchStreamExt: Stream {
     /// This populates a [`Store`] as the stream is polled.
     fn reflect<K>(self, writer: Writer<K>) -> Reflect<Self, K>
     where
-        Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Sized,
+        Self: Stream<Item = watcher::Result<watcher::Event<K>>> + Sized,
         K: Resource + Clone + 'static,
         K::DynamicType: Eq + std::hash::Hash + Clone,
     {


### PR DESCRIPTION
Thought this might be nicer than the separate function call now that we allow doing everything on the stream chain. It also makes it clearer to see what parts get reflected (particularly pre or post modify calls) because it follows from the chain order:

```rust
watcher(api, watcher::Config::default().any_semantic())
    .default_backoff()
    .modify(|pod| { pod.managed_fields_mut().clear(); })
    .reflect(writer)
    .applied_objects();
```

NB: I did some rename experiments on this branch but it was a bad idea and force pushed it away. Sorry about the noise.