### PR TITLE
fix typo in kube-runtime controller example

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -427,7 +427,7 @@ where
 ///
 /// Reconciles are generally requested for all changes on your root objects.
 /// Changes to managed child resources will also trigger the reconciler for the
-/// managing object by travirsing owner references (for `Controller::owns`),
+/// managing object by traversing owner references (for `Controller::owns`),
 /// or traverse a custom mapping (for `Controller::watches`).
 ///
 /// This mapping mechanism ultimately hides the reason for the reconciliation request,


### PR DESCRIPTION
Minor spelling error in the `Controller` struct documentation example. This is fixed by this PR.
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
N/A
<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution
N/A
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
