### PR TITLE
Try to fix codecov + tests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,11 +1,19 @@
 comment:
-  require_changes: no
+  require_changes: false
   layout: "diff,files"
+
 coverage:
+  range: 70..100
+  round: up
+  precision: 1
+  # https://docs.codecov.com/docs/commit-status
   status:
     project:
-      project: off
-      patch: off
+      default:
+        threshold: 1% # avoid false negatives
+        informational: true
+      patch:
+        informational: true
 
 #flags:
 #  kube:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,10 +9,10 @@ coverage:
   # https://docs.codecov.com/docs/commit-status
   status:
     project:
+      default: false
+    patch:
       default:
-        threshold: 1% # avoid false negatives
-        informational: true
-      patch:
+        threshold: 1%
         informational: true
 
 #flags:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
 env:
   RUST_BACKTRACE: 1
 
+# Spend CI time only on latest ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     strategy:
@@ -67,6 +72,18 @@ jobs:
       - name: Test examples
         if: matrix.os != 'windows-latest'
         run: cargo test -p kube-examples --examples -j6
+
+  doc:
+    runs-on: ubuntu-latest
+    name: nightly / doc
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly
+        uses: dtolnay/rust-toolchain@nightly
+      - name: cargo doc
+        run: cargo doc --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
 
   msrv:
     # Run `cargo check` on our minimum supported Rust version
@@ -244,7 +261,6 @@ jobs:
           # Anonymous access is limited to 60 requests / hour / worker
           # github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
-
       - name: Compile e2e job against ${{matrix.tls}}
         run: |
           mkdir -p ~/.cargo/{git,registry}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
   doc:
     runs-on: ubuntu-latest
-    name: nightly / doc
+    name: doc
     steps:
       - uses: actions/checkout@v4
       - name: Install nightly

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ fmt:
   rustfmt +nightly --edition 2021 $(find . -type f -iname *.rs)
 
 doc:
-  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,oidc,jsonpatch,client,derive,runtime,admission,k8s-openapi/latest,unstable-runtime --open
+  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
 
 deny:
   # might require rm Cargo.lock first to match CI

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -4,7 +4,6 @@ use std::{
     sync::Arc,
 };
 
-
 use chrono::{DateTime, Duration, Utc};
 use futures::future::BoxFuture;
 use http::{
@@ -595,6 +594,7 @@ mod test {
 
     use super::*;
     #[tokio::test]
+    #[ignore = "fails on windows mysteriously"]
     async fn exec_auth_command() -> Result<(), Error> {
         let expiry = (Utc::now() + Duration::seconds(60 * 60)).to_rfc3339();
         let test_file = format!(


### PR DESCRIPTION
#### 1. Trying again to stop codecov from posting status checks
Informational is what we want.

#### 2. windows test ignore in client/auth/mod
https://github.com/kube-rs/kube/actions/runs/6443438740/job/17495479744 has started failing mysteriously on windows with a `ParseTokenKey(Error("EOF while parsing a value", line: 2, column: 0))` on client/auth/mod:631 which is weird. this thing hasn't had changes in a year (so probably windows environment related for github ci).

#### 3. add doc test job
we occasionally get outdated doc links being added, trying a doc job to see if it can help catch broken links
see [output](https://github.com/kube-rs/kube/actions/runs/6450332879/job/17509584427)
some warnings in there atm, but those are warnings only