### PR TITLE
Revamp event and log examples to allow more parameters

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,6 @@ For a basic overview of how to use the `Api` try:
 
 ```sh
 cargo run --example job_api
-cargo run --example log_stream
 cargo run --example pod_api
 cargo run --example dynamic_api
 cargo run --example dynamic_jsonpath
@@ -41,6 +40,15 @@ cargo run --example kubectl -- apply -f configmapgen_controller_crd.yaml
 ```
 
 Supported flags are `-lLABELSELECTOR`, `-nNAMESPACE`, `--all`, and `-oyaml`.
+
+There are also two other examples that serve as simplistic analogues of `kubectl logs` and `kubectl events`:
+
+```sh
+# tail logs
+cargo run --example log_stream -- prometheus-promstack-kube-prometheus-prometheus-0 -c prometheus -f --since=3600
+# get events for an object
+cargo run --example event_watcher -- --for=Pod/prometheus-promstack-kube-prometheus-prometheus-0
+```
 
 ## kube admission controller example
 Admission controllers are a bit of a special beast. They don't actually need `kube_client` (unless you need to verify something with the api-server) or `kube_runtime` (unless you also build a complementing reconciler) because, by themselves, they simply get changes sent to them over `https`. You will need a webserver, certificates, and either your controller deployed behind a `Service`, or as we do here: running locally with a private ip that your `k3d` cluster can reach.

--- a/examples/event_watcher.rs
+++ b/examples/event_watcher.rs
@@ -1,42 +1,64 @@
 use futures::{pin_mut, TryStreamExt};
-use k8s_openapi::api::{core::v1::ObjectReference, events::v1::Event};
-use kube::{
-    api::Api,
-    runtime::{watcher, WatchStreamExt},
-    Client,
+use k8s_openapi::{
+    api::{core::v1::ObjectReference, events::v1::Event},
+    apimachinery::pkg::apis::meta::v1::Time,
+    chrono::Utc,
 };
-use tracing::info;
+use kube::{
+    runtime::{watcher, WatchStreamExt},
+    Api, Client, ResourceExt,
+};
+
+/// limited variant of `kubectl events` that works on current context's namespace
+///
+/// requires a new enough cluster that apis/events.k8s.io/v1 work (kubectl uses corev1::Event)
+/// for old style usage of core::v1::Event see node_watcher
+#[derive(clap::Parser)]
+struct App {
+    /// Filter by object and kind
+    ///
+    /// Using --for=Pod/blog-xxxxx
+    /// Note that kind name is case sensitive
+    #[arg(long)]
+    r#for: Option<String>,
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let client = Client::try_default().await?;
+    let app: App = clap::Parser::parse();
 
-    let events: Api<Event> = Api::all(client);
-    let ew = watcher(events, watcher::Config::default()).applied_objects();
+    let events: Api<Event> = Api::default_namespaced(client);
+    let mut conf = watcher::Config::default();
+    if let Some(forval) = app.r#for {
+        if let Some((kind, name)) = forval.split_once('/') {
+            conf = conf.fields(&format!("regarding.kind={kind},regarding.name={name}"));
+        }
+    }
+    let event_stream = watcher(events, conf).default_backoff().applied_objects();
+    pin_mut!(event_stream);
 
-    pin_mut!(ew);
-    while let Some(event) = ew.try_next().await? {
-        handle_event(event)?;
+    println!("{0:<6} {1:<15} {2:<55} {3}", "AGE", "REASON", "OBJECT", "MESSAGE");
+    while let Some(ev) = event_stream.try_next().await? {
+        let age = ev.creation_timestamp().map(format_creation).unwrap_or_default();
+        let reason = ev.reason.unwrap_or_default();
+        let obj = ev.regarding.map(format_objref).flatten().unwrap_or_default();
+        let note = ev.note.unwrap_or_default();
+        println!("{0:<6} {1:<15} {2:<55} {3}", age, reason, obj, note);
     }
     Ok(())
 }
 
-// This function lets the app handle an added/modified event from k8s
-fn handle_event(ev: Event) -> anyhow::Result<()> {
-    info!(
-        "{}: {} ({})",
-        ev.regarding.map(fmt_obj_ref).unwrap_or_default(),
-        ev.reason.unwrap_or_default(),
-        ev.note.unwrap_or_default(),
-    );
-    Ok(())
+fn format_objref(oref: ObjectReference) -> Option<String> {
+    Some(format!("{}/{}", oref.kind?, oref.name?))
 }
 
-fn fmt_obj_ref(oref: ObjectReference) -> String {
-    format!(
-        "{}/{}",
-        oref.kind.unwrap_or_default(),
-        oref.name.unwrap_or_default()
-    )
+fn format_creation(time: Time) -> String {
+    let dur = Utc::now().signed_duration_since(time.0);
+    match (dur.num_days(), dur.num_hours(), dur.num_minutes()) {
+        (days, _, _) if days > 0 => format!("{days}d"),
+        (_, hours, _) if hours > 0 => format!("{hours}h"),
+        (_, _, mins) => format!("{mins}m"),
+    }
 }


### PR DESCRIPTION
We already have `clap` in the dependency tree so thought it would be useful to show how to do some more things in the `kubectl` style.

- `event_watcher` now has an optional flag to limit to one object (ala `kubectl events --for`)
- `log_stream` now supports the basic flags that `kubectl logs` do
- `kubectl` helpers for formatting duration are aligned across examples

(Clippy issues warned about here comes from 1.72 and are fixed in #1288)
