### PR TITLE
`Kubeconfig` allow `certificate_authority_data` not present in `ExecAuthCluster`

### DIFF
--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -556,7 +556,7 @@ pub struct ExecAuthCluster {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insecure_skip_tls_verify: Option<bool>,
     /// PEM-encoded certificate authority certificates. Overrides `certificate_authority`
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde(with = "base64serde")]
     pub certificate_authority_data: Option<Vec<u8>>,
     /// URL to the proxy to be used for all requests.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

#1431 

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

I found if we use #[serde(with = "module")]. It will check if field is present. Let's check on https://github.com/serde-rs/serde/issues/1728. We can add #[serde(default)] to fix this.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
