### PR TITLE
Switch from `jsonpath_lib` to `jsonpath-rust`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -30,7 +30,7 @@ assert-json-diff = "2.0.1"
 garde = { version = "0.16.1", default-features = false, features = ["derive"] }
 anyhow = "1.0.44"
 futures = "0.3.17"
-jsonpath_lib = "0.3.0"
+jsonpath-rust = "0.3.4"
 kube = { path = "../kube", version = "^0.87.1", default-features = false, features = ["admission"] }
 kube-derive = { path = "../kube-derive", version = "^0.87.1", default-features = false } # only needed to opt out of schema
 k8s-openapi = { version = "0.20.0", default-features = false }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -23,7 +23,7 @@ ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws", "tokio/macros"]
 oauth = ["client", "tame-oauth"]
 oidc = ["client", "form_urlencoded"]
 gzip = ["client", "tower-http/decompression-gzip"]
-client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath_lib", "bytes", "futures", "tokio", "tokio-util", "either"]
+client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath-rust", "bytes", "futures", "tokio", "tokio-util", "either"]
 jsonpatch = ["kube-core/jsonpatch"]
 admission = ["kube-core/admission"]
 config = ["__non_core", "pem", "home"]
@@ -56,7 +56,7 @@ rustls-pemfile = { version = "1.0.0", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
 kube-core = { path = "../kube-core", version = "=0.87.1" }
-jsonpath_lib = { version = "0.3.0", optional = true }
+jsonpath-rust = { version = "0.3.4", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
 hyper-rustls = { version = "0.24.0", optional = true }


### PR DESCRIPTION
## Motivation
`jsonpath_lib` is unmaintained, which is not ideal.  It is also forcing everyone to enable a `preserve_order` feature in the `serde_json` dependency.

`preserve_order` is not following the proper feature model, where features are only adding functionality.  It is actually changing how `serde_json` works, switching from `BTreeMap` to `IndexMap`.

## Solution
Switch from [`jsonpath_lib`](https://crates.io/crates/jsonpath_lib) to [`jsonpath-rust`](https://crates.io/crates/jsonpath-rust).

Change has been tested with both unit and integration tests.

---

Based on https://github.com/gregcusack/kube/pull/1