### PR TITLE
Upgrade `k8s-openapi` to `0.19.0` for `v1_27` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run these tests against older clusters as well
-        k8s: [v1.21, latest]
+        k8s: [v1.22, latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -205,7 +205,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.21
+          version: v1.22
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
 [![Rust 1.64](https://img.shields.io/badge/MSRV-1.64-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.64.0)
-[![Tested against Kubernetes v1_21 and above](https://img.shields.io/badge/MK8SV-v1_21-326ce5.svg)](https://kube.rs/kubernetes-version)
+[![Tested against Kubernetes v1_22 and above](https://img.shields.io/badge/MK8SV-v1_22-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)
 
@@ -17,7 +17,7 @@ Select a version of `kube` along with the generated [k8s-openapi](https://github
 ```toml
 [dependencies]
 kube = { version = "0.84.0", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.18.0", features = ["v1_26"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_27"] }
 ```
 
 [Features are available](https://github.com/kube-rs/kube/blob/main/kube/Cargo.toml#L18).
@@ -153,7 +153,7 @@ By default `openssl` is used for TLS, but [rustls](https://github.com/ctz/rustls
 ```toml
 [dependencies]
 kube = { version = "0.84.0", default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.18.0", features = ["v1_26"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_27"] }
 ```
 
 This will pull in `rustls` and `hyper-rustls`. If `default-features` is left enabled, you will pull in two TLS stacks, and the default will remain as `openssl`.

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -18,8 +18,8 @@ name = "boot"
 path = "boot.rs"
 
 [features]
-latest = ["k8s-openapi/v1_26"]
-mk8sv = ["k8s-openapi/v1_21"]
+latest = ["k8s-openapi/v1_27"]
+mk8sv = ["k8s-openapi/v1_22"]
 rustls = ["kube/rustls-tls"]
 openssl = ["kube/openssl-tls"]
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -29,6 +29,6 @@ tracing = "0.1.36"
 tracing-subscriber = "0.3.3"
 futures = "0.3.17"
 kube = { path = "../kube", version = "^0.84.0", default-features = false, features = ["client", "runtime", "ws", "admission", "gzip"] }
-k8s-openapi = { version = "0.18.0", default-features = false }
+k8s-openapi = { version = "0.19.0", default-features = false }
 serde_json = "1.0.68"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3.17"
 jsonpath_lib = "0.3.0"
 kube = { path = "../kube", version = "^0.84.0", default-features = false, features = ["admission"] }
 kube-derive = { path = "../kube-derive", version = "^0.84.0", default-features = false } # only needed to opt out of schema
-k8s-openapi = { version = "0.18.0", default-features = false }
+k8s-openapi = { version = "0.19.0", default-features = false }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.9.19"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,7 +21,7 @@ rustls-tls = ["kube/client", "kube/rustls-tls"]
 runtime = ["kube/runtime", "kube/unstable-runtime"]
 refresh = ["kube/oauth", "kube/oidc"]
 ws = ["kube/ws"]
-latest = ["k8s-openapi/v1_26"]
+latest = ["k8s-openapi/v1_27"]
 
 [dev-dependencies]
 tokio-util = "0.7.0"

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ fmt:
   rustfmt +nightly --edition 2021 $(find . -type f -iname *.rs)
 
 doc:
-  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,oidc,jsonpatch,client,derive,runtime,admission,k8s-openapi/v1_26,unstable-runtime --open
+  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,oidc,jsonpatch,client,derive,runtime,admission,k8s-openapi/v1_27,unstable-runtime --open
 
 deny:
   # might require rm Cargo.lock first to match CI

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -72,7 +72,7 @@ hyper-openssl = { version = "0.9.2", optional = true }
 form_urlencoded = { version = "1.2.0", optional = true }
 
 [dependencies.k8s-openapi]
-version = "0.18.0"
+version = "0.19.0"
 default-features = false
 features = []
 
@@ -85,6 +85,6 @@ tokio-test = "0.4.0"
 tower-test = "0.4.0"
 
 [dev-dependencies.k8s-openapi]
-version = "0.18.0"
+version = "0.19.0"
 default-features = false
 features = ["v1_26"]

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -32,7 +32,7 @@ config = ["__non_core", "pem", "home"]
 __non_core = ["tracing", "serde_yaml", "base64"]
 
 [package.metadata.docs.rs]
-features = ["client", "rustls-tls", "openssl-tls", "ws", "oauth", "oidc", "jsonpatch", "admission", "k8s-openapi/v1_26"]
+features = ["client", "rustls-tls", "openssl-tls", "ws", "oauth", "oidc", "jsonpatch", "admission", "k8s-openapi/v1_27"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -87,4 +87,4 @@ tower-test = "0.4.0"
 [dev-dependencies.k8s-openapi]
 version = "0.19.0"
 default-features = false
-features = ["v1_26"]
+features = ["v1_27"]

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 
 [package.metadata.docs.rs]
-features = ["ws", "admission", "jsonpatch", "k8s-openapi/v1_26"]
+features = ["ws", "admission", "jsonpatch", "k8s-openapi/v1_27"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -43,7 +43,7 @@ features = []
 [dev-dependencies.k8s-openapi]
 version = "0.19.0"
 default-features = false
-features = ["v1_26"]
+features = ["v1_27"]
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -36,12 +36,12 @@ chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 schemars = { version = "0.8.6", optional = true }
 
 [dependencies.k8s-openapi]
-version = "0.18.0"
+version = "0.19.0"
 default-features = false
 features = []
 
 [dev-dependencies.k8s-openapi]
-version = "0.18.0"
+version = "0.19.0"
 default-features = false
 features = ["v1_26"]
 

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro = true
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.9.19"
 kube = { path = "../kube", version = "<1.0.0, >=0.61.0", features = ["derive", "client"] }
-k8s-openapi = { version = "0.19.0", default-features = false, features = ["v1_26"] }
+k8s-openapi = { version = "0.19.0", default-features = false, features = ["v1_27"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 chrono = { version = "0.4.19", default-features = false }
 trybuild = "1.0.48"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro = true
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.9.19"
 kube = { path = "../kube", version = "<1.0.0, >=0.61.0", features = ["derive", "client"] }
-k8s-openapi = { version = "0.18.0", default-features = false, features = ["v1_26"] }
+k8s-openapi = { version = "0.19.0", default-features = false, features = ["v1_26"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 chrono = { version = "0.4.19", default-features = false }
 trybuild = "1.0.48"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -22,7 +22,7 @@ unstable-runtime-stream-control = []
 unstable-runtime-reconcile-on = []
 
 [package.metadata.docs.rs]
-features = ["k8s-openapi/v1_26", "unstable-runtime"]
+features = ["k8s-openapi/v1_27", "unstable-runtime"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -60,4 +60,4 @@ tracing-subscriber = "0.3.17"
 [dev-dependencies.k8s-openapi]
 version = "0.19.0"
 default-features = false
-features = ["v1_26"]
+features = ["v1_27"]

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -46,7 +46,7 @@ async-trait = "0.1.64"
 hashbrown = "0.14.0"
 
 [dependencies.k8s-openapi]
-version = "0.18.0"
+version = "0.19.0"
 default-features = false
 
 [dev-dependencies]
@@ -58,6 +58,6 @@ schemars = "0.8.6"
 tracing-subscriber = "0.3.17"
 
 [dev-dependencies.k8s-openapi]
-version = "0.18.0"
+version = "0.19.0"
 default-features = false
 features = ["v1_26"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -45,7 +45,7 @@ kube-runtime = { path = "../kube-runtime", version = "=0.84.0", optional = true}
 # Not used directly, but required by resolver 2.0 to ensure that the k8s-openapi dependency
 # is considered part of the "deps" graph rather than just the "dev-deps" graph
 [dependencies.k8s-openapi]
-version = "0.18.0"
+version = "0.19.0"
 default-features = false
 
 [dev-dependencies]
@@ -60,6 +60,6 @@ tower-test = "0.4.0"
 anyhow = "1.0.71"
 
 [dev-dependencies.k8s-openapi]
-version = "0.18.0"
+version = "0.19.0"
 default-features = false
 features = ["v1_26"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -32,7 +32,7 @@ runtime = ["kube-runtime"]
 unstable-runtime = ["kube-runtime/unstable-runtime"]
 
 [package.metadata.docs.rs]
-features = ["client", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_26", "unstable-runtime"]
+features = ["client", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_27", "unstable-runtime"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -62,4 +62,4 @@ anyhow = "1.0.71"
 [dev-dependencies.k8s-openapi]
 version = "0.19.0"
 default-features = false
-features = ["v1_26"]
+features = ["v1_27"]

--- a/release.toml
+++ b/release.toml
@@ -4,7 +4,7 @@
 #
 # 0. (optional) cargo release minor ; verify readme + changelog bumped; then git reset --hard
 # 1. PUBLISH_GRACE_SLEEP=20 cargo release minor --execute
-# 1X.  - on failure: follow plan manually, cd into next dirs and publish insequence with cargo publish --features=k8s-openapi/v1_26
+# 1X.  - on failure: follow plan manually, cd into next dirs and publish insequence with cargo publish --features=k8s-openapi/v1_27
 # 2. check consolidated commit
 # 2X.  - on failure: git commit --amend and insert version
 # 3. ./scripts/release-post.sh
@@ -21,4 +21,4 @@ push = false
 tag = false
 # A Kubernetes version is normally supplied by the application consuming the library in the end.
 # Since we don't have that when verifying, supply one ourselves.
-enable-features = ["k8s-openapi/v1_26"]
+enable-features = ["k8s-openapi/v1_27"]


### PR DESCRIPTION
Runs `cargo upgrade -p k8s-openapi` and `just bump-k8s`.