### PR TITLE
Clippy --fix on runtime pedantics

### DIFF
--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -241,7 +241,7 @@ mod tests {
                 Result::<_, Infallible>::Ok(())
             })),
             |s| {
-                s.map(|_| {
+                s.map(|()| {
                     let _ = &y;
                     Ok(())
                 })

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -105,7 +105,7 @@ where
 /// Splits a `TryStream` into separate `Ok` and `Error` streams.
 ///
 /// Note: This will deadlock if one branch outlives the other
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::arc_with_non_send_sync)]
 fn trystream_split_result<S>(
     stream: S,
 ) -> (

--- a/kube-runtime/src/utils/stream_subscribe.rs
+++ b/kube-runtime/src/utils/stream_subscribe.rs
@@ -62,6 +62,8 @@ impl<S: Stream> Stream for StreamSubscribe<S> {
 
         match item {
             Poll::Ready(Some(item)) => {
+                #[allow(clippy::arc_with_non_send_sync)]
+                // ^ this whole module is unstable and does not have a PoC
                 let item = Arc::new(item);
                 this.sender.send(Some(item.clone())).ok();
                 Poll::Ready(Some(item))

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -498,7 +498,7 @@ where
                         } else {
                             debug!("watch list error: {err:?}");
                         }
-                        (Some(Err(err).map_err(Error::InitialListFailed)), State::default())
+                        (Some(Err(Error::InitialListFailed(err))), State::default())
                     }
                 }
             }
@@ -510,7 +510,7 @@ where
                     } else {
                         debug!("watch initlist error: {err:?}");
                     }
-                    (Some(Err(err).map_err(Error::WatchStartFailed)), State::default())
+                    (Some(Err(Error::WatchStartFailed(err))), State::default())
                 }
             },
         },
@@ -553,7 +553,7 @@ where
                     } else {
                         debug!("error watchevent error: {err:?}");
                     }
-                    (Some(Err(err).map_err(Error::WatchError)), new_state)
+                    (Some(Err(Error::WatchError(err))), new_state)
                 }
                 Some(Err(err)) => {
                     if std::matches!(err, ClientErr::Api(ErrorResponse { code: 403, .. })) {
@@ -561,7 +561,7 @@ where
                     } else {
                         debug!("watcher error: {err:?}");
                     }
-                    (Some(Err(err).map_err(Error::WatchFailed)), State::IntialWatch {
+                    (Some(Err(Error::WatchFailed(err))), State::IntialWatch {
                         objects,
                         stream,
                     })
@@ -582,7 +582,7 @@ where
                         debug!("watch initlist error: {err:?}");
                     }
                     (
-                        Some(Err(err).map_err(Error::WatchStartFailed)),
+                        Some(Err(Error::WatchStartFailed(err))),
                         State::InitListed { resource_version },
                     )
                 }
@@ -633,7 +633,7 @@ where
                 } else {
                     debug!("error watchevent error: {err:?}");
                 }
-                (Some(Err(err).map_err(Error::WatchError)), new_state)
+                (Some(Err(Error::WatchError(err))), new_state)
             }
             Some(Err(err)) => {
                 if std::matches!(err, ClientErr::Api(ErrorResponse { code: 403, .. })) {
@@ -641,7 +641,7 @@ where
                 } else {
                     debug!("watcher error: {err:?}");
                 }
-                (Some(Err(err).map_err(Error::WatchFailed)), State::Watching {
+                (Some(Err(Error::WatchFailed(err))), State::Watching {
                     resource_version,
                     stream,
                 })

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -581,10 +581,9 @@ where
                     } else {
                         debug!("watch initlist error: {err:?}");
                     }
-                    (
-                        Some(Err(Error::WatchStartFailed(err))),
-                        State::InitListed { resource_version },
-                    )
+                    (Some(Err(Error::WatchStartFailed(err))), State::InitListed {
+                        resource_version,
+                    })
                 }
             }
         }


### PR DESCRIPTION
Some that have cropped up in new clippy versions.

See the [recent boringssl PR's clippy output](https://github.com/kube-rs/kube/actions/runs/6383547272/job/17324379291?pr=1301) for the lints it fixes.