### PR TITLE
tests: upgraded tarpaulin and added derive macro coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       #     tool: cargo-tarpaulin
       - name: Install tarpaulin # Use dev tarpaulin from git repo for now, until it's pushed to release
         run: |
-          rustup run stable cargo install --git https://github.com/xd009642/tarpaulin.git cargo-tarpaulin
+          rustup run stable cargo install --git https://github.com/xd009642/tarpaulin.git --rev 2b05ebd4f809eeeeb590f68efb8e62758eb59214 cargo-tarpaulin
       - uses: AbsaOSS/k3d-action@v2
         name: "Create Single Cluster"
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,11 +17,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # - name: Install tarpaulin
+      #   uses: taiki-e/install-action@v2
+      #   with:
+      #     tool: cargo-tarpaulin
+      - name: Install tarpaulin # Use dev tarpaulin from git repo for now, until it's pushed to release
+        run: |
+          rustup run stable cargo install --git https://github.com/xd009642/tarpaulin.git cargo-tarpaulin
       - uses: AbsaOSS/k3d-action@v2
         name: "Create Single Cluster"
         with:
@@ -31,8 +35,7 @@ jobs:
             -p 10250:10250
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.18.5'
-          out-type: Xml
-      - uses: codecov/codecov-action@v3
+        run: |
+          rustup run stable cargo tarpaulin -o xml --skip-clean
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/deny.toml
+++ b/deny.toml
@@ -51,7 +51,7 @@ license-files = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/tyrone-wu/runtime-macros.git"]
 
 [bans]
 multiple-versions = "deny"

--- a/justfile
+++ b/justfile
@@ -88,7 +88,7 @@ k3d:
     --k3s-arg "--disable=traefik,servicelb,metrics-server@server:*" \
     --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
     --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*' \
-    --k3s-arg '--kube-apiserver-arg=feature-gates=WatchList=true'
+    --k3s-arg '--kube-apiserver-arg=feature-gates=WatchList=true@server:*'
 
 ## RELEASE RELATED
 

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -33,3 +33,4 @@ schemars = { workspace = true, features = ["chrono"] }
 chrono.workspace = true
 trybuild.workspace = true
 assert-json-diff.workspace = true
+runtime-macros = { git = "https://github.com/tyrone-wu/runtime-macros.git" }

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -33,4 +33,4 @@ schemars = { workspace = true, features = ["chrono"] }
 chrono.workspace = true
 trybuild.workspace = true
 assert-json-diff.workspace = true
-runtime-macros = { git = "https://github.com/tyrone-wu/runtime-macros.git" }
+runtime-macros = { git = "https://github.com/tyrone-wu/runtime-macros.git", rev = "e31f4de52e078d41aba4792a7ea30139606c1362" }

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -599,8 +599,9 @@ fn to_plural(word: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::{env, fs};
+
     use super::*;
-    // TODO Unit test `derive`
 
     #[test]
     fn test_parse_default() {
@@ -615,5 +616,19 @@ mod tests {
         assert_eq!(kube_attrs.version, "v1".to_string());
         assert_eq!(kube_attrs.kind, "Foo".to_string());
         assert!(kube_attrs.namespaced);
+    }
+
+    #[test]
+    fn test_derive_crd() {
+        let path = env::current_dir().unwrap().join("tests").join("crd_enum_test.rs");
+        let file = fs::File::open(path).unwrap();
+        runtime_macros::emulate_derive_macro_expansion(file, &[("CustomResource", derive)]).unwrap();
+
+        let path = env::current_dir()
+            .unwrap()
+            .join("tests")
+            .join("crd_schema_test.rs");
+        let file = fs::File::open(path).unwrap();
+        runtime_macros::emulate_derive_macro_expansion(file, &[("CustomResource", derive)]).unwrap();
     }
 }

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -7,21 +7,18 @@
 
 [one_pass_coverage]
 workspace = true
-features = "kube/derive kube/runtime kube/ws"
+all-features = true
 color = "Always"
 ignored = true
 timeout = "600s"
 exclude = ["e2e"]
-# NB: proc macro code is not picked up by tarpaulin - so could maybe skip kube-derive completely
-excluded_files = ["kube-derive/tests"]
+include-tests = true
 # NB: skipping Doctests because they are slow to build and generally marked no_run
 run-types = ["Tests"]
-ignore_tests = true
 
 # We could potentially pass in examples here
 # but: they don't help in covering kube-derive, and they force a full recompile
-#[example_pass]
-#features = "default"
-#packages = ["kube-examples"]
-#excluded_files = ["examples/"]
-#example = ["crd_derive_schema"]
+[example_pass]
+packages = ["kube-examples"]
+exclude-files = ["examples/"]
+example = ["crd_derive_schema"]


### PR DESCRIPTION
Upgraded tarpaulin to new the new maintainer, added coverage for derive macro, and added an example.

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

Resolves #1144

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

Here's the codecov for this PR. https://app.codecov.io/gh/tyrone-wu/kube/tree/tests%2Fupdate-code-coverage

- [x] Bump to latest (currently 0.27.3) from our pin at [0.18.5](https://github.com/xd009642/tarpaulin/releases/tag/0.18.5) from Nov 2021
  - Upgraded tarpaulin to the new maintainer. 
- [x] Find a better GH Action approach (see below for the issues with actions-rs/tarpaulin) - taike-e install
  - For now, this uses the tarpaulin dev version from https://github.com/xd009642/tarpaulin since the false negative coverage isn't in release yet (not sure when it'll be in). Once it's in release, it can be switched back to taike-e install.
- [x] Try the [proc macro coverage](https://github.com/xd009642/tarpaulin#procedural-macros) so that we can get credit for tests in kube-derive (currently [it looks bad](https://app.codecov.io/gh/kube-rs/kube/tree/main/kube-derive) but it is tested)
  - https://app.codecov.io/gh/tyrone-wu/kube/tree/tests%2Fupdate-code-coverage/kube-derive
  - The `syn` dependency used `v1` in both [runtime-macros](https://github.com/jeremydavis519/runtime-macros) and [runtime-macros-derive](https://github.com/tonyfinn/runtime-macros-derive), and it caused some error when running them against this projects derive macros. I'm not entirely sure if they're being maintained anymore since last update a while ago, and `syn v1` was a pretty ancient version. I ended up forking and upgrading it to `v2` on my own https://github.com/tyrone-wu/runtime-macros. (tbh, I'm not entirely sure what runtime-macros does internally, but I tried upgraded `syn` so that it's compatible with kube's derive macros, and it seems to be getting the coverage which is good I think? 😅) 
- [x] Do an all-features build in coverage (to ensure numbers are the most accurate and the most tests run)
- [x] Try to include one or two examples if it can be done quickly (better to improve coverage with actual integration tests)
  - Tarpaulin now includes the `crd_derive_schema` example, and  `default` feature is now the default of running it (I think).

I noticed the codecov step uses `v3`. Would you prefer also upgrading it to latest `v4`? I'm not sure what things this adds or changes so it might not be necessary.