### PR TITLE
Set a compatible minimum `chrono` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ async-trait = "0.1.64"
 backoff = "0.4.0"
 base64 = "0.22.0"
 bytes = "1.1.0"
-chrono = { version = "0.4.32", default-features = false }
+chrono = { version = "0.4.34", default-features = false }
 darling = "0.20.3"
 derivative = "2.1.1"
 either = "1.6.1"


### PR DESCRIPTION
0.4.32 won't work anymore as noted in #1451