### PR TITLE
Fix examples for custom clients not authenticating

### DIFF
--- a/examples/custom_client_tls.rs
+++ b/examples/custom_client_tls.rs
@@ -20,12 +20,14 @@ async fn main() -> anyhow::Result<()> {
         let https = config.openssl_https_connector()?;
         let service = ServiceBuilder::new()
             .layer(config.base_uri_layer())
+            .option_layer(config.auth_layer()?)
             .service(hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(https));
         Client::new(service, config.default_namespace)
     } else {
         let https = config.rustls_https_connector()?;
         let service = ServiceBuilder::new()
             .layer(config.base_uri_layer())
+            .option_layer(config.auth_layer()?)
             .service(hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(https));
         Client::new(service, config.default_namespace)
     };

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -26,6 +26,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(tower::limit::ConcurrencyLimitLayer::new(4))
         // Add `DecompressionLayer` to make request headers interesting.
         .layer(DecompressionLayer::new())
+        .option_layer(config.auth_layer()?)
         .layer(
             // Attribute names follow [Semantic Conventions].
             // [Semantic Conventions]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-client


### PR DESCRIPTION
Found while testing hyper 1 and found this didn't work even before. Fixed by injecting the auth_layer.