### PR TITLE
Bump `base64` to `0.21`

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -37,7 +37,7 @@ features = ["client", "rustls-tls", "openssl-tls", "ws", "oauth", "oidc", "jsonp
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-base64 = { version = "0.20.0", optional = true }
+base64 = { version = "0.21.4", optional = true }
 chrono = { version = "0.4.23", optional = true, default-features = false }
 home = { version = "0.5.4", optional = true }
 serde = { version = "1.0.130", features = ["derive"] }

--- a/kube-client/src/client/auth/oidc.rs
+++ b/kube-client/src/client/auth/oidc.rs
@@ -364,7 +364,7 @@ impl Refresher {
                     AUTHORIZATION,
                     format!(
                         "Basic {}",
-                        BASE64_ENGINE.encode(format!(
+                        base64::engine::general_purpose::STANDARD.encode(format!(
                             "{}:{}",
                             self.client_id.expose_secret(),
                             self.client_secret.expose_secret()

--- a/kube-client/src/client/auth/oidc.rs
+++ b/kube-client/src/client/auth/oidc.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use base64::{alphabet, engine, Engine as _};
 use chrono::{Duration, TimeZone, Utc};
 use form_urlencoded::Serializer;
 use http::{
@@ -131,11 +130,12 @@ pub mod errors {
     }
 }
 
-const JWT_BASE64_ENGINE: engine::GeneralPurpose = engine::GeneralPurpose::new(
-    &alphabet::URL_SAFE,
-    engine::GeneralPurposeConfig::new()
+use base64::Engine as _;
+const JWT_BASE64_ENGINE: base64::engine::GeneralPurpose = base64::engine::GeneralPurpose::new(
+    &base64::alphabet::URL_SAFE,
+    base64::engine::GeneralPurposeConfig::new()
         .with_decode_allow_trailing_bits(true)
-        .with_decode_padding_mode(engine::DecodePaddingMode::Indifferent),
+        .with_decode_padding_mode(base64::engine::DecodePaddingMode::Indifferent),
 );
 use base64::engine::general_purpose::STANDARD as STANDARD_BASE64_ENGINE;
 

--- a/kube-client/src/client/auth/oidc.rs
+++ b/kube-client/src/client/auth/oidc.rs
@@ -476,7 +476,7 @@ mod tests {
         let invalid_claims_token = format!(
             "{}.{}.{}",
             token_valid.split_once('.').unwrap().0,
-            STANDARD_BASE64_ENGINE.encode(serde_json::to_string(&invalid_claims).unwrap()),
+            JWT_BASE64_ENGINE.encode(serde_json::to_string(&invalid_claims).unwrap()),
             token_valid.rsplit_once('.').unwrap().1,
         );
         oidc.id_token = invalid_claims_token.into();

--- a/kube-client/src/client/auth/oidc.rs
+++ b/kube-client/src/client/auth/oidc.rs
@@ -131,7 +131,7 @@ pub mod errors {
     }
 }
 
-const BASE64_ENGINE: engine::GeneralPurpose = engine::GeneralPurpose::new(
+const JWT_BASE64_ENGINE: engine::GeneralPurpose = engine::GeneralPurpose::new(
     &alphabet::URL_SAFE,
     engine::GeneralPurposeConfig::new()
         .with_decode_allow_trailing_bits(true)

--- a/kube-client/src/client/upgrade.rs
+++ b/kube-client/src/client/upgrade.rs
@@ -39,7 +39,6 @@ pub enum UpgradeConnectionError {
     GetPendingUpgrade(#[source] hyper::Error),
 }
 
-
 // Verify upgrade response according to RFC6455.
 // Based on `tungstenite` and added subprotocol verification.
 pub fn verify_response(res: &Response<Body>, key: &str) -> Result<(), UpgradeConnectionError> {
@@ -90,6 +89,7 @@ pub fn verify_response(res: &Response<Body>, key: &str) -> Result<(), UpgradeCon
 /// Generate a random key for the `Sec-WebSocket-Key` header.
 /// This must be nonce consisting of a randomly selected 16-byte value in base64.
 pub fn sec_websocket_key() -> String {
+    use base64::Engine;
     let r: [u8; 16] = rand::random();
-    base64::encode(r)
+    base64::engine::general_purpose::STANDARD.encode(r)
 }

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -537,7 +537,10 @@ fn load_from_base64_or_file<P: AsRef<Path>>(
 }
 
 fn load_from_base64(value: &str) -> Result<Vec<u8>, LoadDataError> {
-    base64::decode(value).map_err(LoadDataError::DecodeBase64)
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD
+        .decode(value)
+        .map_err(LoadDataError::DecodeBase64)
 }
 
 fn load_from_file<P: AsRef<Path>>(file: &P) -> Result<Vec<u8>, LoadDataError> {
@@ -767,7 +770,6 @@ users:
     client-certificate-data: aGVsbG8K
     client-key-data: aGVsbG8K
 "#;
-
 
         let kubeconfig1 = Kubeconfig::from_yaml(config1)?;
         let kubeconfig2 = Kubeconfig::from_yaml(config2)?;


### PR DESCRIPTION
Final set of breaking dependency bumps for #1181. Followed the [base64 migration notes](https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md#0210) for the deprecated ones, and fixed up the one that used a non-standard config. The import structure is a bit nicer now.