### PR TITLE
Serialize TerminalSize fields as PascalCase

### DIFF
--- a/kube-client/src/api/remote_command.rs
+++ b/kube-client/src/api/remote_command.rs
@@ -28,6 +28,7 @@ type TerminalSizeSender = mpsc::Sender<TerminalSize>;
 /// TerminalSize define the size of a terminal
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
+#[serde(rename_all = "PascalCase")]
 pub struct TerminalSize {
     /// width of the terminal
     pub width: u16,


### PR DESCRIPTION
Doesn't seem to affect anything for the real API-server, but it's what kubectl/client-go sends, so we might as well align with them.
