### PR TITLE
`core`: omit invalid resource version parameters when doing paged requests

### DIFF
--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -103,18 +103,22 @@ impl ListParams {
         }
         if let Some(continue_token) = &self.continue_token {
             qp.append_pair("continue", continue_token);
-        }
+        } else {
+            // When there's a continue token, we don't want to set resourceVersion
+            if let Some(rv) = &self.resource_version {
+                if rv != "0" || (rv == "0" && self.limit.is_none()) {
+                    qp.append_pair("resourceVersion", rv.as_str());
 
-        if let Some(rv) = &self.resource_version {
-            qp.append_pair("resourceVersion", rv.as_str());
-        }
-        match &self.version_match {
-            None => {}
-            Some(VersionMatch::NotOlderThan) => {
-                qp.append_pair("resourceVersionMatch", "NotOlderThan");
-            }
-            Some(VersionMatch::Exact) => {
-                qp.append_pair("resourceVersionMatch", "Exact");
+                    match &self.version_match {
+                        None => {}
+                        Some(VersionMatch::NotOlderThan) => {
+                            qp.append_pair("resourceVersionMatch", "NotOlderThan");
+                        }
+                        Some(VersionMatch::Exact) => {
+                            qp.append_pair("resourceVersionMatch", "Exact");
+                        }
+                    }
+                }
             }
         }
     }

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -738,10 +738,7 @@ mod test {
         let url = corev1::Pod::url_path(&(), Some("ns"));
         let gp = ListParams::default().limit(50).match_any();
         let req = Request::new(url).list(&gp).unwrap();
-        assert_eq!(
-            req.uri().query().unwrap(),
-            "&limit=50"
-        );
+        assert_eq!(req.uri().query().unwrap(), "&limit=50");
     }
 
     #[test]
@@ -749,21 +746,19 @@ mod test {
         let url = corev1::Pod::url_path(&(), Some("ns"));
         let gp = ListParams::default().limit(50).continue_token("1234").match_any();
         let req = Request::new(url).list(&gp).unwrap();
-        assert_eq!(
-            req.uri().query().unwrap(),
-            "&limit=50&continue=1234"
-        );
+        assert_eq!(req.uri().query().unwrap(), "&limit=50&continue=1234");
     }
 
     #[test]
     fn list_paged_with_continue_starting_at() {
         let url = corev1::Pod::url_path(&(), Some("ns"));
-        let gp = ListParams::default().limit(50).continue_token("1234").at("9999").matching(VersionMatch::Exact);
+        let gp = ListParams::default()
+            .limit(50)
+            .continue_token("1234")
+            .at("9999")
+            .matching(VersionMatch::Exact);
         let req = Request::new(url).list(&gp).unwrap();
-        assert_eq!(
-            req.uri().query().unwrap(),
-            "&limit=50&continue=1234"
-        );
+        assert_eq!(req.uri().query().unwrap(), "&limit=50&continue=1234");
     }
 
     #[test]

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -734,15 +734,35 @@ mod test {
     }
 
     #[test]
-    fn list_not_older() {
+    fn list_paged_any_semantic() {
         let url = corev1::Pod::url_path(&(), Some("ns"));
-        let gp = ListParams::default()
-            .at("20")
-            .matching(VersionMatch::NotOlderThan);
+        let gp = ListParams::default().limit(50).match_any();
         let req = Request::new(url).list(&gp).unwrap();
         assert_eq!(
             req.uri().query().unwrap(),
-            "&resourceVersion=20&resourceVersionMatch=NotOlderThan"
+            "&limit=50"
+        );
+    }
+
+    #[test]
+    fn list_paged_with_continue_any_semantic() {
+        let url = corev1::Pod::url_path(&(), Some("ns"));
+        let gp = ListParams::default().limit(50).continue_token("1234").match_any();
+        let req = Request::new(url).list(&gp).unwrap();
+        assert_eq!(
+            req.uri().query().unwrap(),
+            "&limit=50&continue=1234"
+        );
+    }
+
+    #[test]
+    fn list_paged_with_continue_starting_at() {
+        let url = corev1::Pod::url_path(&(), Some("ns"));
+        let gp = ListParams::default().limit(50).continue_token("1234").at("9999").matching(VersionMatch::Exact);
+        let req = Request::new(url).list(&gp).unwrap();
+        assert_eq!(
+            req.uri().query().unwrap(),
+            "&limit=50&continue=1234"
         );
     }
 


### PR DESCRIPTION
## Motivation

Fix #1278

## Solution

This is inspired by what client-go does, which means we don't set the `resourceVersionMatch` and `resourceVersion` when the `continue` param is defined.

I'm not sure if this covers all the scenarios, but it fixed the bug I was seeing.

As an example, if you change the `pod_paged` example to include `.any_semantic()`, the response will not be paged. With this PR the response would be paged as expected.

And as per your suggestion, I didn't implement this during the watcher paging loop because it's not exclusive to the watcher functionality, anyone paging with `list` would have this issue.