### PR TITLE
Expose `Body::empty` for easier tests

### DIFF
--- a/kube-client/src/client/body.rs
+++ b/kube-client/src/client/body.rs
@@ -32,7 +32,8 @@ impl Body {
         Body { kind }
     }
 
-    pub(crate) fn empty() -> Self {
+    /// Create an empty body
+    pub fn empty() -> Self {
         Self::new(Kind::Once(None))
     }
 


### PR DESCRIPTION
minor ergonomic improvement over `Body::from(Bytes::new())`. mock tests generally have to import the `Body` anyway