### PR TITLE
Allow setting a description on a derived CRD

### DIFF
--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
     plural = "fooz",
     root = "FooCrd",
     namespaced,
+    description = "Custom resource representing a Foo",
     status = "FooStatus",
     derive = "PartialEq",
     derive = "Default",
@@ -119,7 +120,7 @@ fn verify_crd() {
             ],
             "schema": {
               "openAPIV3Schema": {
-                "description": "Auto-generated derived type for MyFoo via `CustomResource`",
+                "description": "Custom resource representing a Foo",
                 "properties": {
                   "spec": {
                     "description": "Our spec for Foo\n\nA struct with our chosen Kind will be created for us, using the following kube attrs",

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -10,6 +10,7 @@ struct KubeAttrs {
     group: String,
     version: String,
     kind: String,
+    description: Option<String>,
     #[darling(rename = "root")]
     kind_struct: Option<String>,
     /// lowercase plural of kind (inferred if omitted)
@@ -145,6 +146,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         kind,
         kind_struct,
         version,
+        description,
         namespaced,
         derives,
         schema: schema_mode,
@@ -239,7 +241,8 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         derive_paths.push(syn::parse_quote! { #schemars::JsonSchema });
     }
 
-    let docstr = format!(" Auto-generated derived type for {ident} via `CustomResource`");
+    let docstr = description
+        .unwrap_or_else(|| format!(" Auto-generated derived type for {ident} via `CustomResource`"));
     let quoted_serde = Literal::string(&serde.to_token_stream().to_string());
     let root_obj = quote! {
         #[doc = #docstr]

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -141,6 +141,10 @@ mod custom_resource;
 /// ## `#[kube(category = "apps")]`
 /// Add a single category to `crd.spec.names.categories`.
 ///
+/// ## `#[kube(description = "description")]`
+/// Sets the description of the schema in the generated CRD. If not specified
+/// `Auto-generated derived type for {customResourceName} via CustomResource` will be used instead.
+///
 /// ## Example with all properties
 ///
 /// ```rust
@@ -155,6 +159,7 @@ mod custom_resource;
 ///     kind = "Foo",
 ///     root = "FooCrd",
 ///     namespaced,
+///     description = "Custom resource representing a Foo",
 ///     status = "FooStatus",
 ///     derive = "PartialEq",
 ///     singular = "foot",

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -1,7 +1,7 @@
 #![recursion_limit = "256"]
 
 use assert_json_diff::assert_json_eq;
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use kube_derive::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -132,7 +132,7 @@ fn test_serialized_matches_expected() {
             nullable: None,
             nullable_skipped_with_default: None,
             nullable_with_default: None,
-            timestamp: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            timestamp: TimeZone::from_utc_datetime(&Utc, &NaiveDateTime::from_timestamp_opt(0, 0).unwrap()),
             complex_enum: ComplexEnum::VariantOne { int: 23 },
             untagged_enum_person: UntaggedEnumPerson::GenderAndAge(GenderAndAge {
                 age: 42,

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
     kind = "Foo",
     category = "clux",
     namespaced,
+    description = "Custom resource representing a Foo",
     derive = "PartialEq",
     shortname = "fo",
     shortname = "f"
@@ -195,7 +196,7 @@ fn test_crd_schema_matches_expected() {
                         "additionalPrinterColumns": [],
                         "schema": {
                             "openAPIV3Schema": {
-                                "description": "Auto-generated derived type for FooSpec via `CustomResource`",
+                                "description": "Custom resource representing a Foo",
                                 "properties": {
                                     "spec": {
                                         "properties": {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

While working on a website which shows our CRDs we noticed the sentence `Auto-generated derived type for TrinoClusterSpec via CustomResource` showing up prominently. We therefore would like to have it configurable.

## Solution

Add support for a new `kube(description = "xxx")` attribute on the struct that is used to generate the CRD.