### PR TITLE
PoC: Create an `Api::dynamic` and `Api::cluster` + scope constrain `Api::all`

### DIFF
--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     let client = Client::try_default().await?;
 
     // Manage CRDs first
-    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    let crds: Api<CustomResourceDefinition> = Api::cluster(client.clone());
 
     // Delete any old versions of it first:
     let dp = DeleteParams::default();

--- a/examples/crd_apply.rs
+++ b/examples/crd_apply.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
 
     // 0. Ensure the CRD is installed (you probably just want to do this on CI)
     // (crd file can be created by piping `Foo::crd`'s yaml ser to kubectl apply)
-    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    let crds: Api<CustomResourceDefinition> = Api::cluster(client.clone());
     info!("Creating crd: {}", serde_yaml::to_string(&Foo::crd())?);
     crds.patch("foos.clux.dev", &ssapply, &Patch::Apply(Foo::crd()))
         .await?;

--- a/examples/crd_derive_multi.rs
+++ b/examples/crd_derive_multi.rs
@@ -101,7 +101,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn apply_crd(client: Client, crd: CustomResourceDefinition) -> anyhow::Result<()> {
-    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    let crds: Api<CustomResourceDefinition> = Api::cluster(client.clone());
     info!("Creating crd: {}", serde_yaml::to_string(&crd)?);
     let ssapply = PatchParams::apply("crd_derive_multi").force();
     crds.patch("manyderives.kube.rs", &ssapply, &Patch::Apply(&crd))
@@ -116,7 +116,7 @@ async fn apply_crd(client: Client, crd: CustomResourceDefinition) -> anyhow::Res
 }
 
 async fn cleanup(client: Client) -> anyhow::Result<()> {
-    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    let crds: Api<CustomResourceDefinition> = Api::cluster(client.clone());
     let obj = crds.delete("manyderives.kube.rs", &Default::default()).await?;
     if let either::Either::Left(o) = obj {
         let uid = o.uid().unwrap();

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -220,7 +220,7 @@ async fn main() -> Result<()> {
 
 // Create CRD and wait for it to be ready.
 async fn create_crd(client: Client) -> Result<CustomResourceDefinition> {
-    let api = Api::<CustomResourceDefinition>::all(client);
+    let api = Api::<CustomResourceDefinition>::cluster(client);
     api.create(&PostParams::default(), &Foo::crd()).await?;
 
     // Wait until it's accepted and established by the api-server
@@ -235,7 +235,7 @@ async fn create_crd(client: Client) -> Result<CustomResourceDefinition> {
 
 // Delete the CRD if it exists and wait until it's deleted.
 async fn delete_crd(client: Client) -> Result<()> {
-    let api = Api::<CustomResourceDefinition>::all(client);
+    let api = Api::<CustomResourceDefinition>::cluster(client);
     if api.get("foos.clux.dev").await.is_ok() {
         api.delete("foos.clux.dev", &DeleteParams::default()).await?;
 

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
 
     // 0. Ensure the CRD is installed (you probably just want to do this on CI)
     // (crd file can be created by piping `Foo::crd`'s yaml ser to kubectl apply)
-    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    let crds: Api<CustomResourceDefinition> = Api::cluster(client.clone());
     info!("Creating crd: {}", serde_yaml::to_string(&Foo::crd())?);
     let ssapply = PatchParams::apply("crd_reflector_example").force();
     crds.patch("foos.clux.dev", &ssapply, &Patch::Apply(Foo::crd()))

--- a/examples/dynamic_api.rs
+++ b/examples/dynamic_api.rs
@@ -2,7 +2,7 @@
 
 use kube::{
     api::{Api, DynamicObject, ResourceExt},
-    discovery::{verbs, Discovery, Scope},
+    discovery::{verbs, Discovery},
     Client,
 };
 use tracing::*;
@@ -18,11 +18,7 @@ async fn main() -> anyhow::Result<()> {
             if !caps.supports_operation(verbs::LIST) {
                 continue;
             }
-            let api: Api<DynamicObject> = if caps.scope == Scope::Cluster {
-                Api::all_with(client.clone(), &ar)
-            } else {
-                Api::default_namespaced_with(client.clone(), &ar)
-            };
+            let api: Api<DynamicObject> = Api::dynamic(client.clone(), &ar, caps.scope);
 
             info!("{}/{} : {}", group.name(), ar.version, ar.kind);
 

--- a/examples/kubectl.rs
+++ b/examples/kubectl.rs
@@ -228,12 +228,17 @@ fn dynamic_api(
     ns: Option<&str>,
     all: bool,
 ) -> Api<DynamicObject> {
-    if caps.scope == Scope::Cluster || all {
-        Api::all_with(client, &ar)
-    } else if let Some(namespace) = ns {
-        Api::namespaced_with(client, namespace, &ar)
-    } else {
-        Api::default_namespaced_with(client, &ar)
+    match caps.scope {
+        Scope::Cluster => Api::cluster_with(client, &ar),
+        Scope::Namespaced => {
+            if all {
+                Api::all_with(client, &ar)
+            } else if let Some(namespace) = ns {
+                Api::namespaced_with(client, namespace, &ar)
+            } else {
+                Api::default_namespaced_with(client, &ar)
+            }
+        }
     }
 }
 

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -12,7 +12,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let client = Client::try_default().await?;
 
-    let nodes: Api<Node> = Api::all(client.clone());
+    let nodes: Api<Node> = Api::cluster(client.clone());
     let wc = watcher::Config::default()
         .labels("kubernetes.io/arch=amd64") // filter instances by label
         .timeout(10); // short watch timeout in this example

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -12,7 +12,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let client = Client::try_default().await?;
     let events: Api<Event> = Api::all(client.clone());
-    let nodes: Api<Node> = Api::all(client.clone());
+    let nodes: Api<Node> = Api::cluster(client.clone());
 
     let use_watchlist = std::env::var("WATCHLIST").map(|s| s == "1").unwrap_or(false);
     let wc = if use_watchlist {

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -266,7 +266,7 @@ where
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
 
-    /// let crds: Api<CustomResourceDefinition> = Api::all(client);
+    /// let crds: Api<CustomResourceDefinition> = Api::cluster(client);
     /// crds.delete("foos.clux.dev", &DeleteParams::default()).await?
     ///     .map_left(|o| println!("Deleting CRD: {:?}", o.status))
     ///     .map_right(|s| println!("Deleted CRD: {:?}", s));

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -90,7 +90,7 @@ impl<K: Resource> Api<K> {
         }
     }
 
-    /// Cluster level resources, or resources viewed across all namespaces
+    /// A list/watch only view into namespaced resources across all namespaces
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
     pub fn all_with(client: Client, dyntype: &K::DynamicType) -> Self
@@ -281,7 +281,7 @@ where
     /// # use kube::{Api, Client};
     /// # let client: Client = todo!();
     /// use k8s_openapi::api::core::v1::Node;
-    /// let api: Api<Node> = Api::default_namespaced(client); // resource not namespaced!
+    /// let api: Api<Node> = Api::all(client); // resource not namespaced!
     /// ```
     ///
     /// See [`Api::cluster`] for cluster level resources.

--- a/kube-client/src/api/util/mod.rs
+++ b/kube-client/src/api/util/mod.rs
@@ -86,7 +86,7 @@ mod test {
             },
         }))?;
 
-        let nodes: Api<Node> = Api::all(client.clone());
+        let nodes: Api<Node> = Api::cluster(client.clone());
         nodes.create(&PostParams::default(), &fake_node).await?;
 
         let schedulables = ListParams::default().fields("spec.unschedulable==false");
@@ -114,7 +114,7 @@ mod test {
         let audiences = vec!["api".to_string()];
 
         let serviceaccounts: Api<ServiceAccount> = Api::namespaced(client.clone(), serviceaccount_namespace);
-        let tokenreviews: Api<TokenReview> = Api::all(client);
+        let tokenreviews: Api<TokenReview> = Api::cluster(client);
 
         // Create ServiceAccount
         let fake_sa = serde_json::from_value(json!({

--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -46,7 +46,7 @@ use std::{cmp::Reverse, collections::HashMap, iter::Iterator};
 ///     let client = Client::try_default().await?;
 ///     let apigroup = discovery::group(&client, "apiregistration.k8s.io").await?;
 ///     let (ar, caps) = apigroup.recommended_kind("APIService").unwrap();
-///     let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
+///     let api: Api<DynamicObject> = Api::dynamic(client.clone(), &ar, caps.scope);
 ///     for service in api.list(&Default::default()).await? {
 ///         println!("Found APIService: {}", service.name_any());
 ///     }
@@ -238,7 +238,7 @@ impl ApiGroup {
     ///         if !caps.supports_operation(verbs::LIST) {
     ///             continue;
     ///         }
-    ///         let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
+    ///         let api: Api<DynamicObject> = Api::dynamic(client.clone(), &ar, caps.scope);
     ///         for inst in api.list(&Default::default()).await? {
     ///             println!("Found {}: {}", ar.kind, inst.name_any());
     ///         }
@@ -267,7 +267,7 @@ impl ApiGroup {
     ///         if !caps.supports_operation(verbs::LIST) {
     ///             continue;
     ///         }
-    ///         let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
+    ///         let api: Api<DynamicObject> = Api::dynamic(client.clone(), &ar, caps.scope);
     ///         for inst in api.list(&Default::default()).await? {
     ///             println!("Found {}: {}", ar.kind, inst.name_any());
     ///         }

--- a/kube-client/src/discovery/oneshot.rs
+++ b/kube-client/src/discovery/oneshot.rs
@@ -30,7 +30,7 @@ use kube_core::{
 ///     let client = Client::try_default().await?;
 ///     let apigroup = discovery::group(&client, "apiregistration.k8s.io").await?;
 ///     let (ar, caps) = apigroup.recommended_kind("APIService").unwrap();
-///     let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
+///     let api: Api<DynamicObject> = Api::dynamic(client.clone(), &ar, caps.scope);
 ///     for service in api.list(&Default::default()).await? {
 ///         println!("Found APIService: {}", service.name_any());
 ///     }
@@ -67,7 +67,7 @@ pub async fn group(client: &Client, apigroup: &str) -> Result<ApiGroup> {
 ///     let gv = "apiregistration.k8s.io/v1".parse()?;
 ///     let apigroup = discovery::pinned_group(&client, &gv).await?;
 ///     let (ar, caps) = apigroup.recommended_kind("APIService").unwrap();
-///     let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
+///     let api: Api<DynamicObject> = Api::dynamic(client.clone(), &ar, caps.scope);
 ///     for service in api.list(&Default::default()).await? {
 ///         println!("Found APIService: {}", service.name_any());
 ///     }
@@ -94,7 +94,7 @@ pub async fn pinned_group(client: &Client, gv: &GroupVersion) -> Result<ApiGroup
 ///     let client = Client::try_default().await?;
 ///     let gvk = GroupVersionKind::gvk("apiregistration.k8s.io", "v1", "APIService");
 ///     let (ar, caps) = discovery::pinned_kind(&client, &gvk).await?;
-///     let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
+///     let api: Api<DynamicObject> = Api::dynamic(client.clone(), &ar, caps.scope);
 ///     for service in api.list(&Default::default()).await? {
 ///         println!("Found APIService: {}", service.name_any());
 ///     }

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -574,7 +574,7 @@ mod test {
         }))?;
 
         let client = Client::try_default().await?;
-        let csr: Api<CertificateSigningRequest> = Api::all(client.clone());
+        let csr: Api<CertificateSigningRequest> = Api::cluster(client.clone());
         assert!(csr.create(&PostParams::default(), &dummy_csr).await.is_ok());
 
         // Patch the approval and approve the CSR

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -53,7 +53,7 @@ mod custom_resource;
 ///  # struct FooSpec {}
 ///  # let client: Client = todo!();
 ///  let foos: Api<Foo> = Api::default_namespaced(client.clone());
-///  let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+///  let crds: Api<CustomResourceDefinition> = Api::cluster(client.clone());
 ///  crds.patch("foos.clux.dev", &PatchParams::apply("myapp"), &Patch::Apply(Foo::crd())).await;
 /// # Ok(())
 /// # }

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -855,10 +855,10 @@ where
     /// ```
     /// # use kube::runtime::{Controller, controller::Action, reflector::ObjectRef, watcher};
     /// # use kube::{Api, ResourceExt};
-    /// # use k8s_openapi::api::core::v1::{ConfigMap, Namespace};
+    /// # use k8s_openapi::api::core::v1::{ConfigMap, Pod};
     /// # use futures::StreamExt;
     /// # use std::sync::Arc;
-    /// # type WatchedResource = Namespace;
+    /// # type WatchedResource = Pod;
     /// # struct Context;
     /// # async fn reconcile(_: Arc<ConfigMap>, _: Arc<Context>) -> Result<Action, kube::Error> {
     /// #     Ok(Action::await_change())
@@ -963,7 +963,7 @@ where
     /// fn mapper(_: DaemonSet) -> Option<ObjectRef<CustomResource>> { todo!() }
     /// # async fn doc(client: kube::Client) {
     /// let api: Api<DaemonSet> = Api::all(client.clone());
-    /// let cr: Api<CustomResource> = Api::all(client.clone());
+    /// let cr: Api<CustomResource> = Api::default_namespaced(client.clone());
     /// let daemons = watcher(api, watcher::Config::default())
     ///     .touched_objects()
     ///     .predicate_filter(predicates::generation);

--- a/kube-runtime/src/events.rs
+++ b/kube-runtime/src/events.rs
@@ -292,7 +292,7 @@ mod test {
     async fn event_recorder_attaches_events_without_namespace() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
 
-        let svcs: Api<ClusterRole> = Api::all(client.clone());
+        let svcs: Api<ClusterRole> = Api::cluster(client.clone());
         let s = svcs.get("system:basic-user").await?; // always get this default ClusterRole
         let recorder = Recorder::new(client.clone(), "kube".into(), s.object_ref(&()));
         recorder

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -39,7 +39,7 @@ pub use store::{store, Store};
 /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 /// # let client: kube::Client = todo!();
 ///
-/// let nodes: Api<Node> = Api::all(client);
+/// let nodes: Api<Node> = Api::cluster(client);
 /// let node_filter = Config::default().labels("kubernetes.io/arch=amd64");
 /// let (reader, writer) = reflector::store();
 ///

--- a/kube-runtime/src/wait.rs
+++ b/kube-runtime/src/wait.rs
@@ -39,7 +39,7 @@ pub enum Error {
 /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 /// # let client: kube::Client = todo!();
 ///
-/// let crds: Api<CustomResourceDefinition> = Api::all(client);
+/// let crds: Api<CustomResourceDefinition> = Api::cluster(client);
 /// // .. create or apply a crd here ..
 /// let establish = await_condition(crds, "foos.clux.dev", conditions::is_crd_established());
 /// let _ = tokio::time::timeout(std::time::Duration::from_secs(10), establish).await?;

--- a/kube/src/mock_tests.rs
+++ b/kube/src/mock_tests.rs
@@ -32,7 +32,7 @@ async fn watchers_respect_pagination_limits() {
     // NB: scenario only responds responds to TWO paginated list calls with two objects
     let mocksrv = fakeserver.run(Scenario::PaginatedList);
 
-    let api: Api<Hack> = Api::all(client);
+    let api: Api<Hack> = Api::cluster(client);
     let cfg = Config::default().page_size(1);
     let mut stream = watcher(api, cfg).applied_objects().boxed();
     let first: Hack = stream.try_next().await.unwrap().unwrap();


### PR DESCRIPTION
## Proof of Concept
Wanted to see how this ended up looking. I am not 100% convinced about this yet.

## Motivation
Currently the biggest footgun in kube right now is `Api::all` and its interaction with Namespaced objects.

An `Api::all` on a `Resource = NamespacedResource` is an extremely stunted implementation that only really allows `Api::list`, `Api::watch`.

All the other [Api methods](https://docs.rs/kube/latest/kube/struct.Api.html#) will fail with 404s because it by construction creates invalid request urls.

Main issues:

- get with Api::all() response can't be 404 #1276
- client: Api::all fails to create namespaced resources #1030

and a couple from discussions:

- Can't create 3rd party CRD #1296
- How can I get some resources with the event type? #1312 <- a more exotic one with `finalizer`

## Proposal

1. Put a big warning on `Api::all`
2. Try to shift people away from `Api::all` unless they actually want a cross-namespace lister

This does mean one breaking change:

- `Api::all` now requires `NamespaceResourceScope` + put a big warning on it that it's only for listwatching.

and add two new main `Api` constructors to compensate:

- `Api::cluster` - limited to `ClusterResourceScope`
- `Api::dynamic` - limited to `DynamicResourceScope`
 
a potential setup for api construction from discovery to show this does not make it worse

## Alternatives
- We could not add the `NamespaceResourceScope` scope constraint on `Api::all` for a non-breaking change.
- It's possible this is not worth it, and it's instead worth focusing on the Client V2. However, it's unlikely we'll remove `Api` no matter what, so thought we may as well make this as good as possible

## Drawbacks
- More duplication of constructors (which are hard to find in the [myriad of Api methods on docs.rs](https://docs.rs/kube/latest/kube/struct.Api.html#method.all))
- This still does not prevent people from making the error I actually wanted to prevent, it just makes it less likely (as users will more likely flock to the methods they see in examples, or the one in docs.rs with less big warnings)