### PR TITLE
Fix minor new lints and better info on pod reflector memory usage

### DIFF
--- a/kube-client/src/client/config_ext.rs
+++ b/kube-client/src/client/config_ext.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use http::{header::HeaderName, HeaderValue};
-use hyper::rt::{Read, Write};
+#[cfg(feature = "openssl-tls")] use hyper::rt::{Read, Write};
 use hyper_util::client::legacy::connect::HttpConnector;
 use secrecy::ExposeSecret;
 use tower::{filter::AsyncFilterLayer, util::Either};

--- a/kube-client/src/client/middleware/mod.rs
+++ b/kube-client/src/client/middleware/mod.rs
@@ -88,7 +88,7 @@ mod tests {
     }
 
     fn test_token(token: String) -> RefreshableToken {
-        let expiry = Utc::now() + Duration::seconds(60 * 60);
+        let expiry = Utc::now() + Duration::try_seconds(60 * 60).unwrap();
         let secret_token = SecretString::from(token);
         let info = AuthInfo {
             token: Some(secret_token.clone()),

--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -11,7 +11,7 @@ use either::{Either, Left, Right};
 use futures::{self, AsyncBufRead, StreamExt, TryStream, TryStreamExt};
 use http::{self, Request, Response};
 use http_body_util::BodyExt;
-use hyper_util::rt::TokioIo;
+#[cfg(feature = "ws")] use hyper_util::rt::TokioIo;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as k8s_meta_v1;
 pub use kube_core::response::Status;
 use serde::de::DeserializeOwned;

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -231,9 +231,8 @@ impl Config {
     /// `/var/run/secrets/kubernetes.io/serviceaccount/`.
     ///
     /// This behavior does not match that of the official Kubernetes clients,
-    /// but this approach is compatible with the `rustls-tls` feature
-    /// without setting `tls_server_name`.
-    /// See <https://github.com/kube-rs/kube/issues/1003>.
+    /// but can be used as a consistent entrypoint in many clusters.
+    /// See <https://github.com/kube-rs/kube/issues/1003> for more info.
     pub fn incluster_dns() -> Result<Self, InClusterError> {
         Self::incluster_with_uri(incluster_config::kube_dns())
     }

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -58,9 +58,10 @@ pub use store::{store, Store};
 /// ## Memory Usage
 ///
 /// A reflector often constitutes one of the biggest components of a controller's memory use.
-/// Given ~two thousand pods in a cluster, a reflector around that quickly consumes 1GB of memory.
+/// Given a ~2000 pods cluster, a reflector saving everything (including injected sidecars, managed fields)
+/// can quickly consume a couple of hundred megabytes or more, depending on how much of this you are storing.
 ///
-/// While, sometimes acceptible, there are techniques you can leverage to reduce the memory usage
+/// While generally acceptable, there are techniques you can leverage to reduce the memory usage
 /// depending on your use case.
 ///
 /// 1. Reflect a [`PartialObjectMeta<K>`](kube_client::core::PartialObjectMeta) stream rather than a stream of `K`
@@ -88,6 +89,8 @@ pub use store::{store, Store};
 /// The `stream` can then be passed to `reflector` causing smaller objects to be written to its store.
 /// Note that you **cannot drop everything**; you minimally need the spec properties your app relies on.
 /// Additionally, only `labels`, `annotations` and `managed_fields` are safe to drop from `ObjectMeta`.
+///
+/// For more information check out: https://kube.rs/controllers/optimization/ for graphs and techniques.
 pub fn reflector<K, W>(mut writer: store::Writer<K>, stream: W) -> impl Stream<Item = W::Item>
 where
     K: Lookup + Clone,

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -90,7 +90,7 @@ pub use store::{store, Store};
 /// Note that you **cannot drop everything**; you minimally need the spec properties your app relies on.
 /// Additionally, only `labels`, `annotations` and `managed_fields` are safe to drop from `ObjectMeta`.
 ///
-/// For more information check out: https://kube.rs/controllers/optimization/ for graphs and techniques.
+/// For more information check out: <https://kube.rs/controllers/optimization/> for graphs and techniques.
 pub fn reflector<K, W>(mut writer: store::Writer<K>, stream: W) -> impl Stream<Item = W::Item>
 where
     K: Lookup + Clone,


### PR DESCRIPTION
reflector figure caused a question in discord, but the figure is old and probably not accurate anymore. have recent graphs in the 100-400MB range on https://kube.rs/controllers/optimization/#reflector-optimization with the same data as the doc string was written for so using that very vaguely and linking to the above doc.

also fixing minor new lint errors and doc issues before a release.