### PR TITLE
`Arc` wrap watcher output

### DIFF
--- a/examples/dynamic_watcher.rs
+++ b/examples/dynamic_watcher.rs
@@ -6,7 +6,7 @@ use kube::{
 use serde::de::DeserializeOwned;
 use tracing::*;
 
-use std::{env, fmt::Debug};
+use std::{env, fmt::Debug, sync::Arc};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -39,9 +39,9 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn handle_events<
-    K: Resource<DynamicType = ApiResource> + Clone + Debug + Send + DeserializeOwned + 'static,
+    K: Resource<DynamicType = ApiResource> + Clone + Debug + Send + Sync + DeserializeOwned + 'static,
 >(
-    stream: impl Stream<Item = watcher::Result<Event<K>>> + Send + 'static,
+    stream: impl Stream<Item = watcher::Result<Event<Arc<K>>>> + Send + 'static,
     ar: &ApiResource,
 ) -> anyhow::Result<()> {
     let mut items = stream.applied_objects().boxed();

--- a/examples/event_watcher.rs
+++ b/examples/event_watcher.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use futures::{pin_mut, TryStreamExt};
 use k8s_openapi::api::core::v1::Event;
 use kube::{
@@ -25,12 +27,12 @@ async fn main() -> anyhow::Result<()> {
 }
 
 // This function lets the app handle an added/modified event from k8s
-fn handle_event(ev: Event) -> anyhow::Result<()> {
+fn handle_event(ev: Arc<Event>) -> anyhow::Result<()> {
     info!(
         "Event: \"{}\" via {} {}",
-        ev.message.unwrap().trim(),
-        ev.involved_object.kind.unwrap(),
-        ev.involved_object.name.unwrap()
+        ev.message.as_ref().unwrap().trim(),
+        ev.involved_object.kind.as_ref().unwrap(),
+        ev.involved_object.name.as_ref().unwrap()
     );
     Ok(())
 }

--- a/examples/multi_watcher.rs
+++ b/examples/multi_watcher.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use futures::{stream, StreamExt, TryStreamExt};
 use k8s_openapi::api::{
     apps::v1::Deployment,
@@ -31,9 +33,9 @@ async fn main() -> anyhow::Result<()> {
     // SelectAll Stream elements must have the same Item, so all packed in this:
     #[allow(clippy::large_enum_variant)]
     enum Watched {
-        Config(ConfigMap),
-        Deploy(Deployment),
-        Secret(Secret),
+        Config(Arc<ConfigMap>),
+        Deploy(Arc<Deployment>),
+        Secret(Arc<Secret>),
     }
     while let Some(o) = combo_stream.try_next().await? {
         match o {

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use futures::{pin_mut, TryStreamExt};
 use k8s_openapi::api::core::v1::{Event, Node};
 use kube::{
@@ -25,12 +27,13 @@ async fn main() -> anyhow::Result<()> {
 }
 
 // A simple node problem detector
-async fn check_for_node_failures(events: &Api<Event>, o: Node) -> anyhow::Result<()> {
+async fn check_for_node_failures(events: &Api<Event>, o: Arc<Node>) -> anyhow::Result<()> {
     let name = o.name_any();
     // Nodes often modify a lot - only print broken nodes
-    if let Some(true) = o.spec.unwrap().unschedulable {
+    if let Some(true) = o.spec.clone().unwrap().unschedulable {
         let failed = o
             .status
+            .clone()
             .unwrap()
             .conditions
             .unwrap()

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1207,7 +1207,7 @@ where
         applier(
             move |obj, ctx| {
                 CancelableJoinHandle::spawn(
-                    reconciler(obj, ctx).into_future().in_current_span(),
+                    reconciler(obj.clone(), ctx).into_future().in_current_span(),
                     &Handle::current(),
                 )
             },

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -7,7 +7,7 @@ pub use self::object_ref::{Extra as ObjectRefExtra, ObjectRef};
 use crate::watcher;
 use futures::{Stream, TryStreamExt};
 use kube_client::Resource;
-use std::hash::Hash;
+use std::{hash::Hash, sync::Arc};
 pub use store::{store, Store};
 
 /// Cache objects from a [`watcher()`] stream into a local [`Store`]
@@ -93,7 +93,7 @@ pub fn reflector<K, W>(mut writer: store::Writer<K>, stream: W) -> impl Stream<I
 where
     K: Resource + Clone,
     K::DynamicType: Eq + Hash + Clone,
-    W: Stream<Item = watcher::Result<watcher::Event<K>>>,
+    W: Stream<Item = watcher::Result<watcher::Event<Arc<K>>>>,
 {
     stream.inspect_ok(move |event| writer.apply_watcher_event(event))
 }

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -58,15 +58,14 @@ where
     }
 
     /// Applies a single watcher event to the store
-    pub fn apply_watcher_event(&mut self, event: &watcher::Event<K>) {
+    pub fn apply_watcher_event(&mut self, event: &watcher::Event<Arc<K>>) {
         match event {
             watcher::Event::Applied(obj) => {
-                let key = ObjectRef::from_obj_with(obj, self.dyntype.clone());
-                let obj = Arc::new(obj.clone());
-                self.store.write().insert(key, obj);
+                let key = ObjectRef::from_obj_with(obj.as_ref(), self.dyntype.clone());
+                self.store.write().insert(key, obj.clone());
             }
             watcher::Event::Deleted(obj) => {
-                let key = ObjectRef::from_obj_with(obj, self.dyntype.clone());
+                let key = ObjectRef::from_obj_with(obj.as_ref(), self.dyntype.clone());
                 self.store.write().remove(&key);
             }
             watcher::Event::Restarted(new_objs) => {
@@ -74,8 +73,8 @@ where
                     .iter()
                     .map(|obj| {
                         (
-                            ObjectRef::from_obj_with(obj, self.dyntype.clone()),
-                            Arc::new(obj.clone()),
+                            ObjectRef::from_obj_with(obj.as_ref(), self.dyntype.clone()),
+                            obj.clone(),
                         )
                     })
                     .collect::<AHashMap<_, _>>();

--- a/kube-runtime/src/utils/event_flatten.rs
+++ b/kube-runtime/src/utils/event_flatten.rs
@@ -59,39 +59,43 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::task::Poll;
+    use std::{sync::Arc, task::Poll};
 
     use super::{Error, Event, EventFlatten};
     use futures::{pin_mut, poll, stream, StreamExt};
 
     #[tokio::test]
     async fn watches_applies_uses_correct_eventflattened_stream() {
+        let zero = Arc::new(0);
+        let one = Arc::new(1);
+        let two = Arc::new(2);
+
         let data = stream::iter([
-            Ok(Event::Applied(0)),
-            Ok(Event::Applied(1)),
-            Ok(Event::Deleted(0)),
-            Ok(Event::Applied(2)),
-            Ok(Event::Restarted(vec![1, 2])),
+            Ok(Event::Applied(zero.clone())),
+            Ok(Event::Applied(one.clone())),
+            Ok(Event::Deleted(zero.clone())),
+            Ok(Event::Applied(two.clone())),
+            Ok(Event::Restarted(vec![one.clone(), two.clone()])),
             Err(Error::TooManyObjects),
-            Ok(Event::Applied(2)),
+            Ok(Event::Applied(two.clone())),
         ]);
         let rx = EventFlatten::new(data, false);
         pin_mut!(rx);
-        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(0)))));
-        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(1)))));
+        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(v))) if *v ==  0));
+        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(v))) if *v == 1));
         // NB: no Deleted events here
-        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(2)))));
+        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(v))) if *v == 2));
         // Restart comes through, currently in reverse order
         // (normally on restart they just come in alphabetical order by name)
         // this is fine though, alphabetical event order has no functional meaning in watchers
-        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(1)))));
-        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(2)))));
+        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(v))) if *v == 1));
+        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(v))) if *v == 2));
         // Error passed through
         assert!(matches!(
             poll!(rx.next()),
             Poll::Ready(Some(Err(Error::TooManyObjects)))
         ));
-        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(2)))));
+        assert!(matches!(poll!(rx.next()), Poll::Ready(Some(Ok(v))) if *v == 2));
         assert!(matches!(poll!(rx.next()), Poll::Ready(None)));
     }
 }

--- a/kube-runtime/src/utils/reflect.rs
+++ b/kube-runtime/src/utils/reflect.rs
@@ -2,6 +2,7 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
+use std::sync::Arc;
 
 use futures::{Stream, TryStream};
 use pin_project::pin_project;
@@ -39,9 +40,9 @@ impl<St, K> Stream for Reflect<St, K>
 where
     K: Resource + Clone,
     K::DynamicType: Eq + std::hash::Hash + Clone,
-    St: Stream<Item = Result<Event<K>, Error>>,
+    St: Stream<Item = Result<Event<Arc<K>>, Error>>,
 {
-    type Item = Result<Event<K>, Error>;
+    type Item = Result<Event<Arc<K>>, Error>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut me = self.project();

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -79,14 +79,14 @@ pub trait WatchStreamExt: Stream {
     /// pin_mut!(truncated_deploy_stream);
     ///
     /// while let Some(d) = truncated_deploy_stream.try_next().await? {
-    ///    println!("Truncated Deployment: '{:?}'", serde_json::to_string(&d)?);
+    ///    println!("Truncated Deployment: '{:?}'", serde_json::to_string(d.as_ref())?);
     /// }
     /// # Ok(())
     /// # }
     /// ```
     fn modify<F, K>(self, f: F) -> EventModify<Self, F>
     where
-        Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Sized,
+        Self: Stream<Item = Result<watcher::Event<Arc<K>>, watcher::Error>> + Sized,
         F: FnMut(&mut K),
     {
         EventModify::new(self, f)
@@ -123,7 +123,7 @@ pub trait WatchStreamExt: Stream {
     #[cfg(feature = "unstable-runtime-predicates")]
     fn predicate_filter<K, P>(self, predicate: P) -> PredicateFilter<Self, K, P>
     where
-        Self: Stream<Item = Result<K, watcher::Error>> + Sized,
+        Self: Stream<Item = Result<Arc<K>, watcher::Error>> + Sized,
         K: Resource + 'static,
         P: Predicate<K> + 'static,
     {
@@ -243,7 +243,7 @@ pub trait WatchStreamExt: Stream {
     /// [`Store`]: crate::reflector::Store
     fn reflect<K>(self, writer: Writer<K>) -> Reflect<Self, K>
     where
-        Self: Stream<Item = watcher::Result<watcher::Event<K>>> + Sized,
+        Self: Stream<Item = watcher::Result<watcher::Event<Arc<K>>>> + Sized,
         K: Resource + Clone + 'static,
         K::DynamicType: Eq + std::hash::Hash + Clone,
     {
@@ -269,7 +269,7 @@ pub(crate) mod tests {
 
     pub fn assert_stream<T, K>(x: T) -> T
     where
-        T: Stream<Item = watcher::Result<K>> + Send,
+        T: Stream<Item = watcher::Result<Arc<K>>> + Send,
         K: Resource + Clone + Send + 'static,
     {
         x

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 #[cfg(feature = "unstable-runtime-predicates")]
 use crate::utils::predicate::{Predicate, PredicateFilter};
 #[cfg(feature = "unstable-runtime-subscribe")]
@@ -40,7 +42,7 @@ pub trait WatchStreamExt: Stream {
     /// All Added/Modified events are passed through, and critical errors bubble up.
     fn applied_objects<K>(self) -> EventFlatten<Self, K>
     where
-        Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Sized,
+        Self: Stream<Item = Result<watcher::Event<Arc<K>>, watcher::Error>> + Sized,
     {
         EventFlatten::new(self, false)
     }
@@ -50,7 +52,7 @@ pub trait WatchStreamExt: Stream {
     /// All Added/Modified/Deleted events are passed through, and critical errors bubble up.
     fn touched_objects<K>(self) -> EventFlatten<Self, K>
     where
-        Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Sized,
+        Self: Stream<Item = Result<watcher::Event<Arc<K>>, watcher::Error>> + Sized,
     {
         EventFlatten::new(self, true)
     }

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -383,7 +383,7 @@ mod test {
             .await?;
         let establish = await_condition(crds.clone(), "testcrs.kube.rs", conditions::is_crd_established());
         let crd = tokio::time::timeout(std::time::Duration::from_secs(10), establish).await??;
-        assert!(conditions::is_crd_established().matches_object(crd.as_ref()));
+        assert!(conditions::is_crd_established().matches_object(crd.as_ref().map(|v| &**v)));
         tokio::time::sleep(std::time::Duration::from_secs(2)).await; // Established condition is actually not enough for api discovery :(
 
         // create partial information for it to discover

--- a/kube/src/mock_tests.rs
+++ b/kube/src/mock_tests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     runtime::{
         watcher::{watcher, Config},
@@ -35,9 +37,9 @@ async fn watchers_respect_pagination_limits() {
     let api: Api<Hack> = Api::all(client);
     let cfg = Config::default().page_size(1);
     let mut stream = watcher(api, cfg).applied_objects().boxed();
-    let first: Hack = stream.try_next().await.unwrap().unwrap();
+    let first: Arc<Hack> = stream.try_next().await.unwrap().unwrap();
     assert_eq!(first.spec.num, 1);
-    let second: Hack = stream.try_next().await.unwrap().unwrap();
+    let second: Arc<Hack> = stream.try_next().await.unwrap().unwrap();
     assert_eq!(second.spec.num, 2);
     assert!(poll!(stream.next()).is_pending());
     timeout_after_1s(mocksrv).await;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Controller machinery has been changed to support arbitrary streams; users may instantiate controllers with already established watches, or already created stores. A subscriber interface has also been added to allow for stream sharing; due to the implementation details of the subscriber interface, the output is incompatible with what the controller expects.

This change started as a proof of concept based on https://github.com/kube-rs/kube/issues/1189. It attempts to bridge the two APIs by `Arc`ing the output from watchers. Since this is done at a very low level in the codepath, both the controller and other dependent helpers (e.g. the reflector or event flattener) have been changed to both read and write arc'd streams. As an added benefit, arced streams should relieve some memory pressure by avoiding clones on k8s objects.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

1. Changed `step_trampolined` to arc the object. This is propagated all the way up to the `watcher()`.
2. Reflectors now clone the Arc instead of doing their own Arcs.
3. Event flatten now unwraps the inner value of an event and returns it as an `Arc`
4. Controller now internally works on Arc'd streams. A few associated type bounds have been changed in the triggers (mostly for ok values of TryStreams). Mappers have also had their signatures changed.
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
