### PR TITLE
Upgrade `darling` and `syn` and rename `#[kube(struct)]`

### DIFF
--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
     version = "v1",
     kind = "Foo",
     plural = "fooz",
-    struct = "FooCrd",
+    generate = "FooCrd",
     namespaced,
     status = "FooStatus",
     derive = "PartialEq",

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
     version = "v1",
     kind = "Foo",
     plural = "fooz",
-    generate = "FooCrd",
+    root = "FooCrd",
     namespaced,
     status = "FooStatus",
     derive = "PartialEq",

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -18,9 +18,9 @@ categories = ["api-bindings", "encoding"]
 [dependencies]
 proc-macro2 = "1.0.29"
 quote = "1.0.10"
-syn = { version = "1.0.80", features = ["extra-traits"] }
+syn = { version = "2.0.38", features = ["extra-traits"] }
 serde_json = "1.0.68"
-darling = "0.14.0"
+darling = "0.20.3"
 
 [lib]
 proc-macro = true

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -10,7 +10,7 @@ struct KubeAttrs {
     group: String,
     version: String,
     kind: String,
-    #[darling(rename = "struct")]
+    #[darling(rename = "generate")]
     kind_struct: Option<String>,
     /// lowercase plural of kind (inferred if omitted)
     plural: Option<String>,

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -10,7 +10,7 @@ struct KubeAttrs {
     group: String,
     version: String,
     kind: String,
-    #[darling(rename = "generate")]
+    #[darling(rename = "root")]
     kind_struct: Option<String>,
     /// lowercase plural of kind (inferred if omitted)
     plural: Option<String>,

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -34,12 +34,12 @@ mod custom_resource;
 /// let f = Foo::new("foo-1", FooSpec {
 ///     info: "informative info".into(),
 /// });
-/// println!("foo: {:?}", f); // debug print on generated type
+/// println!("foo: {:?}", f); // debug print on root type
 /// println!("crd: {}", serde_yaml::to_string(&Foo::crd()).unwrap()); // crd yaml
 /// ```
 ///
-/// This example creates a `struct Foo` containing metadata, the spec,
-/// and optionally status. The **generated** type `Foo` can be used with the [`kube`] crate
+/// This example generates a `struct Foo` containing metadata, the spec,
+/// and optionally status. The **root** struct `Foo` can be used with the [`kube`] crate
 /// as an `Api<Foo>` object (`FooSpec` can not be used with [`Api`][`kube::Api`]).
 ///
 /// ```no_run
@@ -73,12 +73,12 @@ mod custom_resource;
 /// Your cr api version. The part after the slash in the top level `apiVersion` key.
 ///
 /// ## `#[kube(kind = "Kind")]`
-/// Name of your kind and your generated root type.
+/// Name of your kind, and implied default for your generated root type.
 ///
 /// # Optional `#[kube]` attributes
 ///
 /// ## `#[kube(singular = "nonstandard-singular")]`
-/// To specify the singular name. Defaults to lowercased `kind`.
+/// To specify the singular name. Defaults to lowercased `.kind` value.
 ///
 /// ## `#[kube(plural = "nonstandard-plural")]`
 /// To specify the plural name. Defaults to inferring from singular.
@@ -86,8 +86,8 @@ mod custom_resource;
 /// ## `#[kube(namespaced)]`
 /// To specify that this is a namespaced resource rather than cluster level.
 ///
-/// ## `#[kube(generate = "StructName")]`
-/// Customize the name of the generated root struct (defaults to `kind`).
+/// ## `#[kube(root = "StructName")]`
+/// Customize the name of the generated root struct (defaults to `.kind` value).
 ///
 /// ## `#[kube(crates(kube_core = "::kube::core"))]`
 /// Customize the crate name the generated code will reach into (defaults to `::kube::core`).
@@ -153,7 +153,7 @@ mod custom_resource;
 ///     group = "clux.dev",
 ///     version = "v1",
 ///     kind = "Foo",
-///     generate = "FooCrd",
+///     root = "FooCrd",
 ///     namespaced,
 ///     status = "FooStatus",
 ///     derive = "PartialEq",

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -86,7 +86,7 @@ mod custom_resource;
 /// ## `#[kube(namespaced)]`
 /// To specify that this is a namespaced resource rather than cluster level.
 ///
-/// ## `#[kube(struct = "StructName")]`
+/// ## `#[kube(generate = "StructName")]`
 /// Customize the name of the generated root struct (defaults to `kind`).
 ///
 /// ## `#[kube(crates(kube_core = "::kube::core"))]`
@@ -153,7 +153,7 @@ mod custom_resource;
 ///     group = "clux.dev",
 ///     version = "v1",
 ///     kind = "Foo",
-///     struct = "FooCrd",
+///     generate = "FooCrd",
 ///     namespaced,
 ///     status = "FooStatus",
 ///     derive = "PartialEq",


### PR DESCRIPTION
- [syn 2](https://github.com/dtolnay/syn/releases/tag/2.0.0)
- [darling 0.20](https://github.com/TedDriggs/darling/releases/tag/v0.20.0) (they bumped minors to nearest 10)

Somewhere from this upgrade is a breaking change that makes it illegal to use `struct` as an attribute name.

Users will see this error if using `#[kube(struct)]`:

```
  --> examples/crd_derive.rs:18:5
   |
18 |     struct = "FooCrd",
   |     ^^^^^^
```

Have worked around this by renaming this attribute name to something less keywordy:

```diff
-#[kube(struct = FooCrd)]
+#[kube(root = FooCrd)]
```

Will point this out in the release notes if it is accepted.