### PR TITLE
Fix potentially panicing unchecked duration adds in runtime

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -474,7 +474,7 @@ where
                 },
                 run_at: reconciler_finished_at
                     .checked_add(requeue_after)
-                    .unwrap_or_else(Instant::now),
+                    .unwrap_or_else(crate::scheduler::far_future),
             }),
             result: Some(result),
         }

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -472,7 +472,9 @@ where
                     obj_ref,
                     reason: reschedule_reason,
                 },
-                run_at: reconciler_finished_at + requeue_after,
+                run_at: reconciler_finished_at
+                    .checked_add(requeue_after)
+                    .unwrap_or_else(Instant::now),
             }),
             result: Some(result),
         }

--- a/kube-runtime/src/scheduler.rs
+++ b/kube-runtime/src/scheduler.rs
@@ -74,6 +74,10 @@ impl<'a, T: Hash + Eq + Clone, R> SchedulerProj<'a, T, R> {
             // Message is already pending, so we can't even expedite it
             return;
         }
+        let next_time = request
+            .run_at
+            .checked_add(*self.debounce)
+            .unwrap_or_else(Instant::now);
         match self.scheduled.entry(request.message) {
             // If new request is supposed to be earlier than the current entry's scheduled
             // time (for eg: the new request is user triggered and the current entry is the
@@ -81,9 +85,8 @@ impl<'a, T: Hash + Eq + Clone, R> SchedulerProj<'a, T, R> {
             Entry::Occupied(mut old_entry) if old_entry.get().run_at >= request.run_at => {
                 // Old entry will run after the new request, so replace it..
                 let entry = old_entry.get_mut();
-                self.queue
-                    .reset_at(&entry.queue_key, request.run_at + *self.debounce);
-                entry.run_at = request.run_at + *self.debounce;
+                self.queue.reset_at(&entry.queue_key, next_time);
+                entry.run_at = next_time;
                 old_entry.replace_key();
             }
             Entry::Occupied(_old_entry) => {
@@ -93,8 +96,8 @@ impl<'a, T: Hash + Eq + Clone, R> SchedulerProj<'a, T, R> {
                 // No old entry, we're free to go!
                 let message = entry.key().clone();
                 entry.insert(ScheduledEntry {
-                    run_at: request.run_at + *self.debounce,
-                    queue_key: self.queue.insert_at(message, request.run_at + *self.debounce),
+                    run_at: next_time,
+                    queue_key: self.queue.insert_at(message, next_time),
                 });
             }
         }

--- a/kube-runtime/src/scheduler.rs
+++ b/kube-runtime/src/scheduler.rs
@@ -77,7 +77,7 @@ impl<'a, T: Hash + Eq + Clone, R> SchedulerProj<'a, T, R> {
         let next_time = request
             .run_at
             .checked_add(*self.debounce)
-            .unwrap_or_else(Instant::now);
+            .unwrap_or_else(far_future);
         match self.scheduled.entry(request.message) {
             // If new request is supposed to be earlier than the current entry's scheduled
             // time (for eg: the new request is user triggered and the current entry is the
@@ -281,6 +281,13 @@ pub fn debounced_scheduler<T: Eq + Hash + Clone, S: Stream<Item = ScheduleReques
     debounce: Duration,
 ) -> Scheduler<T, S> {
     Scheduler::new(requests, debounce)
+}
+
+// internal fallback for overflows in schedule times
+pub(crate) fn far_future() -> Instant {
+    // private method from tokio for convenience - remove if upstream becomes pub
+    // https://github.com/tokio-rs/tokio/blob/6fcd9c02176bf3cd570bc7de88edaa3b95ea480a/tokio/src/time/instant.rs#L57-L63
+    Instant::now() + Duration::from_secs(86400 * 365 * 30)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #1488. Searched a lot and found 3 legit cases.

Prevents pathological overlows of `Instant` + `Duration` with now() defaulted use of [`Instant::checked_add`](https://doc.rust-lang.org/std/time/struct.Instant.html#method.checked_add)