### PR TITLE
Add support for `LogParams::since_time`

### DIFF
--- a/examples/log_stream.rs
+++ b/examples/log_stream.rs
@@ -1,5 +1,9 @@
 use futures::{AsyncBufReadExt, TryStreamExt};
-use k8s_openapi::api::core::v1::Pod;
+use k8s_openapi::{
+    api::core::v1::Pod,
+    apimachinery::pkg::apis::meta::v1::Time,
+    chrono::{DateTime, Utc},
+};
 use kube::{
     api::{Api, LogParams},
     Client,
@@ -19,8 +23,11 @@ struct App {
     follow: bool,
 
     /// Since seconds
-    #[arg(long, short = 's')]
+    #[arg(long, conflicts_with = "since_time")]
     since: Option<i64>,
+    /// Since time
+    #[arg(long, conflicts_with = "since")]
+    since_time: Option<DateTime<Utc>>,
 
     /// Include timestamps in the log output
     #[arg(long, default_value = "false")]
@@ -43,6 +50,7 @@ async fn main() -> anyhow::Result<()> {
             container: app.container,
             tail_lines: app.tail,
             since_seconds: app.since,
+            since_time: app.since_time.map(|st| Time(st)),
             timestamps: app.timestamps,
             ..LogParams::default()
         })

--- a/examples/log_stream.rs
+++ b/examples/log_stream.rs
@@ -1,7 +1,6 @@
 use futures::{AsyncBufReadExt, TryStreamExt};
 use k8s_openapi::{
     api::core::v1::Pod,
-    apimachinery::pkg::apis::meta::v1::Time,
     chrono::{DateTime, Utc},
 };
 use kube::{
@@ -50,7 +49,7 @@ async fn main() -> anyhow::Result<()> {
             container: app.container,
             tail_lines: app.tail,
             since_seconds: app.since,
-            since_time: app.since_time.map(|st| Time(st)),
+            since_time: app.since_time,
             timestamps: app.timestamps,
             ..LogParams::default()
         })

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -354,7 +354,6 @@ impl Request {
 /// Cheap sanity check to ensure type maps work as expected
 #[cfg(test)]
 mod test {
-    use super::Time;
     use crate::{request::Request, resource::Resource};
     use chrono::{DateTime, TimeZone, Utc};
     use k8s::core::v1 as corev1;

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 
 pub use k8s_openapi::api::autoscaling::v1::{Scale, ScaleSpec, ScaleStatus};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
 
 // ----------------------------------------------------------------------------
 // Log subresource
@@ -35,7 +34,7 @@ pub struct LogParams {
     /// precedes the time a pod was started, only logs since the pod start will be returned.
     /// If this value is in the future, no logs will be returned.
     /// Only one of sinceSeconds or sinceTime may be specified.
-    pub since_time: Option<Time>,
+    pub since_time: Option<chrono::DateTime<chrono::Utc>>,
     /// If set, the number of lines from the end of the logs to show.
     /// If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime
     pub tail_lines: Option<i64>,
@@ -72,7 +71,7 @@ impl Request {
         if let Some(ss) = &lp.since_seconds {
             qp.append_pair("sinceSeconds", &ss.to_string());
         } else if let Some(st) = &lp.since_time {
-            let ser_since = st.0.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            let ser_since = st.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
             qp.append_pair("sinceTime", &ser_since);
         }
 
@@ -387,7 +386,7 @@ mod test {
         let date: DateTime<Utc> = Utc.with_ymd_and_hms(2023, 10, 19, 13, 14, 26).unwrap();
         let lp = LogParams {
             since_seconds: None,
-            since_time: Some(Time(date)),
+            since_time: Some(date),
             ..Default::default()
         };
         let req = Request::new(url).logs("mypod", &lp).unwrap();

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 pub use k8s_openapi::api::autoscaling::v1::{Scale, ScaleSpec, ScaleStatus};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
 
 // ----------------------------------------------------------------------------
 // Log subresource
@@ -30,6 +31,11 @@ pub struct LogParams {
     /// If this value precedes the time a pod was started, only logs since the pod start will be returned.
     /// If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.
     pub since_seconds: Option<i64>,
+    /// An RFC3339 timestamp from which to show logs. If this value
+    /// precedes the time a pod was started, only logs since the pod start will be returned.
+    /// If this value is in the future, no logs will be returned.
+    /// Only one of sinceSeconds or sinceTime may be specified.
+    pub since_time: Option<Time>,
     /// If set, the number of lines from the end of the logs to show.
     /// If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime
     pub tail_lines: Option<i64>,
@@ -65,6 +71,9 @@ impl Request {
 
         if let Some(ss) = &lp.since_seconds {
             qp.append_pair("sinceSeconds", &ss.to_string());
+        } else if let Some(st) = &lp.since_time {
+            let ser_since = st.0.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            qp.append_pair("sinceTime", &ser_since);
         }
 
         if let Some(tl) = &lp.tail_lines {


### PR DESCRIPTION
Adds a missing `sinceTime` parameter equivalent from [`PodLogOptions`](https://github.com/kubernetes/kubernetes/blob/a95a79c785ec449074afc689306d1155aa039025/pkg/apis/core/types.go#L5177C2-L5181C1) for #1339

Think this is missing because of https://github.com/kubernetes/kubernetes/issues/108498

Tested using

```sh
RUST_LOG=debug cargo run --example log_stream -- coredns-77ccd57875-k46v4 --since-time="2023-11-12T12:23:53Z"
```

on k3d.

### Time Type

Am currently using [`k8s_openapi::apimachinery::pkg::apis::meta::v1::Time`](https://docs.rs/k8s-openapi/latest/k8s_openapi/apimachinery/pkg/apis/meta/v1/struct.Time.html) for the time wrapper but that's only a newtype over `DateTime<Utc>` (via `chrono`).

This is a little awkward because the newtype implements serialize but we need it as a raw value for a query param (and passing it through `serde_json::to_string` did not feel useful), so in the end I am doing the same [thing k8s-openapi is doing in its own serialize](https://docs.rs/k8s-openapi/latest/src/k8s_openapi/v1_28/apimachinery/pkg/apis/meta/v1/time.rs.html#34-36) and calling chrono's to_rfc... fn.

On a positive point, this does mean the `LogParams` type matches the type found on `ObjectMeta` (for creation_timestamp and deletion_timestamp), but this isn't actually very useful for the end user (as can be seen in the example with basically needing both types and converting between them).

It could be simpler to expose `DateTime<Utc>` as the api time, but that means the type is locked down. Maybe we leave it and maybe push a PR to `k8s-openapi` for convenience impls on `Time` instead later to make it slightly more ergonomic?

Also happy to remove the `Time` wrapper from `LogParams` and just put `DateTime<Utc>` in there. Not sure which is best.