### PR TITLE
Bump `pem` to 3

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -48,7 +48,7 @@ http-body = { version = "0.4.2", optional = true }
 either = { version = "1.6.1", optional = true }
 thiserror = "1.0.29"
 futures = { version = "0.3.17", optional = true }
-pem = { version = "1.1.0", optional = true }
+pem = { version = "3.0.1", optional = true }
 openssl = { version = "0.10.36", optional = true }
 rustls = { version = "0.21.0", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "1.0.0", optional = true }

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -365,8 +365,8 @@ fn certs(data: &[u8]) -> Result<Vec<Vec<u8>>, pem::PemError> {
     Ok(pem::parse_many(data)?
         .into_iter()
         .filter_map(|p| {
-            if p.tag == "CERTIFICATE" {
-                Some(p.contents)
+            if p.tag() == "CERTIFICATE" {
+                Some(p.into_contents())
             } else {
                 None
             }


### PR DESCRIPTION
Replaces #1267 and uses previously backed out change from https://github.com/kube-rs/kube/issues/1181. Not a problem since the MSRV is no longer at the tail (which it was at the time).