### PR TITLE
Fix `connector` shadowing to fix no-tls build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Build workspace
         run: cargo build
 
+      - name: Build no-tls
+        run: cargo build -p kube --no-default-features --features=client
+        if: matrix.os == 'ubuntu-latest' # only linux tests all feature combinations
+
       # Workspace unit tests with various feature sets
       - name: Run workspace unit tests (no default features)
         run: cargo test --workspace --lib --no-default-features -j6

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -94,7 +94,7 @@ impl TryFrom<Config> for ClientBuilder<GenericService> {
 
 /// Helper function for implementation of [`TryFrom<Config>`] for [`ClientBuilder`].
 /// Ignores [`Config::proxy_url`], which at this point is already handled.
-fn make_generic_builder<H>(base_connector: H, config: Config) -> Result<ClientBuilder<GenericService>, Error>
+fn make_generic_builder<H>(connector: H, config: Config) -> Result<ClientBuilder<GenericService>, Error>
 where
     H: 'static + Clone + Send + Sync + Service<http::Uri>,
     H::Response: 'static + Connection + AsyncRead + AsyncWrite + Send + Unpin,
@@ -111,9 +111,9 @@ where
         // Create a custom client to use something else.
         // If TLS features are not enabled, http connector will be used.
         #[cfg(feature = "rustls-tls")]
-        let connector = config.rustls_https_connector_with_connector(base_connector)?;
+        let connector = config.rustls_https_connector_with_connector(connector)?;
         #[cfg(all(not(feature = "rustls-tls"), feature = "openssl-tls"))]
-        let connector = config.openssl_https_connector_with_connector(base_connector)?;
+        let connector = config.openssl_https_connector_with_connector(connector)?;
         #[cfg(all(not(feature = "rustls-tls"), not(feature = "openssl-tls")))]
         if auth_layer.is_none() || config.cluster_url.scheme() == Some(&http::uri::Scheme::HTTPS) {
             // no tls stack situation only works on anonymous auth with http scheme

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -116,7 +116,7 @@ where
         let connector = config.openssl_https_connector_with_connector(connector)?;
         #[cfg(all(not(feature = "rustls-tls"), not(feature = "openssl-tls")))]
         if config.cluster_url.scheme() == Some(&http::uri::Scheme::HTTPS) {
-            // no tls stack situation only works on anonymous auth with http scheme
+            // no tls stack situation only works with http scheme
             return Err(Error::TlsRequired);
         }
 

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -115,7 +115,7 @@ where
         #[cfg(all(not(feature = "rustls-tls"), feature = "openssl-tls"))]
         let connector = config.openssl_https_connector_with_connector(connector)?;
         #[cfg(all(not(feature = "rustls-tls"), not(feature = "openssl-tls")))]
-        if auth_layer.is_none() || config.cluster_url.scheme() == Some(&http::uri::Scheme::HTTPS) {
+        if config.cluster_url.scheme() == Some(&http::uri::Scheme::HTTPS) {
             // no tls stack situation only works on anonymous auth with http scheme
             return Err(Error::TlsRequired);
         }


### PR DESCRIPTION
Adds a feature test on linux for no-tls. Maybe we need to do `cargo hack` in the future.

includes a relatively minor fix to no-tls; only bail when scheme is https.