### PR TITLE
More conservative clippy fixes

### DIFF
--- a/kube-client/src/api/subresource.rs
+++ b/kube-client/src/api/subresource.rs
@@ -545,14 +545,9 @@ where
     K: Clone + DeserializeOwned + Execute,
 {
     /// Execute a command in a pod
-    pub async fn exec<I: Debug, T>(
-        &self,
-        name: &str,
-        command: I,
-        ap: &AttachParams,
-    ) -> Result<AttachedProcess>
+    pub async fn exec<I, T>(&self, name: &str, command: I, ap: &AttachParams) -> Result<AttachedProcess>
     where
-        I: IntoIterator<Item = T>,
+        I: IntoIterator<Item = T> + Debug,
         T: Into<String>,
     {
         let mut req = self

--- a/kube-runtime/src/events.rs
+++ b/kube-runtime/src/events.rs
@@ -20,8 +20,7 @@ pub struct Event {
 
     /// The short reason explaining why the `action` was taken.
     ///
-    /// This must be at most 128 characters, and is often PascalCased. Shows up in `kubectl describe` as `Reason`.
-    /// Usually denoted
+    /// This must be at most 128 characters, generally in `PascalCase`. Shows up in `kubectl describe` as `Reason`.
     pub reason: String,
 
     /// A optional description of the status of the `action`.

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -206,7 +206,7 @@ pub enum InitialListStrategy {
     /// List first, then watch from given resouce version
     ///
     /// This is the old and default way of watching. The watcher will do a paginated list call first before watching.
-    /// When using this mode, you can configure the page_size on the watcher.
+    /// When using this mode, you can configure the `page_size` on the watcher.
     #[default]
     ListWatch,
     /// Kubernetes 1.27 Streaming Lists
@@ -245,10 +245,10 @@ pub struct Config {
 
     /// Control how the watcher fetches the initial list of objects.
     ///
-    /// ListWatch: The watcher will fetch the initial list of objects using a list call.
-    /// StreamingList: The watcher will fetch the initial list of objects using a watch call.
+    /// - `ListWatch`: The watcher will fetch the initial list of objects using a list call.
+    /// - `StreamingList`: The watcher will fetch the initial list of objects using a watch call.
     ///
-    /// StreamingList is more efficient than ListWatch, but it requires the server to support
+    /// `StreamingList` is more efficient than `ListWatch`, but it requires the server to support
     /// streaming list bookmarks (opt-in feature gate in Kubernetes 1.27).
     ///
     /// See [upstream documentation on streaming lists](https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists),


### PR DESCRIPTION
this fixes CI, but doesn't clean up the unused imports that arise from being used with features, might do that later.

(running `clippy --fix` without `--all-features` is a bad idea #1416)