### PR TITLE
add `controller::Config` and debounce period to scheduler

### DIFF
--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -7,7 +7,7 @@ use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
     api::{Api, ObjectMeta, Patch, PatchParams, Resource},
     runtime::{
-        controller::{Action, Controller},
+        controller::{Action, Config, Controller},
         watcher,
     },
     Client, CustomResource,
@@ -102,8 +102,11 @@ async fn main() -> Result<()> {
         }
     });
 
+    let mut config = Config::default();
+    config.debounce(Duration::from_secs(2));
     Controller::new(cmgs, watcher::Config::default())
         .owns(cms, watcher::Config::default())
+        .with_config(config)
         .reconcile_all_on(reload_rx.map(|_| ()))
         .shutdown_on_signal()
         .run(reconcile, error_policy, Arc::new(Data { client }))

--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -7,7 +7,7 @@ use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
     api::{Api, ObjectMeta, Patch, PatchParams, Resource},
     runtime::{
-        controller::{Action, Config, Controller},
+        controller::{Action, Controller},
         watcher,
     },
     Client, CustomResource,
@@ -102,11 +102,8 @@ async fn main() -> Result<()> {
         }
     });
 
-    let mut config = Config::default();
-    config.debounce(Duration::from_secs(2));
     Controller::new(cmgs, watcher::Config::default())
         .owns(cms, watcher::Config::default())
-        .with_config(config)
         .reconcile_all_on(reload_rx.map(|_| ()))
         .shutdown_on_signal()
         .run(reconcile, error_policy, Arc::new(Data { client }))

--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -156,7 +156,7 @@ impl Client {
                     // Error requesting
                     .or_else(|err| err.downcast::<hyper::Error>().map(|err| Error::HyperError(*err)))
                     // Error from another middleware
-                    .unwrap_or_else(|err| Error::Service(err))
+                    .unwrap_or_else(Error::Service)
             })?;
         Ok(res)
     }

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -246,6 +246,7 @@ const APPLIER_REQUEUE_BUF_SIZE: usize = 100;
 ///
 /// This is the "hard-mode" version of [`Controller`], which allows you some more customization
 /// (such as triggering from arbitrary [`Stream`]s), at the cost of being a bit more verbose.
+#[allow(clippy::needless_pass_by_value)]
 pub fn applier<K, QueueStream, ReconcilerFut, Ctx>(
     mut reconciler: impl FnMut(Arc<K>, Arc<Ctx>) -> ReconcilerFut,
     error_policy: impl Fn(Arc<K>, &ReconcilerFut::Error, Arc<Ctx>) -> Action,

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -437,8 +437,10 @@ impl Config {
     /// This option delays (and keeps delaying) reconcile requests for objects while
     /// the object is updated. It can **permanently hide** updates from your reconciler
     /// if set too high on objects that are updated frequently (like nodes).
-    pub fn debounce(&mut self, debounce: Duration) {
+    #[must_use]
+    pub fn debounce(mut self, debounce: Duration) -> Self {
         self.debounce = debounce;
+        self
     }
 }
 
@@ -1331,8 +1333,6 @@ mod tests {
 
         let (queue_tx, queue_rx) = futures::channel::mpsc::unbounded::<ObjectRef<ConfigMap>>();
         let (store_rx, mut store_tx) = reflector::store();
-        let mut config = Config::default();
-        config.debounce(Duration::from_millis(1));
         let applier = applier(
             |obj, _| {
                 Box::pin(async move {
@@ -1345,7 +1345,7 @@ mod tests {
             Arc::new(()),
             store_rx,
             queue_rx.map(Result::<_, Infallible>::Ok),
-            config,
+            Config::default(),
         );
         pin_mut!(applier);
         for i in 0..items {

--- a/kube-runtime/src/controller/runner.rs
+++ b/kube-runtime/src/controller/runner.rs
@@ -158,9 +158,9 @@ mod tests {
         let mut count = 0;
         let (mut sched_tx, sched_rx) = mpsc::unbounded();
         let mut runner = Box::pin(
-            // The debounce period needs to zero because otherwise the scheduler has a default
-            // debounce period of 1 ms, which will lead to the second request to be discarded.
-            Runner::new(scheduler(sched_rx, Some(Duration::ZERO)), |_| {
+            // The debounce period needs to zero because a debounce period > 0
+            // will lead to the second request to be discarded.
+            Runner::new(scheduler(sched_rx), |_| {
                 count += 1;
                 // Panic if this ref is already held, to simulate some unsafe action..
                 let mutex_ref = rc.borrow_mut();
@@ -205,7 +205,7 @@ mod tests {
         // pause();
         let (mut sched_tx, sched_rx) = mpsc::unbounded();
         let (result_tx, result_rx) = oneshot::channel();
-        let mut runner = Runner::new(scheduler(sched_rx, None), |msg: &u8| futures::future::ready(*msg));
+        let mut runner = Runner::new(scheduler(sched_rx), |msg: &u8| futures::future::ready(*msg));
         // Start a background task that starts listening /before/ we enqueue the message
         // We can't just use Stream::poll_next(), since that bypasses the waker system
         Handle::current().spawn(async move { result_tx.send(runner.next().await).unwrap() });
@@ -244,7 +244,6 @@ mod tests {
                         run_at: Instant::now(),
                     }])
                     .chain(stream::pending()),
-                    None,
                 ),
                 |msg| {
                     assert!(*is_ready.lock().unwrap());
@@ -281,7 +280,6 @@ mod tests {
                         },
                     ])
                     .chain(stream::pending()),
-                    None,
                 ),
                 |msg| {
                     assert!(*is_ready.lock().unwrap());
@@ -317,7 +315,6 @@ mod tests {
                         run_at: Instant::now(),
                     }])
                     .chain(stream::pending()),
-                    None,
                 ),
                 |()| {
                     panic!("run_msg should never be invoked if readiness gate fails");

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -29,7 +29,7 @@ pub mod utils;
 pub mod wait;
 pub mod watcher;
 
-pub use controller::{applier, Controller};
+pub use controller::{applier, Config, Controller};
 pub use finalizer::finalizer;
 pub use reflector::reflector;
 pub use scheduler::scheduler;

--- a/kube-runtime/src/scheduler.rs
+++ b/kube-runtime/src/scheduler.rs
@@ -224,6 +224,7 @@ pub fn scheduler<T: Eq + Hash + Clone, S: Stream<Item = ScheduleRequest<T>>>(req
 /// to receive an uninterrupted request before actually emitting it.
 ///
 /// For more info, see [`scheduler()`].
+#[allow(clippy::module_name_repetitions)]
 pub fn debounced_scheduler<T: Eq + Hash + Clone, S: Stream<Item = ScheduleRequest<T>>>(
     requests: S,
     debounce: Duration,


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
Without debouncing, the scheduler does not get enough time to deduplicate events leading to unnecessary reconcile runs by the controller. Although reconcile loops are idempotent, we should avoid running them if not required.
<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution
Add `controller::Config` to allow configuring the behavior of the controller. Introduce a debounce period for the scheduler to allow for deduplication of requests. By default, the debounce period is set to 1 second.
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

Fixes #1247 