### PR TITLE
Fix clippy isuses on rust 1.72

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 default-members = ["kube"]
+resolver = "1"
 members = [
   "kube",
   "kube-client",

--- a/kube-client/src/client/auth/oidc.rs
+++ b/kube-client/src/client/auth/oidc.rs
@@ -152,7 +152,7 @@ pub struct Oidc {
 
 impl Oidc {
     /// Config key for the ID token.
-    const CONFIG_ID_TOKEN: &str = "id-token";
+    const CONFIG_ID_TOKEN: &'static str = "id-token";
     /// How many seconds before ID token expiration we want to refresh it.
     const EXPIRY_DELTA_SECONDS: i64 = 10;
 
@@ -278,13 +278,13 @@ struct Refresher {
 
 impl Refresher {
     /// Config key for the client ID.
-    const CONFIG_CLIENT_ID: &str = "client-id";
+    const CONFIG_CLIENT_ID: &'static str = "client-id";
     /// Config key for the client secret.
-    const CONFIG_CLIENT_SECRET: &str = "client-secret";
+    const CONFIG_CLIENT_SECRET: &'static str = "client-secret";
     /// Config key for the issuer url.
-    const CONFIG_ISSUER_URL: &str = "idp-issuer-url";
+    const CONFIG_ISSUER_URL: &'static str = "idp-issuer-url";
     /// Config key for the refresh token.
-    const CONFIG_REFRESH_TOKEN: &str = "refresh-token";
+    const CONFIG_REFRESH_TOKEN: &'static str = "refresh-token";
 
     /// Create a new instance of this struct from the provider config.
     fn from_config(config: &HashMap<String, String>) -> Result<Self, errors::RefreshInitError> {

--- a/kube/src/mock_tests.rs
+++ b/kube/src/mock_tests.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::Result;
 use futures::{poll, StreamExt, TryStreamExt};
 use http::{Request, Response};
-use hyper::{body::to_bytes, Body};
+use hyper::{Body};
 use kube_derive::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/kube/src/mock_tests.rs
+++ b/kube/src/mock_tests.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::Result;
 use futures::{poll, StreamExt, TryStreamExt};
 use http::{Request, Response};
-use hyper::{Body};
+use hyper::Body;
 use kube_derive::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
### resolver choice explicit
caused warning on regular `cargo build`:

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

(we can't use resolver 2 atm due to the peer dependency on k8s-openapi and its features)

### & without explicit lifetime

caused: 
```
`&` without an explicit lifetime name cannot be used here
warning: `&` without an explicit lifetime name cannot be used here
   --> kube-client/src/client/auth/oidc.rs:155:28
    |
155 |     const CONFIG_ID_TOKEN: &str = "id-token";
    |                            ^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
    = note: `#[warn(elided_lifetimes_in_associated_constant)]` on by default
help: use the `'static` lifetime
    |
155 |     const CONFIG_ID_TOKEN: &'static str = "id-token";
    |                             +++++++
```