### PR TITLE
adds watch-list implementation without breaking changes

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -213,3 +213,7 @@ path = "secret_syncer.rs"
 name = "pod_shell_crossterm"
 path = "pod_shell_crossterm.rs"
 required-features = ["ws"]
+
+[[example]]
+name = "namespace_reflector"
+path = "namespace_reflector.rs"

--- a/examples/namespace_reflector.rs
+++ b/examples/namespace_reflector.rs
@@ -1,0 +1,49 @@
+use futures::TryStreamExt;
+use k8s_openapi::api::core::v1::Namespace;
+use kube::{
+    api::Api,
+    runtime::{predicates, reflector, watcher, WatchStreamExt},
+    Client, ResourceExt,
+};
+use tracing::*;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let client = Client::try_default().await?;
+
+    let api: Api<Namespace> = Api::all(client);
+    let (reader, writer) = reflector::store::<Namespace>();
+
+    tokio::spawn(async move {
+        // Show state every 5 seconds of watching
+        loop {
+            reader.wait_until_ready().await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            info!("Current namespace count: {}", reader.state().len());
+            // full information with debug logs
+            for p in reader.state() {
+                let yaml = serde_yaml::to_string(p.as_ref()).unwrap();
+                debug!("Namespace {}: \n{}", p.name_any(), yaml);
+            }
+        }
+    });
+
+    let stream = watcher(api, watcher::Config::default().streaming_lists())
+        .default_backoff()
+        .modify(|ns| {
+            // memory optimization for our store - we don't care about managed fields/annotations/status
+            ns.managed_fields_mut().clear();
+            ns.annotations_mut().clear();
+            ns.status = None;
+        })
+        .reflect(writer)
+        .applied_objects()
+        .predicate_filter(predicates::resource_version); // NB: requires an unstable feature
+
+    futures::pin_mut!(stream);
+    while let Some(ns) = stream.try_next().await? {
+        info!("saw {}", ns.name_any());
+    }
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -83,11 +83,12 @@ e2e-job-musl features:
   chmod +x e2e/job
 
 k3d:
-  k3d cluster create main --servers 1 --registry-create main \
+  k3d cluster create main --servers 1 --registry-create main --image rancher/k3s:v1.27.3-k3s1 \
     --no-lb --no-rollback \
     --k3s-arg "--disable=traefik,servicelb,metrics-server@server:*" \
     --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
-    --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*'
+    --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*' \
+    --k3s-arg '--kube-apiserver-arg=feature-gates=WatchList=true'
 
 ## RELEASE RELATED
 

--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -53,7 +53,7 @@ pub mod rustls_tls {
 
         let mut client_config = if let Some((chain, pkey)) = identity_pem.map(client_auth).transpose()? {
             config_builder
-                .with_single_cert(chain, pkey)
+                .with_client_auth_cert(chain, pkey)
                 .map_err(Error::InvalidPrivateKey)?
         } else {
             config_builder.with_no_client_auth()

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -305,6 +305,29 @@ pub struct WatchParams {
     /// If the feature gate WatchBookmarks is not enabled in apiserver,
     /// this field is ignored.
     pub bookmarks: bool,
+
+    /// Kubernetes 1.27 Streaming Lists
+    /// `sendInitialEvents=true` may be set together with `watch=true`.
+    /// In that case, the watch stream will begin with synthetic events to
+    /// produce the current state of objects in the collection. Once all such
+    /// events have been sent, a synthetic "Bookmark" event  will be sent.
+    /// The bookmark will report the ResourceVersion (RV) corresponding to the
+    /// set of objects, and be marked with `"k8s.io/initial-events-end": "true"` annotation.
+    /// Afterwards, the watch stream will proceed as usual, sending watch events
+    /// corresponding to changes (subsequent to the RV) to objects watched.
+    ///
+    /// When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+    /// option to also be set. The semantic of the watch request is as following:
+    /// - `resourceVersionMatch` = NotOlderThan
+    ///   is interpreted as "data at least as new as the provided `resourceVersion`"
+    ///   and the bookmark event is send when the state is synced
+    ///   to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+    ///   If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+    ///   bookmark event is send when the state is synced at least to the moment
+    ///   when request started being processed.
+    /// - `resourceVersionMatch` set to any other value or unset
+    ///   Invalid error is returned.
+    pub send_initial_events: bool,
 }
 
 impl WatchParams {
@@ -314,6 +337,11 @@ impl WatchParams {
             if *to >= 295 {
                 return Err(Error::Validation("WatchParams::timeout must be < 295s".into()));
             }
+        }
+        if self.send_initial_events && !self.bookmarks {
+            return Err(Error::Validation(
+                "WatchParams::bookmarks must be set when using send_initial_events".into(),
+            ));
         }
         Ok(())
     }
@@ -334,6 +362,10 @@ impl WatchParams {
         if self.bookmarks {
             qp.append_pair("allowWatchBookmarks", "true");
         }
+        if self.send_initial_events {
+            qp.append_pair("sendInitialEvents", "true");
+            qp.append_pair("resourceVersionMatch", "NotOlderThan");
+        }
     }
 }
 
@@ -347,6 +379,7 @@ impl Default for WatchParams {
             label_selector: None,
             field_selector: None,
             timeout: None,
+            send_initial_events: false,
         }
     }
 }
@@ -399,6 +432,37 @@ impl WatchParams {
     #[must_use]
     pub fn disable_bookmarks(mut self) -> Self {
         self.bookmarks = false;
+        self
+    }
+
+    /// Kubernetes 1.27 Streaming Lists
+    /// `sendInitialEvents=true` may be set together with `watch=true`.
+    /// In that case, the watch stream will begin with synthetic events to
+    /// produce the current state of objects in the collection. Once all such
+    /// events have been sent, a synthetic "Bookmark" event  will be sent.
+    /// The bookmark will report the ResourceVersion (RV) corresponding to the
+    /// set of objects, and be marked with `"k8s.io/initial-events-end": "true"` annotation.
+    /// Afterwards, the watch stream will proceed as usual, sending watch events
+    /// corresponding to changes (subsequent to the RV) to objects watched.
+    ///
+    /// When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+    /// option to also be set. The semantic of the watch request is as following:
+    /// - `resourceVersionMatch` = NotOlderThan
+    ///   is interpreted as "data at least as new as the provided `resourceVersion`"
+    ///   and the bookmark event is send when the state is synced
+    ///   to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+    ///   If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+    ///   bookmark event is send when the state is synced at least to the moment
+    ///   when request started being processed.
+    /// - `resourceVersionMatch` set to any other value or unset
+    ///   Invalid error is returned.
+    ///
+    /// Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+    /// compatibility reasons) and to false otherwise.
+    #[must_use]
+    pub fn initial_events(mut self) -> Self {
+        self.send_initial_events = true;
+
         self
     }
 }

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -465,6 +465,17 @@ impl WatchParams {
 
         self
     }
+
+    /// Constructor for doing Kubernetes 1.27 Streaming List watches
+    ///
+    /// Enables [`VersionMatch::NotGreaterThan`] semantics and [`WatchParams::send_initial_events`].
+    pub fn streaming_lists() -> Self {
+        Self {
+            send_initial_events: true,
+            bookmarks: true, // required
+            ..WatchParams::default()
+        }
+    }
 }
 
 /// Common query parameters for put/post calls

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -522,6 +522,18 @@ mod test {
             "/api/v1/namespaces/ns/pods?&watch=true&timeoutSeconds=290&allowWatchBookmarks=true&resourceVersion=0"
         );
     }
+
+    #[test]
+    fn watch_streaming_list() {
+        let url = corev1::Pod::url_path(&(), Some("ns"));
+        let wp = WatchParams::default().initial_events();
+        let req = Request::new(url).watch(&wp, "0").unwrap();
+        assert_eq!(
+            req.uri(),
+            "/api/v1/namespaces/ns/pods?&watch=true&timeoutSeconds=290&allowWatchBookmarks=true&sendInitialEvents=true&resourceVersionMatch=NotOlderThan&resourceVersion=0"
+        );
+    }
+
     #[test]
     fn watch_metadata_path() {
         let url = corev1::Pod::url_path(&(), Some("ns"));

--- a/kube-core/src/watch.rs
+++ b/kube-core/src/watch.rs
@@ -59,4 +59,9 @@ pub struct Bookmark {
 pub struct BookmarkMeta {
     /// The only field we need from a Bookmark event.
     pub resource_version: String,
+
+    /// Kubernetes 1.27 Streaming Lists
+    /// The rest of the fields are optional and may be empty.
+    #[serde(default)]
+    pub annotations: std::collections::BTreeMap<String, String>,
 }

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -237,15 +237,13 @@ pub struct Config {
     pub list_semantic: ListSemantic,
 
     /// Kubernetes 1.27 Streaming Lists
-    /// Determines how the watcher fetches the initial list of objects.
-    /// Defaults to `ListWatch` for backwards compatibility.
+    /// Control how the watcher fetches the initial list of objects.
     ///
     /// ListWatch: The watcher will fetch the initial list of objects using a list call.
     /// StreamingList: The watcher will fetch the initial list of objects using a watch call.
     ///
     /// StreamingList is more efficient than ListWatch, but it requires the server to support
-    /// streaming list bookmarks. If the server does not support streaming list bookmarks,
-    /// the watcher will fall back to ListWatch.
+    /// streaming list bookmarks (opt-in feature gate in Kubernetes 1.27).
     ///
     /// See https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
     /// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3157-watch-list#design-details


### PR DESCRIPTION
## Motivation

Implement support for [watch-list](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/3157-watch-list/README.md). 

We have 18000 namespaces in our cluster, we store custom resources where some collections have large schemas and the cardinality is also in the 100k's. For example, when a client doesn't use pagination our API server memory usage can balloon up to 2-300 GB under certain conditions

## Solution

The most important goal is to reduce memory pressure on the API server. It would be nice to be able to reduce it on the client side too, in that case, we also care about knowing when the initial sync and or resync is in progress or at the very least completed. 

Since this is for a new k8s version, I think it might be ok to change the watch event contract slightly.  I've come up with a couple of approaches

Option 1: do nothing, still accumulate everything in a vec and emit `Event::Restarted` as the first event, when this streaming model is enabled. The name of the event is a bit weird, and it could maybe be renamed to express intent better although that would introduce breaking changes
Option 2: Modify the applied event to have an option<bool> or an enum value to indicate if we're still in the initial listing state
Option 3: Introduce 2 new events, one that indicates a relist is starting and one that indicates the relist is completed, this can then remove the need for the Restarted event because these 2 new events give enough signal. 
Option 4: stop being helpful and just expose the same events as the plain k8s API

Personally I'm in favor of option 3. Option 3 will allow for keeping client-side memory usage low, and it would allow for flagging a store as in or out of sync.
This PR currently holds option 1

This is a draft, so it's not signed. I'll work through what is required to submit PR's from my work email for the final PR. I just wanted to gather feedback.

closes: #1254 
