### PR TITLE
Change default TLS stack to `rustls-tls`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,19 +37,9 @@ jobs:
       #     echo "OPENSSL_LIB_DIR=C:/Program Files/OpenSSL-Win64/lib" >> $env:GITHUB_ENV
       #     echo "OPENSSL_DIR=C:/Program Files/OpenSSL-Win64/" >> $env:GITHUB_ENV
       #     echo "OPENSSL_INCLUDE_DIR=C:/Program Files/OpenSSL-Win64/include" >> $env:GITHUB_ENV
-      # Only test Rustls on Windows instead due to #1191
-      - name: "Interim Hacky Windows Test for #1191"
-        if: matrix.os == 'windows-latest'
-        run: |
-          sed -i '0,/openssl/s//rustls/' kube/Cargo.toml
-          cat kube/Cargo.toml
-          cargo build
-          cargo test --workspace --lib --exclude kube-examples --exclude e2e -j6
-
 
       # Real CI work starts here
       - name: Build workspace
-        if: matrix.os != 'windows-latest'
         run: cargo build
 
       # Workspace unit tests with various feature sets
@@ -58,7 +48,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' # only linux tests all feature combinations
       - name: Run workspace unit tests (default features)
         run: cargo test --workspace --lib --exclude kube-examples --exclude e2e -j6
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os != 'macos-latest'
       - name: Run workspace unit tests (all features)
         if: matrix.os != 'windows-latest'
         run: cargo test --workspace --lib --all-features --exclude kube-examples --exclude e2e -j6

--- a/README.md
+++ b/README.md
@@ -146,17 +146,17 @@ Controller::new(root_kind_api, Config::default())
 
 Here `reconcile` and `error_policy` refer to functions you define. The first will be called when the root or child elements change, and the second when the `reconciler` returns an `Err`.
 
-## Rustls
+## TLS
 
-By default `openssl` is used for TLS, but [rustls](https://github.com/ctz/rustls) is supported. To switch, turn off `default-features`, and enable the `rustls-tls` feature:
+By default [rustls](https://github.com/ctz/rustls) is used for TLS, but `openssl` is supported. To switch, turn off `default-features`, and enable the `openssl-tls` feature:
 
 ```toml
 [dependencies]
-kube = { version = "0.84.0", default-features = false, features = ["client", "rustls-tls"] }
+kube = { version = "0.84.0", default-features = false, features = ["client", "openssl-tls"] }
 k8s-openapi = { version = "0.18.0", features = ["v1_26"] }
 ```
 
-This will pull in `rustls` and `hyper-rustls`. If `default-features` is left enabled, you will pull in two TLS stacks, and the default will remain as `openssl`.
+This will pull in `openssl` and `hyper-openssl`. If `default-features` is left enabled, you will pull in two TLS stacks, and the default will remain as `rustls`.
 
 ## musl-libc
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 release = false
 
 [features]
-default = ["openssl-tls", "kubederive", "ws", "latest", "runtime", "refresh"]
+default = ["rustls-tls", "kubederive", "ws", "latest", "runtime", "refresh"]
 kubederive = ["kube/derive"]
 openssl-tls = ["kube/client", "kube/openssl-tls"]
 rustls-tls = ["kube/client", "kube/rustls-tls"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -128,9 +128,9 @@ cargo run --example crd_reflector
 
 The `crd_reflector` will just await changes. You can run `kubectl apply -f crd-baz.yaml`, or `kubectl delete -f crd-baz.yaml -n default`, or `kubectl edit foos baz -n default` to verify that the events are being picked up.
 
-## rustls
-Disable default features and enable `rustls-tls`:
+## openssl
+Disable default features and enable `openssl-tls`:
 
 ```sh
-cargo run --example pod_watcher --no-default-features --features=rustls-tls,latest,runtime
+cargo run --example pod_watcher --no-default-features --features=openssl-tls,latest,runtime
 ```

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -9,7 +9,8 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let config = Config::infer().await?;
-    let https = config.openssl_https_connector()?;
+
+    let https = config.rustls_https_connector()?;
     let service = tower::ServiceBuilder::new()
         .layer(config.base_uri_layer())
         .option_layer(config.auth_layer()?)

--- a/examples/custom_client_tls.rs
+++ b/examples/custom_client_tls.rs
@@ -14,15 +14,15 @@ async fn main() -> anyhow::Result<()> {
     let config = Config::infer().await?;
 
     // Pick TLS at runtime
-    let use_rustls = std::env::var("USE_RUSTLS").map(|s| s == "1").unwrap_or(false);
-    let client = if use_rustls {
-        let https = config.rustls_https_connector()?;
+    let use_openssl = std::env::var("USE_OPENSSL").map(|s| s == "1").unwrap_or(false);
+    let client = if use_openssl {
+        let https = config.openssl_https_connector()?;
         let service = ServiceBuilder::new()
             .layer(config.base_uri_layer())
             .service(hyper::Client::builder().build(https));
         Client::new(service, config.default_namespace)
     } else {
-        let https = config.openssl_https_connector()?;
+        let https = config.rustls_https_connector()?;
         let service = ServiceBuilder::new()
             .layer(config.base_uri_layer())
             .service(hyper::Client::builder().build(https));

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -14,7 +14,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let config = Config::infer().await?;
-    let https = config.openssl_https_connector()?;
+    let https = config.rustls_https_connector()?;
     let service = ServiceBuilder::new()
         .layer(config.base_uri_layer())
         // showcase rate limiting; max 10rps, and 4 concurrent

--- a/kube-client/src/client/auth/oauth.rs
+++ b/kube-client/src/client/auth/oauth.rs
@@ -108,17 +108,17 @@ impl Gcp {
                     "At least one of rustls-tls or openssl-tls feature must be enabled to use oauth feature"
                 );
                 // Current TLS feature precedence when more than one are set:
-                // 1. openssl-tls
-                // 2. rustls-tls
-                #[cfg(feature = "openssl-tls")]
-                let https =
-                    hyper_openssl::HttpsConnector::new().map_err(Error::CreateOpensslHttpsConnector)?;
-                #[cfg(all(not(feature = "openssl-tls"), feature = "rustls-tls"))]
+                // 1. rustls-tls
+                // 2. openssl-tls
+                #[cfg(feature = "rustls-tls")]
                 let https = hyper_rustls::HttpsConnectorBuilder::new()
                     .with_native_roots()
                     .https_only()
                     .enable_http1()
                     .build();
+                #[cfg(all(not(feature = "rustls-tls"), feature = "openssl-tls"))]
+                let https =
+                    hyper_openssl::HttpsConnector::new().map_err(Error::CreateOpensslHttpsConnector)?;
 
                 let client = hyper::Client::builder().build::<_, hyper::Body>(https);
 

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -88,8 +88,8 @@ impl TryFrom<Config> for ClientBuilder<BoxService<Request<hyper::Body>, Response
             #[cfg(all(not(feature = "rustls-tls"), feature = "openssl-tls"))]
             let connector = config.openssl_https_connector_with_connector(connector)?;
             #[cfg(all(not(feature = "rustls-tls"), not(feature = "openssl-tls")))]
-            if auth_layer.is_none() {
-                // no tls stack situation only works on anonymous auth
+            if auth_layer.is_none() || config.cluster_url.scheme() == Some(&http::uri::Scheme::HTTPS) {
+                // no tls stack situation only works on anonymous auth with http scheme
                 return Err(Error::TlsRequired);
             }
 

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -78,14 +78,14 @@ impl TryFrom<Config> for ClientBuilder<BoxService<Request<hyper::Body>, Response
             connector.enforce_http(false);
 
             // Current TLS feature precedence when more than one are set:
-            // 1. openssl-tls
-            // 2. rustls-tls
+            // 1. rustls-tls
+            // 2. openssl-tls
             // Create a custom client to use something else.
             // If TLS features are not enabled, http connector will be used.
-            #[cfg(feature = "openssl-tls")]
-            let connector = config.openssl_https_connector_with_connector(connector)?;
-            #[cfg(all(not(feature = "openssl-tls"), feature = "rustls-tls"))]
+            #[cfg(feature = "rustls-tls")]
             let connector = config.rustls_https_connector_with_connector(connector)?;
+            #[cfg(all(not(feature = "rustls-tls"), feature = "openssl-tls"))]
+            let connector = config.openssl_https_connector_with_connector(connector)?;
 
             let mut connector = TimeoutConnector::new(connector);
 

--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -53,7 +53,7 @@ pub mod rustls_tls {
 
         let mut client_config = if let Some((chain, pkey)) = identity_pem.map(client_auth).transpose()? {
             config_builder
-                .with_single_cert(chain, pkey)
+                .with_client_auth_cert(chain, pkey)
                 .map_err(Error::InvalidPrivateKey)?
         } else {
             config_builder.with_no_client_auth()

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -71,6 +71,10 @@ pub enum Error {
     #[error("rustls tls error: {0}")]
     RustlsTls(#[source] crate::client::RustlsTlsError),
 
+    /// Missing TLS stacks when TLS is required
+    #[error("TLS required but no TLS stack selected")]
+    TlsRequired,
+
     /// Failed to upgrade to a WebSocket connection
     #[cfg(feature = "ws")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -16,18 +16,24 @@ rust-version = "1.64.0"
 edition = "2021"
 
 [features]
-default = ["client", "openssl-tls"]
+default = ["client", "rustls-tls"]
+
+# default features
+client = ["kube-client/client", "config"]
+config = ["kube-client/config"]
 rustls-tls = ["kube-client/rustls-tls"]
+
+# alternative features
 openssl-tls = ["kube-client/openssl-tls"]
+
+# auxiliary features
 ws = ["kube-client/ws", "kube-core/ws"]
 oauth = ["kube-client/oauth"]
 oidc = ["kube-client/oidc"]
 gzip = ["kube-client/gzip"]
-client = ["kube-client/client", "config"]
 jsonpatch = ["kube-core/jsonpatch"]
 admission = ["kube-core/admission"]
 derive = ["kube-derive", "kube-core/schema"]
-config = ["kube-client/config"]
 runtime = ["kube-runtime"]
 unstable-runtime = ["kube-runtime/unstable-runtime"]
 


### PR DESCRIPTION
## Motivation

Want to encourage the use of the more secure and robust TLS stack by default.
Based on feedback (see e.g. #1192) and personal experience have not seen or heard about any current issues.
The main blocker bug was resolved some months ago
This also allows us to not have a [huge windows hack in our windows CI](https://github.com/kube-rs/kube/blob/a9f1a4f141d6ccdbf8e327955c51fa0d4bdf446b/.github/workflows/ci.yml#L29-L53).

## Solution

- switch our explicit default to feature to `kube/rustls-tls`
- switch our precedence when both features are enabled to `rustls-tls`
- make windows run tests in the same way as other platforms

As a clean-up while in the area, have also prevented erroneous `Client` construction on a TLS requiring cluster, when TLS stacks are disabled. That caused an ugly freezen in #1275
