### PR TITLE
Stash WIP of future potential use of `#[diagnostic]`

### DIFF
--- a/examples/dynamic_watcher.rs
+++ b/examples/dynamic_watcher.rs
@@ -8,6 +8,9 @@ use tracing::*;
 
 use std::{env, fmt::Debug};
 
+#[derive(Clone, Debug)]
+struct MyStruct {}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
@@ -27,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
     let (ar, _caps) = kube::discovery::pinned_kind(&client, &gvk).await?;
 
     // Use the full resource info to create an Api with the ApiResource as its DynamicType
-    let api = Api::<DynamicObject>::all_with(client, &ar);
+    let api = Api::<MyStruct>::all_with(client, &ar);
     let wc = watcher::Config::default();
 
     // Start a metadata or a full resource watch

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -7,6 +7,7 @@
 //! Everything in this crate is re-exported from [`kube`](https://crates.io/crates/kube)
 //! (even with zero features) under [`kube::core`]((https://docs.rs/kube/*/kube/core/index.html)).
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![feature(diagnostic_namespace)]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -24,6 +24,12 @@ impl ResourceScope for DynamicResourceScope {}
 /// - `.metadata.resource_version`
 ///
 /// This avoids a bunch of the unnecessary unwrap mechanics for apps.
+#[diagnostic::on_unimplemented(
+    message = "The `kube::Resource` trait is not implemented for `{Self}`",
+    label = "Is this type a `k8s-openapi` top level Kubernetes type, or a dynamic type created via `CustomResource`",
+    note = "If this is a CustomResource, please use the generated top level struct (not the spec struct) for `Api`",
+    note = "If this is a fully typed openapi struct, ensure you use the top-level resource type (e.g. `Pod` over `PodSpec`) for `Api`"
+)]
 pub trait Resource {
     /// Type information for types that do not know their resource information at compile time.
     ///


### PR DESCRIPTION
Quick test of https://github.com/rust-lang/rust/pull/119888 [playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=05133acce8e1d163d481e97631f17536) using

```sh
cargo +nightly run --example dynamic_watcher
```

Stashing this here for my own memory.
Currently does not seem to be super helpful as it doesn't give me the warning via a trait bound:

```
error[E0599]: the function or associated item `all_with` exists for struct `Api<MyStruct>`, but its trait bounds were not satisfied
   --> examples/dynamic_watcher.rs:33:32
    |
12  | struct MyStruct {}
    | --------------- doesn't satisfy `MyStruct: Resource`
...
33  |     let api = Api::<MyStruct>::all_with(client, &ar);
    |                                ^^^^^^^^ function or associated item cannot be called on `Api<MyStruct>` due to unsatisfied trait bounds
    |
note: if you're trying to build a new `kube::Api<MyStruct>` consider using one of the following associated functions:
      kube::Api::<K>::all_with
      kube::Api::<K>::namespaced_with
      kube::Api::<K>::default_namespaced_with
      kube::Api::<K>::all
      and 2 others
   --> /home/clux/kube/kube/kube-client/src/api/mod.rs:78:5
    |
78  |       pub fn all_with(client: Client, dyntype: &K::DynamicType) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
91  | /     pub fn namespaced_with(client: Client, ns: &str, dyntype: &K::DynamicType) -> Self
92  | |     where
93  | |         K: Resource<Scope = DynamicResourceScope>,
    | |__________________________________________________^
...
112 | /     pub fn default_namespaced_with(client: Client, dyntype: &K::DynamicType) -> Self
113 | |     where
114 | |         K: Resource<Scope = DynamicResourceScope>,
    | |__________________________________________________^
...
162 |       pub fn all(client: Client) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the following trait bounds were not satisfied:
            `MyStruct: Resource`
note: the trait `Resource` must be implemented
   --> /home/clux/kube/kube/kube-core/src/resource.rs:33:1
    |
33  | pub trait Resource {
    | ^^^
```


