### PR TITLE
Upgrade `k8s-openapi` for Kubernetes `v1_29` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run these tests against older clusters as well
-        k8s: [v1.23, latest]
+        k8s: [v1.24, latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -216,7 +216,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.23
+          version: v1.24
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
           cluster-name: "test-cluster-1"
           args: >-
             --agents 1
-            --image docker.io/rancher/k3s:v1.23.4-k3s1
+            --image docker.io/rancher/k3s:v1.24.4-k3s1
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Select a version of `kube` along with the generated [k8s-openapi](https://github
 ```toml
 [dependencies]
 kube = { version = "0.87.2", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.20.0", features = ["latest"] }
+k8s-openapi = { version = "0.21.0", features = ["latest"] }
 ```
 
 [Features are available](https://github.com/kube-rs/kube/blob/main/kube/Cargo.toml#L18).
@@ -153,7 +153,7 @@ By default [rustls](https://github.com/ctz/rustls) is used for TLS, but `openssl
 ```toml
 [dependencies]
 kube = { version = "0.87.2", default-features = false, features = ["client", "openssl-tls"] }
-k8s-openapi = { version = "0.20.0", features = ["latest"] }
+k8s-openapi = { version = "0.21.0", features = ["latest"] }
 ```
 
 This will pull in `openssl` and `hyper-openssl`. If `default-features` is left enabled, you will pull in two TLS stacks, and the default will remain as `rustls`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
 [![Rust 1.70](https://img.shields.io/badge/MSRV-1.70-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.70.0)
-[![Tested against Kubernetes v1_23 and above](https://img.shields.io/badge/MK8SV-v1_23-326ce5.svg)](https://kube.rs/kubernetes-version)
+[![Tested against Kubernetes v1_24 and above](https://img.shields.io/badge/MK8SV-v1_24-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -29,6 +29,6 @@ tracing = "0.1.36"
 tracing-subscriber = "0.3.3"
 futures = "0.3.17"
 kube = { path = "../kube", version = "^0.87.2", default-features = false, features = ["client", "runtime", "ws", "admission", "gzip"] }
-k8s-openapi = { version = "0.20.0", default-features = false }
+k8s-openapi = { version = "0.21.0", default-features = false }
 serde_json = "1.0.68"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -19,7 +19,7 @@ path = "boot.rs"
 
 [features]
 latest = ["k8s-openapi/latest"]
-mk8sv = ["k8s-openapi/v1_23"]
+mk8sv = ["k8s-openapi/v1_24"]
 rustls = ["kube/rustls-tls"]
 openssl = ["kube/openssl-tls"]
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -33,7 +33,7 @@ futures = "0.3.17"
 jsonpath-rust = "0.3.4"
 kube = { path = "../kube", version = "^0.87.2", default-features = false, features = ["admission"] }
 kube-derive = { path = "../kube-derive", version = "^0.87.2", default-features = false } # only needed to opt out of schema
-k8s-openapi = { version = "0.20.0", default-features = false }
+k8s-openapi = { version = "0.21.0", default-features = false }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.9.19"

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -74,7 +74,7 @@ hyper-openssl = { version = "0.9.2", optional = true }
 form_urlencoded = { version = "1.2.0", optional = true }
 
 [dependencies.k8s-openapi]
-version = "0.20.0"
+version = "0.21.0"
 default-features = false
 features = []
 
@@ -87,6 +87,6 @@ tokio-test = "0.4.0"
 tower-test = "0.4.0"
 
 [dev-dependencies.k8s-openapi]
-version = "0.20.0"
+version = "0.21.0"
 default-features = false
 features = ["latest"]

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -36,12 +36,12 @@ chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 schemars = { version = "0.8.6", optional = true }
 
 [dependencies.k8s-openapi]
-version = "0.20.0"
+version = "0.21.0"
 default-features = false
 features = []
 
 [dev-dependencies.k8s-openapi]
-version = "0.20.0"
+version = "0.21.0"
 default-features = false
 features = ["latest"]
 

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro = true
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.9.19"
 kube = { path = "../kube", version = "<1.0.0, >=0.61.0", features = ["derive", "client"] }
-k8s-openapi = { version = "0.20.0", default-features = false, features = ["latest"] }
+k8s-openapi = { version = "0.21.0", default-features = false, features = ["latest"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 chrono = { version = "0.4.19", default-features = false }
 trybuild = "1.0.48"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -46,7 +46,7 @@ async-trait = "0.1.64"
 hashbrown = "0.14.0"
 
 [dependencies.k8s-openapi]
-version = "0.20.0"
+version = "0.21.0"
 default-features = false
 
 [dev-dependencies]
@@ -58,6 +58,6 @@ schemars = "0.8.6"
 tracing-subscriber = "0.3.17"
 
 [dev-dependencies.k8s-openapi]
-version = "0.20.0"
+version = "0.21.0"
 default-features = false
 features = ["latest"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -52,7 +52,7 @@ kube-runtime = { path = "../kube-runtime", version = "=0.87.2", optional = true}
 # Not used directly, but required by resolver 2.0 to ensure that the k8s-openapi dependency
 # is considered part of the "deps" graph rather than just the "dev-deps" graph
 [dependencies.k8s-openapi]
-version = "0.20.0"
+version = "0.21.0"
 default-features = false
 
 [dev-dependencies]
@@ -67,6 +67,6 @@ tower-test = "0.4.0"
 anyhow = "1.0.71"
 
 [dev-dependencies.k8s-openapi]
-version = "0.20.0"
+version = "0.21.0"
 default-features = false
 features = ["latest"]


### PR DESCRIPTION
Runs `just bump-k8s` for our MK8SV and then cargo upgrades the crate.