### PR TITLE
Add proxy `Body::collect_bytes` for easier unit tests

### DIFF
--- a/kube-client/src/client/body.rs
+++ b/kube-client/src/client/body.rs
@@ -44,6 +44,11 @@ impl Body {
     {
         Body::new(Kind::Wrap(body.map_err(Into::into).boxed_unsync()))
     }
+
+    /// Collect all the pieces of the body
+    pub fn collect(self) -> http_body_util::combinators::Collect<Self> {
+        <Self as BodyExt>::collect(self)
+    }
 }
 
 impl From<Bytes> for Body {

--- a/kube-client/src/client/body.rs
+++ b/kube-client/src/client/body.rs
@@ -44,7 +44,7 @@ impl Body {
         Body::new(Kind::Wrap(body.map_err(Into::into).boxed_unsync()))
     }
 
-    /// Collect all the pieces of the body
+    /// Collect all the data frames and trailers of the request body
     pub async fn collect_bytes(self) -> Result<Bytes, crate::Error> {
         Ok(<Self as BodyExt>::collect(self).await?.to_bytes())
     }

--- a/kube-client/src/client/body.rs
+++ b/kube-client/src/client/body.rs
@@ -46,7 +46,7 @@ impl Body {
 
     /// Collect all the data frames and trailers of the request body
     pub async fn collect_bytes(self) -> Result<Bytes, crate::Error> {
-        Ok(<Self as BodyExt>::collect(self).await?.to_bytes())
+        Ok(self.collect().await?.to_bytes())
     }
 
     pub(crate) fn into_data_stream(

--- a/kube-client/src/client/body.rs
+++ b/kube-client/src/client/body.rs
@@ -46,8 +46,8 @@ impl Body {
     }
 
     /// Collect all the pieces of the body
-    pub fn collect(self) -> http_body_util::combinators::Collect<Self> {
-        <Self as BodyExt>::collect(self)
+    pub async fn collect_bytes(self) -> Result<Bytes, crate::Error> {
+        Ok(<Self as BodyExt>::collect(self).await?.to_bytes())
     }
 }
 


### PR DESCRIPTION
Avoids people having to pull in `http_body_util` for the `BodyExt`

Tested with https://github.com/kube-rs/controller-rs/pull/69 locally.