### PR TITLE
Upgrade `k8s-openapi` to 0.22 and bump MK8SV to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run these tests against older clusters as well
-        k8s: [v1.24, latest]
+        k8s: [v1.25, latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -211,7 +211,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.24
+          version: v1.25
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           cluster-name: "test-cluster-1"
           args: >-
-            --image docker.io/rancher/k3s:v1.25.4-k3s1
+            --image docker.io/rancher/k3s:v1.25.16-k3s1
             -p 10250:10250
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
       - name: Run cargo-tarpaulin

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           cluster-name: "test-cluster-1"
           args: >-
-            --image docker.io/rancher/k3s:v1.24.4-k3s1
+            --image docker.io/rancher/k3s:v1.25.4-k3s1
             -p 10250:10250
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
       - name: Run cargo-tarpaulin

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           cluster-name: "test-cluster-1"
           args: >-
-            --image docker.io/rancher/k3s:v1.25.16-k3s1
+            --image docker.io/rancher/k3s:v1.25.16-k3s1-amd64
             -p 10250:10250
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
       - name: Run cargo-tarpaulin

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,14 +23,16 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-tarpaulin@0.28.0
-      - uses: AbsaOSS/k3d-action@v2
-        name: "Create Single Cluster"
+      - uses: nolar/setup-k3d-k3s@v1
         with:
-          cluster-name: "test-cluster-1"
-          args: >-
-            --image docker.io/rancher/k3s:v1.25.16-k3s1-amd64
-            -p 10250:10250
-            --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+          version: v1.25
+          # k3d-kube
+          k3d-name: kube
+          # Used to avoid rate limits when fetching the releases from k3s repo.
+          # Anonymous access is limited to 60 requests / hour / worker
+          # github-token: ${{ secrets.GITHUB_TOKEN }}
+          k3d-args: "-p 10250:10250 --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
+
       - name: Run cargo-tarpaulin
         run: |
           rustup run stable cargo tarpaulin -o xml --skip-clean

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ hyper-socks2 = { version = "0.9.0", default-features = false }
 hyper-timeout = "0.5.1"
 json-patch = "1.0.0"
 jsonpath-rust = "0.5.0"
-k8s-openapi = { version = "0.21.0", default-features = false }
+k8s-openapi = { version = "0.22.0", default-features = false }
 openssl = "0.10.36"
 parking_lot = "0.12.0"
 pem = "3.0.1"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
 [![Rust 1.75](https://img.shields.io/badge/MSRV-1.75-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.75.0)
-[![Tested against Kubernetes v1_24 and above](https://img.shields.io/badge/MK8SV-v1_24-326ce5.svg)](https://kube.rs/kubernetes-version)
+[![Tested against Kubernetes v1_25 and above](https://img.shields.io/badge/MK8SV-v1_25-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -19,7 +19,7 @@ path = "boot.rs"
 
 [features]
 latest = ["k8s-openapi/latest"]
-mk8sv = ["k8s-openapi/v1_24"]
+mk8sv = ["k8s-openapi/v1_25"]
 rustls = ["kube/rustls-tls"]
 openssl = ["kube/openssl-tls"]
 

--- a/justfile
+++ b/justfile
@@ -107,8 +107,8 @@ bump-k8s:
   #!/usr/bin/env bash
   latest=$(cargo tree --format "{f}" -i k8s-openapi | head -n 1 | choose -f ',' 1)
   # bumping supported version also bumps our mk8sv
-  mk8svnew=${latest::-2}$((${latest:3} - 4))
-  mk8svold=${latest::-2}$((${latest:3} - 5))
+  mk8svnew=${latest::-2}$((${latest:3} - 5))
+  mk8svold=${latest::-2}$((${latest:3} - 6))
   fastmod -m -d e2e -e toml "$mk8svold" "$mk8svnew"
   fastmod -m -d .github/workflows -e yml "${mk8svold/_/\.}" "${mk8svnew/_/.}"
   # bump mk8sv badge


### PR DESCRIPTION
Propagating the new [k8s-openapi release](https://github.com/Arnavion/k8s-openapi/releases/tag/v0.22.0), which as usual requires a few propagating steps and a new minor release. Will do a release after merging this.

```
cargo upgrade -p k8s-openapi -i
just bump-k8s
```

Trivial chores to make it work as intended:
- shifted one integer in the `justfile` recipe down to get it to give me the right MK8SV (otherwise it gave me 1.26).
- k3s alignment in CI (auto-bump picked a tag in coverage that didn't exist, and usual action takes minor versions)