### PR TITLE
replace once_cell Lazy with ordinary static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ hyper-timeout = "0.5.1"
 json-patch = "1.0.0"
 jsonpath-rust = "0.5.0"
 k8s-openapi = { version = "0.21.0", default-features = false }
-once_cell = "1.8.0"
 openssl = "0.10.36"
 parking_lot = "0.12.0"
 pem = "3.0.1"

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -32,7 +32,6 @@ thiserror.workspace = true
 form_urlencoded.workspace = true
 http.workspace = true
 json-patch = { workspace = true, optional = true }
-once_cell.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 schemars = { workspace = true, optional = true }
 k8s-openapi.workspace = true

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -216,10 +216,7 @@ pub trait ResourceExt: Resource {
     fn managed_fields_mut(&mut self) -> &mut Vec<ManagedFieldsEntry>;
 }
 
-// TODO: replace with ordinary static when BTreeMap::new() is no longer
-// const-unstable.
-use once_cell::sync::Lazy;
-static EMPTY_MAP: Lazy<BTreeMap<String, String>> = Lazy::new(BTreeMap::new);
+static EMPTY_MAP: BTreeMap<String, String> = BTreeMap::new();
 
 impl<K: Resource> ResourceExt for K {
     fn name_unchecked(&self) -> String {
@@ -251,7 +248,7 @@ impl<K: Resource> ResourceExt for K {
     }
 
     fn labels(&self) -> &BTreeMap<String, String> {
-        self.meta().labels.as_ref().unwrap_or(&*EMPTY_MAP)
+        self.meta().labels.as_ref().unwrap_or(&EMPTY_MAP)
     }
 
     fn labels_mut(&mut self) -> &mut BTreeMap<String, String> {
@@ -259,7 +256,7 @@ impl<K: Resource> ResourceExt for K {
     }
 
     fn annotations(&self) -> &BTreeMap<String, String> {
-        self.meta().annotations.as_ref().unwrap_or(&*EMPTY_MAP)
+        self.meta().annotations.as_ref().unwrap_or(&EMPTY_MAP)
     }
 
     fn annotations_mut(&mut self) -> &mut BTreeMap<String, String> {


### PR DESCRIPTION
`BTreeMap::new` in const context is stabilized at Rust 1.65.

https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.new