### PR TITLE
Minor fixes to `ObjectList`

### DIFF
--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -357,10 +357,9 @@ mod test {
         assert_eq!(mypod.namespace().unwrap(), "dev");
         assert_eq!(mypod.name_unchecked(), "blog");
         assert!(mypod.status().is_none());
-        assert_eq!(
-            mypod.spec().containers[0],
-            ContainerSimple { image: "blog".into() }
-        );
+        assert_eq!(mypod.spec().containers[0], ContainerSimple {
+            image: "blog".into()
+        });
 
         assert_eq!(PodSimple::api_version(&ar), "v1");
         assert_eq!(PodSimple::version(&ar), "v1");

--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -16,7 +16,7 @@ use std::borrow::Cow;
 /// and is generally produced from list/watch/delete collection queries on an [`Resource`](super::Resource).
 ///
 /// This is almost equivalent to [`k8s_openapi::List<T>`](k8s_openapi::List), but iterable.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ObjectList<T>
 where
     T: Clone,


### PR DESCRIPTION
## Motivation

Starting from the `0.88.0` release, `ObjectList` has a new attribute named `types`. This attribute is serialized and deserialized using the `flatten` directive of serde.

However, it turns out that `serde` has a bug that prevents the proper deserialization of attributes that are using the `flatten` and `default` directives. See [here](https://github.com/serde-rs/serde/issues/1626) and [here](https://github.com/serde-rs/serde/issues/1879).

This serde bug affects the freshly introduced `ObjectList.types` attribute. It's not possible to deserialize an `ObjectList` that is missing the `apiVersion` and/or the `kind` values.

## Solution

This commit introduces a custom deserializer for the `types` attribute of `ObjectList` that solves this problem.

On top of handling the deserialization case, the custom deserializer provides better default values compared to the ones of the stock `TypeMeta`.
The `TypeMeta` struct has empty strings as default values. However, in the context of `ObjectList`, proper default values should be `v1` and `List` instead.

There's also a second commit to this PR that makes `ObjectList` derive the `Clone` trait. This is not related with this specific issue, but is something that some code I've written would take advantage of. If you're not fine with this specific commit I can drop it from this PR.
