### PR TITLE
replace chrono feature clock with now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ async-trait = "0.1.64"
 backoff = "0.4.0"
 base64 = "0.22.0"
 bytes = "1.1.0"
-chrono = { version = "0.4.23", default-features = false }
+chrono = { version = "0.4.32", default-features = false }
 darling = "0.20.3"
 derivative = "2.1.1"
 either = "1.6.1"

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -32,7 +32,7 @@ thiserror.workspace = true
 form_urlencoded.workspace = true
 http.workspace = true
 json-patch = { workspace = true, optional = true }
-chrono = { workspace = true, features = ["clock"] }
+chrono = { workspace = true, features = ["now"] }
 schemars = { workspace = true, optional = true }
 k8s-openapi.workspace = true
 


### PR DESCRIPTION
Seems to be able to use a subset of `clock` feature, `now` which is introduced at 0.4.32.

https://github.com/chronotope/chrono/releases/tag/v0.4.32