### PR TITLE
Document `Controller::reconcile_on`  and remove `Err` input requirement

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -56,7 +56,6 @@ tokio = { version = "1.14.0", features = ["full", "test-util"] }
 rand = "0.8.0"
 schemars = "0.8.6"
 tracing-subscriber = "0.3.17"
-tokio-stream = "0.1.14"
 
 [dev-dependencies.k8s-openapi]
 version = "0.20.0"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -56,6 +56,7 @@ tokio = { version = "1.14.0", features = ["full", "test-util"] }
 rand = "0.8.0"
 schemars = "0.8.6"
 tracing-subscriber = "0.3.17"
+tokio-stream = "0.1.14"
 
 [dev-dependencies.k8s-openapi]
 version = "0.20.0"

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1111,7 +1111,8 @@ where
     /// # fn error_policy(_: Arc<ConfigMap>, _: &kube::Error, _: Arc<()>) -> Action { Action::await_change() }
     /// #
     /// let ns = "external-configs".to_string();
-    /// let mut next_object = [ObjectRef::new("managed-cm1").within(&ns)].into_iter().cycle();
+    /// let externals = [ObjectRef::new("managed-cm1").within(&ns)];
+    /// let mut next_object = externals.into_iter().cycle();
     /// let interval = tokio::time::interval(Duration::from_secs(60)); // hit the object every minute
     /// let external_stream = IntervalStream::new(interval).map(|_| Ok(next_object.next().unwrap()));
     ///

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1113,7 +1113,7 @@ where
     ///     name: String,
     /// }
     /// let external_stream = watch_external_objects().map(|ext| {
-    ///     Ok(ObjectRef::new(&format!("{}-cm", ext.name)).within(&ns))
+    ///     ObjectRef::new(&format!("{}-cm", ext.name)).within(&ns)
     /// });
     ///
     /// Controller::new(Api::<ConfigMap>::namespaced(client, &ns), Config::default())
@@ -1125,15 +1125,14 @@ where
     /// ```
     #[cfg(feature = "unstable-runtime-reconcile-on")]
     #[must_use]
-    pub fn reconcile_on(
-        mut self,
-        trigger: impl Stream<Item = Result<ObjectRef<K>, watcher::Error>> + Send + 'static,
-    ) -> Self {
+    pub fn reconcile_on(mut self, trigger: impl Stream<Item = ObjectRef<K>> + Send + 'static) -> Self {
         self.trigger_selector.push(
             trigger
-                .map_ok(move |obj| ReconcileRequest {
-                    obj_ref: obj,
-                    reason: ReconcileReason::Unknown,
+                .map(move |obj| {
+                    Ok(ReconcileRequest {
+                        obj_ref: obj,
+                        reason: ReconcileReason::Unknown,
+                    })
                 })
                 .boxed(),
         );

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1093,7 +1093,7 @@ where
     ///
     /// ```no_run
     /// # async {
-    /// # use futures::{StreamExt, TryStreamExt};
+    /// # use futures::{StreamExt, Stream, stream, TryStreamExt};
     /// # use k8s_openapi::api::core::v1::{ConfigMap};
     /// # use kube::api::Api;
     /// # use kube::runtime::controller::Action;
@@ -1101,20 +1101,20 @@ where
     /// # use kube::runtime::{reflector, watcher, Controller, WatchStreamExt};
     /// # use kube::runtime::watcher::Config;
     /// # use kube::{Client, Error, ResourceExt};
-    /// # use tokio_stream::wrappers::IntervalStream;
     /// # use std::future;
-    /// # use std::time::Duration;
     /// # use std::sync::Arc;
     /// #
     /// # let client: Client = todo!();
     /// # async fn reconcile(_: Arc<ConfigMap>, _: Arc<()>) -> Result<Action, Error> { Ok(Action::await_change()) }
     /// # fn error_policy(_: Arc<ConfigMap>, _: &kube::Error, _: Arc<()>) -> Action { Action::await_change() }
-    /// #
-    /// let ns = "external-configs".to_string();
-    /// let externals = [ObjectRef::new("managed-cm1").within(&ns)];
-    /// let mut next_object = externals.into_iter().cycle();
-    /// let interval = tokio::time::interval(Duration::from_secs(60)); // hit the object every minute
-    /// let external_stream = IntervalStream::new(interval).map(|_| Ok(next_object.next().unwrap()));
+    /// # fn watch_external_objects() -> impl Stream<Item = ExternalObject> + Send + 'static { stream::iter(vec![]) }
+    /// # let ns = "controller-ns".to_string();
+    /// struct ExternalObject {
+    ///     name: String,
+    /// }
+    /// let external_stream = watch_external_objects().map(|ext| {
+    ///     Ok(ObjectRef::new(&format!("{}-cm", ext.name)).within(&ns))
+    /// });
     ///
     /// Controller::new(Api::<ConfigMap>::namespaced(client, &ns), Config::default())
     ///     .reconcile_on(external_stream)

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1087,7 +1087,7 @@ where
 
     /// Trigger the reconciliation process for a managed object `ObjectRef<K>` whenever `trigger` emits a value
     ///
-    /// This can be used to inject reconciliations for specific objects from an external  resource.
+    /// This can be used to inject reconciliations for specific objects from an external resource.
     ///
     /// # Example:
     ///

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1107,7 +1107,7 @@ where
     /// # let client: Client = todo!();
     /// # async fn reconcile(_: Arc<ConfigMap>, _: Arc<()>) -> Result<Action, Error> { Ok(Action::await_change()) }
     /// # fn error_policy(_: Arc<ConfigMap>, _: &kube::Error, _: Arc<()>) -> Action { Action::await_change() }
-    /// # fn watch_external_objects() -> impl Stream<Item = ExternalObject> + Send + 'static { stream::iter(vec![]) }
+    /// # fn watch_external_objects() -> impl Stream<Item = ExternalObject> { stream::iter(vec![]) }
     /// # let ns = "controller-ns".to_string();
     /// struct ExternalObject {
     ///     name: String,


### PR DESCRIPTION
The unstable method currently suggests that this method can be used to help share a store with the reconciler. This is actually nothing specific to `reconcile_on`, and you can do the same with the streams interface with `watches_stream`.

(We made the `reconcile_on` right before `watches_stream` became a thing so this makes sense.)

Secondly, we pretended we would handle errors being passed in from a third-party resource which is not true. See https://github.com/kube-rs/kube/pull/1304#issuecomment-1753843059. We now no longer accept a stream of `Result<ObjectRef, Error>` but a stream of `ObjectRef`. Users creating reconcilers around third party apis / external resources need to do error handling when dealing with these separately.

The example now highlights that this has a better use-case with actually getting arbitrary third-party info, and then mapping that to kubernetes objects.

Planning on putting whatever we settle on here as the de-facto example for "external relations" on https://kube.rs/controllers/relations/#external-relations as it would be good to have something that compiled that i can refer it to.

![image](https://github.com/kube-rs/kube/assets/134092/359e25ad-7146-4ab0-a07a-dc69e30667f8)


(CI required a fixup in https://github.com/kube-rs/kube/pull/1305)