### PR TITLE
replace futures crate api with standard library

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,8 @@
 disallowed-names = []
+disallowed-macros = [
+  "futures::ready",             # use instead `std::task::ready`
+  "futures::pin_mut",           # use instead `std::pin::pin`
+]
+disallowed-methods = [
+  "futures::future::ready",     # use instead `std::future::ready`
+]

--- a/examples/event_watcher.rs
+++ b/examples/event_watcher.rs
@@ -38,7 +38,8 @@ async fn main() -> anyhow::Result<()> {
             conf = conf.fields(&format!("regarding.kind={kind},regarding.name={name}"));
         }
     }
-    let mut event_stream = pin!(watcher(events, conf).default_backoff().applied_objects());
+    let event_stream = watcher(events, conf).default_backoff().applied_objects();
+    let mut event_stream = pin!(event_stream);
 
     println!("{0:<6} {1:<15} {2:<55} {3}", "AGE", "REASON", "OBJECT", "MESSAGE");
     while let Some(ev) = event_stream.try_next().await? {

--- a/examples/event_watcher.rs
+++ b/examples/event_watcher.rs
@@ -1,4 +1,6 @@
-use futures::{pin_mut, TryStreamExt};
+use std::pin::pin;
+
+use futures::TryStreamExt;
 use k8s_openapi::{
     api::{core::v1::ObjectReference, events::v1::Event},
     apimachinery::pkg::apis::meta::v1::Time,
@@ -36,8 +38,7 @@ async fn main() -> anyhow::Result<()> {
             conf = conf.fields(&format!("regarding.kind={kind},regarding.name={name}"));
         }
     }
-    let event_stream = watcher(events, conf).default_backoff().applied_objects();
-    pin_mut!(event_stream);
+    let mut event_stream = pin!(watcher(events, conf).default_backoff().applied_objects());
 
     println!("{0:<6} {1:<15} {2:<55} {3}", "AGE", "REASON", "OBJECT", "MESSAGE");
     while let Some(ev) = event_stream.try_next().await? {

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -20,11 +20,12 @@ async fn main() -> anyhow::Result<()> {
         .timeout(10); // short watch timeout in this example
 
     let (reader, writer) = reflector::store();
-    let mut stream = pin!(watcher(nodes, wc)
+    let stream = watcher(nodes, wc)
         .default_backoff()
         .reflect(writer)
         .applied_objects()
-        .predicate_filter(predicates::labels.combine(predicates::annotations))); // NB: requires an unstable feature
+        .predicate_filter(predicates::labels.combine(predicates::annotations)); // NB: requires an unstable feature
+    let mut stream = pin!(stream);
 
     // Periodically read our state in the background
     tokio::spawn(async move {

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -22,7 +22,8 @@ async fn main() -> anyhow::Result<()> {
     } else {
         watcher::Config::default()
     };
-    let mut obs = pin!(watcher(nodes, wc).default_backoff().applied_objects());
+    let obs = watcher(nodes, wc).default_backoff().applied_objects();
+    let mut obs = pin!(obs);
 
     while let Some(n) = obs.try_next().await? {
         check_for_node_failures(&client, n).await?;

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -1,4 +1,6 @@
-use futures::{pin_mut, TryStreamExt};
+use std::pin::pin;
+
+use futures::TryStreamExt;
 use k8s_openapi::api::core::v1::{Event, Node};
 use kube::{
     api::{Api, ListParams, ResourceExt},
@@ -20,9 +22,8 @@ async fn main() -> anyhow::Result<()> {
     } else {
         watcher::Config::default()
     };
-    let obs = watcher(nodes, wc).default_backoff().applied_objects();
+    let mut obs = pin!(watcher(nodes, wc).default_backoff().applied_objects());
 
-    pin_mut!(obs);
     while let Some(n) = obs.try_next().await? {
         check_for_node_failures(&client, n).await?;
     }

--- a/examples/pod_reflector.rs
+++ b/examples/pod_reflector.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
-    let mut stream = pin!(watcher(api, watcher::Config::default().any_semantic())
+    let stream = watcher(api, watcher::Config::default().any_semantic())
         .default_backoff()
         .modify(|pod| {
             // memory optimization for our store - we don't care about managed fields/annotations/status
@@ -41,7 +41,8 @@ async fn main() -> anyhow::Result<()> {
         })
         .reflect(writer)
         .applied_objects()
-        .predicate_filter(predicates::resource_version)); // NB: requires an unstable feature
+        .predicate_filter(predicates::resource_version); // NB: requires an unstable feature
+    let mut stream = pin!(stream);
 
     while let Some(pod) = stream.try_next().await? {
         info!("saw {}", pod.name_any());

--- a/kube-client/src/client/middleware/mod.rs
+++ b/kube-client/src/client/middleware/mod.rs
@@ -27,10 +27,9 @@ impl<S> Layer<S> for AuthLayer {
 mod tests {
     use super::*;
 
-    use std::{matches, sync::Arc};
+    use std::{matches, pin::pin, sync::Arc};
 
     use chrono::{Duration, Utc};
-    use futures::pin_mut;
     use http::{header::AUTHORIZATION, HeaderValue, Request, Response};
     use secrecy::SecretString;
     use tokio::sync::Mutex;
@@ -52,7 +51,7 @@ mod tests {
 
         let spawned = tokio::spawn(async move {
             // Receive the requests and respond
-            pin_mut!(handle);
+            let mut handle = pin!(handle);
             let (request, send) = handle.next_request().await.expect("service not called");
             assert_eq!(
                 request.headers().get(AUTHORIZATION).unwrap(),

--- a/kube-runtime/src/controller/future_hash_map.rs
+++ b/kube-runtime/src/controller/future_hash_map.rs
@@ -77,10 +77,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::task::Poll;
+    use std::{future, task::Poll};
 
     use super::FutureHashMap;
-    use futures::{channel::mpsc, future, poll, StreamExt};
+    use futures::{channel::mpsc, poll, StreamExt};
 
     #[tokio::test]
     async fn fhm_should_forward_all_values_and_shut_down() {

--- a/kube-runtime/src/controller/runner.rs
+++ b/kube-runtime/src/controller/runner.rs
@@ -1,9 +1,10 @@
 use super::future_hash_map::FutureHashMap;
 use crate::scheduler::{ScheduleRequest, Scheduler};
-use futures::{future, Future, FutureExt, Stream, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use pin_project::pin_project;
 use std::{
     convert::Infallible,
+    future::{self, Future},
     hash::Hash,
     pin::Pin,
     task::{Context, Poll},
@@ -29,7 +30,7 @@ pub struct Runner<T, R, F, MkF, Ready = future::Ready<Result<(), Infallible>>> {
     run_msg: MkF,
     slots: FutureHashMap<T, F>,
     #[pin]
-    ready_to_execute_after: future::Fuse<Ready>,
+    ready_to_execute_after: futures::future::Fuse<Ready>,
     is_ready_to_execute: bool,
     stopped: bool,
     max_concurrent_executions: u16,
@@ -163,8 +164,7 @@ mod tests {
     };
     use futures::{
         channel::{mpsc, oneshot},
-        future::{self},
-        poll, stream, Future, SinkExt, StreamExt, TryStreamExt,
+        future, poll, stream, Future, SinkExt, StreamExt, TryStreamExt,
     };
     use std::{
         cell::RefCell,

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -31,9 +31,10 @@ pub use store::{store, Store};
 /// or [controller-rs](https://github.com/kube-rs/controller-rs) for the similar controller integration with [actix-web](https://actix.rs/).
 ///
 /// ```no_run
+/// use std::future::ready;
 /// use k8s_openapi::api::core::v1::Node;
 /// use kube::runtime::{reflector, watcher, WatchStreamExt, watcher::Config};
-/// use futures::{StreamExt, future::ready};
+/// use futures::StreamExt;
 /// # use kube::api::Api;
 /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 /// # let client: kube::Client = todo!();

--- a/kube-runtime/src/utils/delayed_init.rs
+++ b/kube-runtime/src/utils/delayed_init.rs
@@ -102,10 +102,10 @@ pub struct InitDropped;
 
 #[cfg(test)]
 mod tests {
-    use std::task::Poll;
+    use std::{pin::pin, task::Poll};
 
     use super::DelayedInit;
-    use futures::{pin_mut, poll};
+    use futures::poll;
     use tracing::Level;
     use tracing_subscriber::util::SubscriberInitExt;
 
@@ -121,8 +121,7 @@ mod tests {
     async fn must_allow_single_reader() {
         let _tracing = setup_tracing();
         let (tx, rx) = DelayedInit::<u8>::new();
-        let get1 = rx.get();
-        pin_mut!(get1);
+        let mut get1 = pin!(rx.get());
         assert_eq!(poll!(get1.as_mut()), Poll::Pending);
         tx.init(1);
         assert_eq!(poll!(get1), Poll::Ready(Ok(1)));
@@ -132,10 +131,9 @@ mod tests {
     async fn must_allow_concurrent_readers_while_waiting() {
         let _tracing = setup_tracing();
         let (tx, rx) = DelayedInit::<u8>::new();
-        let get1 = rx.get();
-        let get2 = rx.get();
-        let get3 = rx.get();
-        pin_mut!(get1, get2, get3);
+        let mut get1 = pin!(rx.get());
+        let mut get2 = pin!(rx.get());
+        let mut get3 = pin!(rx.get());
         assert_eq!(poll!(get1.as_mut()), Poll::Pending);
         assert_eq!(poll!(get2.as_mut()), Poll::Pending);
         assert_eq!(poll!(get3.as_mut()), Poll::Pending);
@@ -149,8 +147,7 @@ mod tests {
     async fn must_allow_reading_after_init() {
         let _tracing = setup_tracing();
         let (tx, rx) = DelayedInit::<u8>::new();
-        let get1 = rx.get();
-        pin_mut!(get1);
+        let mut get1 = pin!(rx.get());
         assert_eq!(poll!(get1.as_mut()), Poll::Pending);
         tx.init(1);
         assert_eq!(poll!(get1), Poll::Ready(Ok(1)));
@@ -162,10 +159,9 @@ mod tests {
     async fn must_allow_concurrent_readers_in_any_order() {
         let _tracing = setup_tracing();
         let (tx, rx) = DelayedInit::<u8>::new();
-        let get1 = rx.get();
-        let get2 = rx.get();
-        let get3 = rx.get();
-        pin_mut!(get1, get2, get3);
+        let mut get1 = pin!(rx.get());
+        let mut get2 = pin!(rx.get());
+        let mut get3 = pin!(rx.get());
         assert_eq!(poll!(get1.as_mut()), Poll::Pending);
         assert_eq!(poll!(get2.as_mut()), Poll::Pending);
         assert_eq!(poll!(get3.as_mut()), Poll::Pending);

--- a/kube-runtime/src/utils/event_modify.rs
+++ b/kube-runtime/src/utils/event_modify.rs
@@ -46,10 +46,10 @@ where
 
 #[cfg(test)]
 pub(crate) mod test {
-    use std::{task::Poll, vec};
+    use std::{pin::pin, task::Poll, vec};
 
     use super::{Error, Event, EventModify};
-    use futures::{pin_mut, poll, stream, StreamExt};
+    use futures::{poll, stream, StreamExt};
 
     #[tokio::test]
     async fn eventmodify_modifies_innner_value_of_event() {
@@ -58,10 +58,9 @@ pub(crate) mod test {
             Err(Error::TooManyObjects),
             Ok(Event::Restarted(vec![10])),
         ]);
-        let ev_modify = EventModify::new(st, |x| {
+        let mut ev_modify = pin!(EventModify::new(st, |x| {
             *x += 1;
-        });
-        pin_mut!(ev_modify);
+        }));
 
         assert!(matches!(
             poll!(ev_modify.next()),

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -22,14 +22,13 @@ pub use stream_subscribe::StreamSubscribe;
 pub use watch_ext::WatchStreamExt;
 
 use futures::{
-    pin_mut,
     stream::{self, Peekable},
     Future, FutureExt, Stream, StreamExt, TryStream, TryStreamExt,
 };
 use pin_project::pin_project;
 use std::{
     fmt::Debug,
-    pin::Pin,
+    pin::{pin, Pin},
     sync::{Arc, Mutex},
     task::Poll,
 };
@@ -77,8 +76,7 @@ where
         // TODO: remove #[allow] once fix reaches nightly.
         let inner = this.inner.lock().unwrap();
         let mut inner = Pin::new(inner);
-        let inner_peek = inner.as_mut().peek();
-        pin_mut!(inner_peek);
+        let inner_peek = pin!(inner.as_mut().peek());
         match inner_peek.poll(cx) {
             Poll::Ready(Some(x_ref)) => {
                 if (this.should_consume_item)(x_ref) {

--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -1,9 +1,9 @@
 use crate::{reflector::ObjectRef, watcher::Error};
 use core::{
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
-use futures::{ready, Stream};
+use futures::Stream;
 use kube_client::Resource;
 use pin_project::pin_project;
 use std::{
@@ -195,10 +195,10 @@ pub mod predicates {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::task::Poll;
+    use std::{pin::pin, task::Poll};
 
     use super::{predicates, Error, PredicateFilter};
-    use futures::{pin_mut, poll, stream, FutureExt, StreamExt};
+    use futures::{poll, stream, FutureExt, StreamExt};
     use kube_client::Resource;
     use serde_json::json;
 
@@ -229,8 +229,7 @@ pub(crate) mod tests {
             Ok(mkobj(1)),
             Ok(mkobj(2)),
         ]);
-        let rx = PredicateFilter::new(data, predicates::generation);
-        pin_mut!(rx);
+        let mut rx = pin!(PredicateFilter::new(data, predicates::generation));
 
         // mkobj(1) passed through
         let first = rx.next().now_or_never().unwrap().unwrap().unwrap();

--- a/kube-runtime/src/utils/reflect.rs
+++ b/kube-runtime/src/utils/reflect.rs
@@ -54,11 +54,11 @@ where
 
 #[cfg(test)]
 pub(crate) mod test {
-    use std::{task::Poll, vec};
+    use std::{pin::pin, task::Poll, vec};
 
     use super::{Error, Event, Reflect};
     use crate::reflector;
-    use futures::{pin_mut, poll, stream, StreamExt};
+    use futures::{poll, stream, StreamExt};
     use k8s_openapi::api::core::v1::Pod;
 
     fn testpod(name: &str) -> Pod {
@@ -78,8 +78,7 @@ pub(crate) mod test {
         ]);
         let (reader, writer) = reflector::store();
 
-        let reflect = Reflect::new(st, writer);
-        pin_mut!(reflect);
+        let mut reflect = pin!(Reflect::new(st, writer));
         assert_eq!(reader.len(), 0);
 
         assert!(matches!(

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -61,20 +61,20 @@ pub trait WatchStreamExt: Stream {
     /// Stream shorthand for `stream.map_ok(|event| { event.modify(f) })`.
     ///
     /// ```no_run
-    /// # use futures::{pin_mut, Stream, StreamExt, TryStreamExt};
+    /// # use std::pin::pin;
+    /// # use futures::{Stream, StreamExt, TryStreamExt};
     /// # use kube::{Api, Client, ResourceExt};
     /// # use kube_runtime::{watcher, WatchStreamExt};
     /// # use k8s_openapi::api::apps::v1::Deployment;
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
     /// let deploys: Api<Deployment> = Api::all(client);
-    /// let truncated_deploy_stream = watcher(deploys, watcher::Config::default())
+    /// let mut truncated_deploy_stream = pin!(watcher(deploys, watcher::Config::default())
     ///     .modify(|deploy| {
     ///         deploy.managed_fields_mut().clear();
     ///         deploy.status = None;
     ///     })
-    ///     .applied_objects();
-    /// pin_mut!(truncated_deploy_stream);
+    ///     .applied_objects());
     ///
     /// while let Some(d) = truncated_deploy_stream.try_next().await? {
     ///    println!("Truncated Deployment: '{:?}'", serde_json::to_string(&d)?);
@@ -100,17 +100,17 @@ pub trait WatchStreamExt: Stream {
     ///
     /// ## Usage
     /// ```no_run
-    /// # use futures::{pin_mut, Stream, StreamExt, TryStreamExt};
+    /// # use std::pin::pin;
+    /// # use futures::{Stream, StreamExt, TryStreamExt};
     /// use kube::{Api, Client, ResourceExt};
     /// use kube_runtime::{watcher, WatchStreamExt, predicates};
     /// use k8s_openapi::api::apps::v1::Deployment;
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
     /// let deploys: Api<Deployment> = Api::default_namespaced(client);
-    /// let changed_deploys = watcher(deploys, watcher::Config::default())
+    /// let mut changed_deploys = pin!(watcher(deploys, watcher::Config::default())
     ///     .applied_objects()
-    ///     .predicate_filter(predicates::generation);
-    /// pin_mut!(changed_deploys);
+    ///     .predicate_filter(predicates::generation));
     ///
     /// while let Some(d) = changed_deploys.try_next().await? {
     ///    println!("saw Deployment '{} with hitherto unseen generation", d.name_any());
@@ -200,7 +200,7 @@ pub trait WatchStreamExt: Stream {
     ///
     /// ## Usage
     /// ```no_run
-    /// # use futures::{pin_mut, Stream, StreamExt, TryStreamExt};
+    /// # use futures::{Stream, StreamExt, TryStreamExt};
     /// # use std::time::Duration;
     /// # use tracing::{info, warn};
     /// use kube::{Api, Client, ResourceExt};

--- a/kube-runtime/src/wait.rs
+++ b/kube-runtime/src/wait.rs
@@ -1,4 +1,6 @@
 //! Waits for objects to reach desired states
+use std::{future, pin::pin};
+
 use futures::TryStreamExt;
 use kube_client::{Api, Resource};
 use serde::de::DeserializeOwned;
@@ -52,11 +54,10 @@ where
     K: Clone + Debug + Send + DeserializeOwned + Resource + 'static,
 {
     // Skip updates until the condition is satisfied.
-    let stream = watch_object(api, name).try_skip_while(|obj| {
+    let mut stream = pin!(watch_object(api, name).try_skip_while(|obj| {
         let matches = cond.matches_object(obj.as_ref());
-        futures::future::ok(!matches)
-    });
-    futures::pin_mut!(stream);
+        future::ready(Ok(!matches))
+    }));
 
     // Then take the first update that satisfies the condition.
     let obj = stream


### PR DESCRIPTION
Replaces `futures` crate's APIs with the corresponding ones in the standard library.