### PR TITLE
Fixed KUBERNETES_EXEC_INFO environment variable passed to auth plugins

### DIFF
--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -554,7 +554,7 @@ fn auth_exec(auth: &ExecConfig) -> Result<ExecCredential, Error> {
     // Provide exec info to child process
     let exec_info = serde_json::to_string(&ExecCredential {
         api_version: auth.api_version.clone(),
-        kind: None,
+        kind: "ExecCredential".to_string().into(),
         spec: Some(ExecCredentialSpec {
             interactive: Some(interactive),
         }),


### PR DESCRIPTION
Closes #1318

## Motivation

Custom authentication plugin fails when used with this client. Authentication plugins expect `KUBERNETES_EXEC_INFO` environment variable, which should contain a serialized [`ExecCredential`](https://github.com/kubernetes/client-go/blob/33d14001dbdfd2f3eccfa907b8cc3738f514680e/pkg/apis/clientauthentication/types.go#L28) object. Field `kind` of this object should contain `ExecCredential` string.

## Solution

Setting `kind` to `ExecCredential` before serialization.