### PR TITLE
rustls: optionally use WebPKI roots to avoid panicking on Android & iOS

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,8 +31,6 @@ allow = [
     # Pulled in via aws_lc_rs when using rustls-tls and aws-lc-rs features
     # https://openssl-library.org/source/license/index.html
     "OpenSSL",
-    # Pulled in via hyper-rustls when using the webpki-roots feature
-    "MPL-2.0",
 ]
 
 exceptions = [
@@ -42,6 +40,9 @@ exceptions = [
     # this is not a problem for us. See https://github.com/dtolnay/unicode-ident/pull/9/files
     # for more details.
     { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
+    # Pulled in via hyper-rustls when using the webpki-roots feature,
+    # which is off by default.
+    { allow = ["MPL-2.0"], name = "webpki-roots" },
 ]
 
 [[licenses.clarify]]

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,8 @@ allow = [
     # Pulled in via aws_lc_rs when using rustls-tls and aws-lc-rs features
     # https://openssl-library.org/source/license/index.html
     "OpenSSL",
+    # Pulled in via hyper-rustls when using the webpki-roots feature
+    "MPL-2.0",
 ]
 
 exceptions = [

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["web-programming::http-client", "network-programming", "api-bindin
 [features]
 default = ["client"]
 rustls-tls = ["rustls", "rustls-pemfile", "hyper-rustls", "hyper-http-proxy?/rustls-tls-native-roots"]
+webpki-roots = ["hyper-rustls/webpki-roots"]
 aws-lc-rs = ["rustls?/aws-lc-rs"]
 openssl-tls = ["openssl", "hyper-openssl"]
 ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws", "tokio/macros"]

--- a/kube-client/src/client/auth/oauth.rs
+++ b/kube-client/src/client/auth/oauth.rs
@@ -118,10 +118,16 @@ impl Gcp {
                 // Current TLS feature precedence when more than one are set:
                 // 1. rustls-tls
                 // 2. openssl-tls
-                #[cfg(feature = "rustls-tls")]
+                #[cfg(all(feature = "rustls-tls", not(feature = "webpki-roots")))]
                 let https = hyper_rustls::HttpsConnectorBuilder::new()
                     .with_native_roots()
                     .map_err(Error::NoValidNativeRootCA)?
+                    .https_only()
+                    .enable_http1()
+                    .build();
+                #[cfg(all(feature = "rustls-tls", feature = "webpki-roots"))]
+                let https = hyper_rustls::HttpsConnectorBuilder::new()
+                    .with_webpki_roots()
                     .https_only()
                     .enable_http1()
                     .build();

--- a/kube-client/src/client/auth/oidc.rs
+++ b/kube-client/src/client/auth/oidc.rs
@@ -313,10 +313,16 @@ impl Refresher {
             .install_default()
             .unwrap();
 
-        #[cfg(feature = "rustls-tls")]
+        #[cfg(all(feature = "rustls-tls", not(feature = "webpki-roots")))]
         let https = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
             .map_err(|_| errors::RefreshInitError::NoValidNativeRootCA)?
+            .https_only()
+            .enable_http1()
+            .build();
+        #[cfg(all(feature = "rustls-tls", feature = "webpki-roots"))]
+        let https = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_webpki_roots()
             .https_only()
             .enable_http1()
             .build();

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -37,6 +37,7 @@ unstable-runtime = ["kube-runtime/unstable-runtime", "runtime"]
 unstable-client = ["kube-client/unstable-client", "client"]
 socks5 = ["kube-client/socks5", "client"]
 http-proxy = ["kube-client/http-proxy", "client"]
+webpki-roots = ["kube-client/webpki-roots", "client"]
 
 [package.metadata.docs.rs]
 features = ["client", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/latest", "unstable-runtime", "socks5", "http-proxy"]


### PR DESCRIPTION
## Motivation

Using `kube-rs` on iOS, I came across a panic in the underlying `hyper-rustls` root cert initialization [trying to access the native roots](https://github.com/rustls/hyper-rustls/blob/1c8811a72d089aae0ed05e5416ae4ece21f97828/src/config.rs#L26), which doesn't work on Android or iOS, according [to this open issue](https://github.com/rustls/rustls-native-certs/issues/3).

## Solution

My solution was to add a check to [fall back to the WebPKI roots](https://github.com/rustls/hyper-rustls/blob/1c8811a72d089aae0ed05e5416ae4ece21f97828/src/config.rs#L55) when on Android or iOS, which fixes the issue for me, but could make sense upstream, too.

Please let me know if this change makes sense to you or whether I'm missing anything. And thanks a lot for all the work you've done on the `kube-rs` ecosystem! 😊