### PR TITLE
Add type meta data for list types

### DIFF
--- a/kube-core/src/metadata.rs
+++ b/kube-core/src/metadata.rs
@@ -17,6 +17,42 @@ pub struct TypeMeta {
     pub kind: String,
 }
 
+impl TypeMeta {
+    /// Construct a new `TypeMeta` for the object list from the given resource.
+    ///
+    /// ```
+    /// # use k8s_openapi::api::core::v1::Pod;
+    /// # use kube_core::TypeMeta;
+    ///
+    /// let type_meta = TypeMeta::list::<Pod>();
+    /// assert_eq!(type_meta.kind, "PodList");
+    /// assert_eq!(type_meta.api_version, "v1");
+    /// ```
+    pub fn list<K: Resource<DynamicType = ()>>() -> Self {
+        TypeMeta {
+            api_version: K::api_version(&()).into(),
+            kind: K::kind(&()).to_string() + "List",
+        }
+    }
+
+    /// Construct a new `TypeMeta` for the object from the given resource.
+    ///
+    /// ```
+    /// # use k8s_openapi::api::core::v1::Pod;
+    /// # use kube_core::TypeMeta;
+    ///
+    /// let type_meta = TypeMeta::resource::<Pod>();
+    /// assert_eq!(type_meta.kind, "Pod");
+    /// assert_eq!(type_meta.api_version, "v1");
+    /// ```
+    pub fn resource<K: Resource<DynamicType = ()>>() -> Self {
+        TypeMeta {
+            api_version: K::api_version(&()).into(),
+            kind: K::kind(&()).into(),
+        }
+    }
+}
+
 /// A generic representation of any object with `ObjectMeta`.
 ///
 /// It allows clients to get access to a particular `ObjectMeta`

--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -54,11 +54,12 @@ impl<T: Clone> ObjectList<T> {
     ///
     /// ```
     /// use kube::api::{ListMeta, ObjectList, TypeMeta};
+    /// use k8s_openapi::api::core::v1::Pod;
     ///
-    /// let types: TypeMeta = Default::default();
+    /// let types: TypeMeta = TypeMeta::list::<Pod>();
     /// let metadata: ListMeta = Default::default();
     /// let items = vec![1, 2, 3];
-    /// let objectlist = ObjectList { types, metadata, items };
+    /// # let objectlist = ObjectList { types, metadata, items };
     ///
     /// let first = objectlist.iter().next();
     /// println!("First element: {:?}", first); // prints "First element: Some(1)"
@@ -73,11 +74,12 @@ impl<T: Clone> ObjectList<T> {
     ///
     /// ```
     /// use kube::api::{ListMeta, ObjectList, TypeMeta};
+    /// use k8s_openapi::api::core::v1::Pod;
     ///
-    /// let types: TypeMeta = Default::default();
+    /// let types: TypeMeta = TypeMeta::list::<Pod>();
     /// let metadata: ListMeta = Default::default();
     /// let items = vec![1, 2, 3];
-    /// let mut objectlist = ObjectList { types, metadata, items };
+    /// # let mut objectlist = ObjectList { types, metadata, items };
     ///
     /// let mut first = objectlist.iter_mut().next();
     ///

--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -21,7 +21,10 @@ pub struct ObjectList<T>
 where
     T: Clone,
 {
-    // NB: kind and apiVersion can be set here, but no need for it atm
+    /// The type fields, always present
+    #[serde(flatten, default)]
+    pub types: TypeMeta,
+
     /// ListMeta - only really used for its `resourceVersion`
     ///
     /// See [ListMeta](k8s_openapi::apimachinery::pkg::apis::meta::v1::ListMeta)
@@ -50,11 +53,12 @@ impl<T: Clone> ObjectList<T> {
     /// # Example
     ///
     /// ```
-    /// use kube::api::{ListMeta, ObjectList};
+    /// use kube::api::{ListMeta, ObjectList, TypeMeta};
     ///
+    /// let types: TypeMeta = Default::default();
     /// let metadata: ListMeta = Default::default();
     /// let items = vec![1, 2, 3];
-    /// let objectlist = ObjectList { metadata, items };
+    /// let objectlist = ObjectList { types, metadata, items };
     ///
     /// let first = objectlist.iter().next();
     /// println!("First element: {:?}", first); // prints "First element: Some(1)"
@@ -68,11 +72,12 @@ impl<T: Clone> ObjectList<T> {
     /// # Example
     ///
     /// ```
-    /// use kube::api::{ObjectList, ListMeta};
+    /// use kube::api::{ListMeta, ObjectList, TypeMeta};
     ///
+    /// let types: TypeMeta = Default::default();
     /// let metadata: ListMeta = Default::default();
     /// let items = vec![1, 2, 3];
-    /// let mut objectlist = ObjectList { metadata, items };
+    /// let mut objectlist = ObjectList { types, metadata, items };
     ///
     /// let mut first = objectlist.iter_mut().next();
     ///
@@ -300,7 +305,9 @@ pub struct NotUsed {}
 
 #[cfg(test)]
 mod test {
-    use super::{ApiResource, HasSpec, HasStatus, NotUsed, Object, Resource};
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, ListMeta};
+
+    use super::{ApiResource, HasSpec, HasStatus, NotUsed, Object, Resource, ObjectList, TypeMeta};
     use crate::resource::ResourceExt;
 
     #[test]
@@ -337,14 +344,53 @@ mod test {
         assert_eq!(mypod.namespace().unwrap(), "dev");
         assert_eq!(mypod.name_unchecked(), "blog");
         assert!(mypod.status().is_none());
-        assert_eq!(mypod.spec().containers[0], ContainerSimple {
-            image: "blog".into()
-        });
+        assert_eq!(
+            mypod.spec().containers[0],
+            ContainerSimple { image: "blog".into() }
+        );
 
         assert_eq!(PodSimple::api_version(&ar), "v1");
         assert_eq!(PodSimple::version(&ar), "v1");
         assert_eq!(PodSimple::plural(&ar), "pods");
         assert_eq!(PodSimple::kind(&ar), "Pod");
         assert_eq!(PodSimple::group(&ar), "");
+    }
+
+    #[test]
+    fn k8s_object_list() {
+        use k8s_openapi::api::core::v1::Pod;
+        // by grabbing the ApiResource info from the Resource trait
+        let ar = ApiResource::erase::<Pod>(&());
+        assert_eq!(ar.group, "");
+        assert_eq!(ar.kind, "Pod");
+        let podlist: ObjectList<Pod> = ObjectList {
+            types: TypeMeta{
+                api_version: ar.api_version,
+                kind: ar.kind + "List",
+            },
+            metadata: ListMeta{..Default::default()},
+            items: vec![Pod {
+                metadata: ObjectMeta {
+                    name: Some("test".into()),
+                    namespace: Some("dev".into()),
+                    ..ObjectMeta::default()
+                },
+                spec: None,
+                status: None,
+            }],
+        };
+
+        assert_eq!(&podlist.types.kind, "PodList");
+        assert_eq!(&podlist.types.api_version, "v1");
+
+        let mypod = &podlist.items[0];
+        let meta = mypod.meta();
+        assert_eq!(&mypod.metadata, meta);
+        assert_eq!(meta.namespace.as_ref().unwrap(), "dev");
+        assert_eq!(meta.name.as_ref().unwrap(), "test");
+        assert_eq!(mypod.namespace().unwrap(), "dev");
+        assert_eq!(mypod.name_unchecked(), "test");
+        assert!(mypod.status.is_none());
+        assert!(mypod.spec.is_none());
     }
 }

--- a/kube/src/mock_tests.rs
+++ b/kube/src/mock_tests.rs
@@ -96,6 +96,8 @@ impl ApiServerVerifier {
             assert!(!req_uri.contains("continue=")); // first list has no continue
 
             let respdata = json!({
+                "kind": "HackList",
+                "apiVersion": "kube.rs/v1",
                 "metadata": {
                   "continue": "first",
                 },
@@ -111,6 +113,8 @@ impl ApiServerVerifier {
             let req_uri = request.uri().to_string();
             assert!(req_uri.contains("&continue=first"));
             let respdata = json!({
+                "kind": "HackList",
+                "apiVersion": "kube.rs/v1",
                 "metadata": {
                     "continue": "",
                     "resourceVersion": "2"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

While implementing generic resource listing from discovery results, it seems the type meta is omitted, though it is guarantied to be supplied on the list resource type. This makes it hard to know the resource kind if the ApiCapabilities goes out of scope.

## Solution

Store the TypeMeta with the resource list result.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
