### PR TITLE
tarpaulin bump and simplify config setup

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,11 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
       - uses: AbsaOSS/k3d-action@v2
         name: "Create Single Cluster"
         with:
@@ -31,8 +32,5 @@ jobs:
             -p 10250:10250
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.27.3'
-          out-type: Xml
+        run: rustup run stable cargo tarpaulin -o xml
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.18.5'
+          version: '0.27.3'
           out-type: Xml
       - uses: codecov/codecov-action@v3

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -7,21 +7,19 @@
 
 [one_pass_coverage]
 workspace = true
-features = "kube/derive kube/runtime kube/ws"
+#features = "kube/derive kube/runtime kube/ws kube/jsonpatch kube/admission kube/gzip"
+all-features = true
 color = "Always"
-ignored = true
+ignored = true # integration tests
 timeout = "600s"
-exclude = ["e2e"]
-# NB: proc macro code is not picked up by tarpaulin - so could maybe skip kube-derive completely
-excluded_files = ["kube-derive/tests"]
+exclude = ["e2e", "kube-derive"] # proc-macro code not picked up by tarpaulin
+include-tests = true # include test coverage info to see what runs
 # NB: skipping Doctests because they are slow to build and generally marked no_run
 run-types = ["Tests"]
-ignore_tests = true
 
-# We could potentially pass in examples here
-# but: they don't help in covering kube-derive, and they force a full recompile
+# We could potentially pass in examples here - but better to write integration tests in kube
 #[example_pass]
-#features = "default"
 #packages = ["kube-examples"]
 #excluded_files = ["examples/"]
-#example = ["crd_derive_schema"]
+#workspace = true
+#run-types = ["Tests"]


### PR DESCRIPTION
experiment for #1144 where we can compare against https://app.codecov.io/gh/kube-rs/kube/tree/main/
[config ref](https://github.com/xd009642/tarpaulin/blob/develop/src/config/mod.rs)