### PR TITLE
Change explicit `v1_28` feature to use `latest` feature alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ These crates build upon Kubernetes [apimachinery](https://github.com/kubernetes/
 
 ## Installation
 
-Select a version of `kube` along with the generated [k8s-openapi](https://github.com/Arnavion/k8s-openapi) types corresponding for your cluster version:
+Select a version of `kube` along with the generated [k8s-openapi](https://github.com/Arnavion/k8s-openapi) structs at your chosen [Kubernetes version](https://kube.rs/kubernetes-version/):
 
 ```toml
 [dependencies]
 kube = { version = "0.86.0", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.20.0", features = ["v1_28"] }
+k8s-openapi = { version = "0.20.0", features = ["latest"] }
 ```
 
 [Features are available](https://github.com/kube-rs/kube/blob/main/kube/Cargo.toml#L18).
@@ -153,7 +153,7 @@ By default [rustls](https://github.com/ctz/rustls) is used for TLS, but `openssl
 ```toml
 [dependencies]
 kube = { version = "0.86.0", default-features = false, features = ["client", "openssl-tls"] }
-k8s-openapi = { version = "0.20.0", features = ["v1_28"] }
+k8s-openapi = { version = "0.20.0", features = ["latest"] }
 ```
 
 This will pull in `openssl` and `hyper-openssl`. If `default-features` is left enabled, you will pull in two TLS stacks, and the default will remain as `rustls`.

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -18,7 +18,7 @@ name = "boot"
 path = "boot.rs"
 
 [features]
-latest = ["k8s-openapi/v1_28"]
+latest = ["k8s-openapi/latest"]
 mk8sv = ["k8s-openapi/v1_23"]
 rustls = ["kube/rustls-tls"]
 openssl = ["kube/openssl-tls"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,7 +21,7 @@ rustls-tls = ["kube/client", "kube/rustls-tls"]
 runtime = ["kube/runtime", "kube/unstable-runtime"]
 refresh = ["kube/oauth", "kube/oidc"]
 ws = ["kube/ws"]
-latest = ["k8s-openapi/v1_28"]
+latest = ["k8s-openapi/latest"]
 
 [dev-dependencies]
 tokio-util = "0.7.0"

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ fmt:
   rustfmt +nightly --edition 2021 $(find . -type f -iname *.rs)
 
 doc:
-  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,oidc,jsonpatch,client,derive,runtime,admission,k8s-openapi/v1_28,unstable-runtime --open
+  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,oidc,jsonpatch,client,derive,runtime,admission,k8s-openapi/latest,unstable-runtime --open
 
 deny:
   # might require rm Cargo.lock first to match CI

--- a/justfile
+++ b/justfile
@@ -114,14 +114,10 @@ bump-msrv msrv:
 # Increment the Kubernetes feature version from k8s-openapi for tests; "just bump-k8s"
 bump-k8s:
   #!/usr/bin/env bash
-  current=$(cargo tree --format "{f}" -i k8s-openapi | head -n 1)
-  next=${current::-2}$((${current:3} + 1))
-  fastmod -m -d . -e toml "$current" "$next"
-  fastmod -m "$current" "$next" -- README.md
-  fastmod -m "$current" "$next" -- justfile
+  latest=$(cargo tree --format "{f}" -i k8s-openapi | head -n 1 | choose -f ',' 1)
   # bumping supported version also bumps our mk8sv
-  mk8svnew=${current::-2}$((${current:3} - 4))
-  mk8svold=${current::-2}$((${current:3} - 5))
+  mk8svnew=${latest::-2}$((${latest:3} - 4))
+  mk8svold=${latest::-2}$((${latest:3} - 5))
   fastmod -m -d e2e -e toml "$mk8svold" "$mk8svnew"
   fastmod -m -d .github/workflows -e yml "${mk8svold/_/\.}" "${mk8svnew/_/.}"
   # bump mk8sv badge

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -32,7 +32,7 @@ config = ["__non_core", "pem", "home"]
 __non_core = ["tracing", "serde_yaml", "base64"]
 
 [package.metadata.docs.rs]
-features = ["client", "rustls-tls", "openssl-tls", "ws", "oauth", "oidc", "jsonpatch", "admission", "k8s-openapi/v1_28"]
+features = ["client", "rustls-tls", "openssl-tls", "ws", "oauth", "oidc", "jsonpatch", "admission", "k8s-openapi/latest"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -87,4 +87,4 @@ tower-test = "0.4.0"
 [dev-dependencies.k8s-openapi]
 version = "0.20.0"
 default-features = false
-features = ["v1_28"]
+features = ["latest"]

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "../README.md"
 
 [package.metadata.docs.rs]
-features = ["ws", "admission", "jsonpatch", "k8s-openapi/v1_28"]
+features = ["ws", "admission", "jsonpatch", "k8s-openapi/latest"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -43,7 +43,7 @@ features = []
 [dev-dependencies.k8s-openapi]
 version = "0.20.0"
 default-features = false
-features = ["v1_28"]
+features = ["latest"]
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro = true
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.9.19"
 kube = { path = "../kube", version = "<1.0.0, >=0.61.0", features = ["derive", "client"] }
-k8s-openapi = { version = "0.20.0", default-features = false, features = ["v1_28"] }
+k8s-openapi = { version = "0.20.0", default-features = false, features = ["latest"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 chrono = { version = "0.4.19", default-features = false }
 trybuild = "1.0.48"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -22,7 +22,7 @@ unstable-runtime-stream-control = []
 unstable-runtime-reconcile-on = []
 
 [package.metadata.docs.rs]
-features = ["k8s-openapi/v1_28", "unstable-runtime"]
+features = ["k8s-openapi/latest", "unstable-runtime"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -60,4 +60,4 @@ tracing-subscriber = "0.3.17"
 [dev-dependencies.k8s-openapi]
 version = "0.20.0"
 default-features = false
-features = ["v1_28"]
+features = ["latest"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -38,7 +38,7 @@ runtime = ["kube-runtime"]
 unstable-runtime = ["kube-runtime/unstable-runtime"]
 
 [package.metadata.docs.rs]
-features = ["client", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_28", "unstable-runtime"]
+features = ["client", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/latest", "unstable-runtime"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -68,4 +68,4 @@ anyhow = "1.0.71"
 [dev-dependencies.k8s-openapi]
 version = "0.20.0"
 default-features = false
-features = ["v1_28"]
+features = ["latest"]

--- a/release.toml
+++ b/release.toml
@@ -4,7 +4,7 @@
 #
 # 0. (optional) cargo release minor ; verify readme + changelog bumped; then git reset --hard
 # 1. PUBLISH_GRACE_SLEEP=20 cargo release minor --execute
-# 1X.  - on failure: follow plan manually, cd into next dirs and publish insequence with cargo publish --features=k8s-openapi/v1_28
+# 1X.  - on failure: follow plan manually, cd into next dirs and publish insequence with cargo publish --features=k8s-openapi/latest
 # 2. check consolidated commit
 # 2X.  - on failure: git commit --amend and insert version
 # 3. ./scripts/release-post.sh
@@ -21,4 +21,4 @@ push = false
 tag = false
 # A Kubernetes version is normally supplied by the application consuming the library in the end.
 # Since we don't have that when verifying, supply one ourselves.
-enable-features = ["k8s-openapi/v1_28"]
+enable-features = ["k8s-openapi/latest"]


### PR DESCRIPTION
Simplify our build setup to always set our MAX as the latest version `k8s-openapi` exposes.

This doesn't let us avoid all the automation to bump (still need an explicit version for k3d on CI for the minimum check), but it avoids having to bump all the readme and toml files for the latest dev-deps.

Brought up in https://github.com/kube-rs/kube/pull/1291#issuecomment-1712945569

Have updated recommendations in https://kube.rs/kubernetes-version/ to more explicitly tell users to use `latest` unless they have a reason for it (before we where a bit vague about it - but now it's easier with the feature alias).