### PR TITLE
client: Add feature flag for BoringSSL TLS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
       # Prevent GitHub from cancelling all in-progress jobs when a matrix job fails.
       fail-fast: false
       matrix:
-        tls: [openssl, rustls]
+        tls: [openssl, rustls, boring]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v2

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -22,6 +22,7 @@ latest = ["k8s-openapi/latest"]
 mk8sv = ["k8s-openapi/v1_23"]
 rustls = ["kube/rustls-tls"]
 openssl = ["kube/openssl-tls"]
+boring = ["kube/boring-tls"]
 
 [dependencies]
 anyhow = "1.0.44"

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 default = ["client"]
 rustls-tls = ["rustls", "rustls-pemfile", "hyper-rustls"]
 openssl-tls = ["openssl", "hyper-openssl"]
+boring-tls = ["boring", "hyper-boring"]
 ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws", "tokio/macros"]
 oauth = ["client", "tame-oauth"]
 oidc = ["client", "form_urlencoded"]
@@ -38,6 +39,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 base64 = { version = "0.20.0", optional = true }
+boring = { version = "3.1.0", optional = true }
 chrono = { version = "0.4.23", optional = true, default-features = false }
 home = { version = "0.5.4", optional = true }
 serde = { version = "1.0.130", features = ["derive"] }
@@ -58,6 +60,7 @@ kube-core = { path = "../kube-core", version = "=0.86.0" }
 jsonpath_lib = { version = "0.3.0", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
+hyper-boring = { version = "3.1.0", optional = true }
 hyper-rustls = { version = "0.24.0", optional = true }
 tokio-tungstenite = { version = "0.20.0", optional = true }
 tower = { version = "0.4.13", optional = true, features = ["buffer", "filter", "util"] }

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -64,7 +64,11 @@ impl<Svc> ClientBuilder<Svc> {
 impl TryFrom<Config> for ClientBuilder<BoxService<Request<hyper::Body>, Response<Box<DynBody>>, BoxError>> {
     type Error = Error;
 
-    /// Builds a default [`ClientBuilder`] stack from a given configuration
+    /// Builds a default [`ClientBuilder`] stack from a given configuration.
+    ///
+    /// The TLS implementation used by the constructed client depends on which
+    /// crate feature flags are enabled. See [the documentation on configuring
+    /// TLS](crate::client#configuring-tls) for details.
     fn try_from(config: Config) -> Result<Self> {
         use std::time::Duration;
 

--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -35,12 +35,17 @@ mod config_ext;
 pub use auth::Error as AuthError;
 pub use config_ext::ConfigExt;
 pub mod middleware;
-#[cfg(any(feature = "rustls-tls", feature = "openssl-tls"))] mod tls;
+#[cfg(any(feature = "rustls-tls", feature = "openssl-tls"))]
+mod tls;
 
+#[cfg(feature = "boring-tls")]
+pub use tls::boring_tls::Error as BoringTlsError;
 #[cfg(feature = "openssl-tls")]
 pub use tls::openssl_tls::Error as OpensslTlsError;
-#[cfg(feature = "rustls-tls")] pub use tls::rustls_tls::Error as RustlsTlsError;
-#[cfg(feature = "ws")] mod upgrade;
+#[cfg(feature = "rustls-tls")]
+pub use tls::rustls_tls::Error as RustlsTlsError;
+#[cfg(feature = "ws")]
+mod upgrade;
 
 #[cfg(feature = "oauth")]
 #[cfg_attr(docsrs, doc(cfg(feature = "oauth")))]
@@ -50,7 +55,8 @@ pub use auth::OAuthError;
 #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]
 pub use auth::oidc_errors;
 
-#[cfg(feature = "ws")] pub use upgrade::UpgradeConnectionError;
+#[cfg(feature = "ws")]
+pub use upgrade::UpgradeConnectionError;
 
 pub use builder::{ClientBuilder, DynBody};
 

--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -239,3 +239,105 @@ pub mod openssl_tls {
         Ok(builder)
     }
 }
+
+#[cfg(feature = "boring-tls")]
+pub mod boring_tls {
+    use boring::{
+        pkey::PKey,
+        ssl::{SslConnector, SslConnectorBuilder, SslMethod},
+        x509::X509,
+    };
+    use thiserror::Error;
+
+    /// Errors from BoringSSL TLS
+    #[derive(Debug, Error)]
+    pub enum Error {
+        /// Failed to create BoringSSL HTTPS connector
+        #[error("failed to create BoringSSL HTTPS connector: {0}")]
+        CreateHttpsConnector(#[source] boring::error::ErrorStack),
+
+        /// Failed to create BoringSSL SSL connector
+        #[error("failed to create BoringSSL SSL connector: {0}")]
+        CreateSslConnector(#[source] SslConnectorError),
+    }
+
+    /// Errors from creating a `SslConnectorBuilder`
+    #[derive(Debug, Error)]
+    pub enum SslConnectorError {
+        /// Failed to build SslConnectorBuilder
+        #[error("failed to build SslConnectorBuilder: {0}")]
+        CreateBuilder(#[source] boring::error::ErrorStack),
+
+        /// Failed to deserialize PEM-encoded chain of certificates
+        #[error("failed to deserialize PEM-encoded chain of certificates: {0}")]
+        DeserializeCertificateChain(#[source] boring::error::ErrorStack),
+
+        /// Failed to deserialize PEM-encoded private key
+        #[error("failed to deserialize PEM-encoded private key: {0}")]
+        DeserializePrivateKey(#[source] boring::error::ErrorStack),
+
+        /// Failed to set private key
+        #[error("failed to set private key: {0}")]
+        SetPrivateKey(#[source] boring::error::ErrorStack),
+
+        /// Failed to get a leaf certificate, the certificate chain is empty
+        #[error("failed to get a leaf certificate, the certificate chain is empty")]
+        GetLeafCertificate,
+
+        /// Failed to set the leaf certificate
+        #[error("failed to set the leaf certificate: {0}")]
+        SetLeafCertificate(#[source] boring::error::ErrorStack),
+
+        /// Failed to append a certificate to the chain
+        #[error("failed to append a certificate to the chain: {0}")]
+        AppendCertificate(#[source] boring::error::ErrorStack),
+
+        /// Failed to deserialize DER-encoded root certificate
+        #[error("failed to deserialize DER-encoded root certificate: {0}")]
+        DeserializeRootCertificate(#[source] boring::error::ErrorStack),
+
+        /// Failed to add a root certificate
+        #[error("failed to add a root certificate: {0}")]
+        AddRootCertificate(#[source] boring::error::ErrorStack),
+    }
+
+    /// Create `boring::ssl::SslConnectorBuilder` required for `hyper_boring::HttpsConnector`.
+    pub fn ssl_connector_builder(
+        identity_pem: Option<&Vec<u8>>,
+        root_certs: Option<&Vec<Vec<u8>>>,
+    ) -> Result<SslConnectorBuilder, SslConnectorError> {
+        let mut builder =
+            SslConnector::builder(SslMethod::tls()).map_err(SslConnectorError::CreateBuilder)?;
+        if let Some(pem) = identity_pem {
+            let mut chain = X509::stack_from_pem(pem)
+                .map_err(SslConnectorError::DeserializeCertificateChain)?
+                .into_iter();
+            let leaf_cert = chain.next().ok_or(SslConnectorError::GetLeafCertificate)?;
+            builder
+                .set_certificate(&leaf_cert)
+                .map_err(SslConnectorError::SetLeafCertificate)?;
+            for cert in chain {
+                builder
+                    .add_extra_chain_cert(cert)
+                    .map_err(SslConnectorError::AppendCertificate)?;
+            }
+
+            let pkey = PKey::private_key_from_pem(pem).map_err(SslConnectorError::DeserializePrivateKey)?;
+            builder
+                .set_private_key(&pkey)
+                .map_err(SslConnectorError::SetPrivateKey)?;
+        }
+
+        if let Some(ders) = root_certs {
+            for der in ders {
+                let cert = X509::from_der(der).map_err(SslConnectorError::DeserializeRootCertificate)?;
+                builder
+                    .cert_store_mut()
+                    .add_cert(cert)
+                    .map_err(SslConnectorError::AddRootCertificate)?;
+            }
+        }
+
+        Ok(builder)
+    }
+}

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -71,6 +71,12 @@ pub enum Error {
     #[error("rustls tls error: {0}")]
     RustlsTls(#[source] crate::client::RustlsTlsError),
 
+    /// Errors from BoringSSL TLS
+    #[cfg(feature = "boring-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "boring-tls")))]
+    #[error("boringssl tls error: {0}")]
+    BoringTls(#[source] crate::client::BoringTlsError),
+
     /// Missing TLS stacks when TLS is required
     #[error("TLS required but no TLS stack selected")]
     TlsRequired,

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -25,6 +25,7 @@ rustls-tls = ["kube-client/rustls-tls"]
 
 # alternative features
 openssl-tls = ["kube-client/openssl-tls"]
+boring-tls = ["kube-client/boring-tls"]
 
 # auxiliary features
 ws = ["kube-client/ws", "kube-core/ws"]


### PR DESCRIPTION

## Motivation

Curerently, `kube-client` supports using either Rustls or OpenSSL as the
TLS backend. BoringSSL is an alterative TLS implementation, based on a
fork of OpenSSL and maintained by Google. Rust bindings for BoringSSL
are available in the `boring` crate. Some users of `kube-client` may
wish to use BoringSSL as the TLS implementation, rather than OpenSSL or
Rustls. This can potentially be implemented in downstream code, on top
of `kube-client`'s config module, but this would require re-implementing
a large amount of `kube-client`'s `auth` module in user code. Therefore,
it seemed nicer to just provide it in `kube-client`.

## Solution

This commit adds support for BoringSSL as a third TLS option. The
`boring` crate has a very similar API to the `openssl` crate, so the
BoringSSL client code looks quite similar to the OpenSSL client code.

I've also attempted to modify the CI configuration to also run tests
with BoringSSL. However, I wasn't able to verify that this works without
an actual CI run, so it's possible that the E2E test docker environment
can't actually build BoringSSL and we'll have to add additional build
deps there. I'm happy to follow up on that after a CI run has completed.