### PR TITLE
Reduce buffering between watcher and Store

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -30,7 +30,7 @@ rust.unsafe_code = "forbid"
 #rust.missing_docs = "warn"
 
 [dependencies]
-futures.workspace = true
+futures = { workspace = true, features = ["async-await"] }
 kube-client = { path = "../kube-client", version = "=0.91.0", default-features = false, features = ["jsonpatch", "client"] }
 derivative.workspace = true
 serde.workspace = true

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1753,7 +1753,7 @@ mod tests {
             |obj, _| {
                 Box::pin(async move {
                     // Try to flood the rescheduling buffer buffer by just putting it back in the queue immediately
-                    println!("reconciling {:?}", obj.metadata.name);
+                    //println!("reconciling {:?}", obj.metadata.name);
                     Ok(Action::requeue(Duration::ZERO))
                 })
             },
@@ -1763,6 +1763,7 @@ mod tests {
             queue_rx.map(Result::<_, Infallible>::Ok),
             Config::default(),
         ));
+        store_tx.apply_watcher_event(&watcher::Event::Restart);
         for i in 0..items {
             let obj = ConfigMap {
                 metadata: ObjectMeta {

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1772,7 +1772,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            store_tx.apply_watcher_event(&watcher::Event::Applied(obj.clone()));
+            store_tx.apply_watcher_event(&watcher::Event::Apply(obj.clone()));
             queue_tx.unbounded_send(ObjectRef::from_obj(&obj)).unwrap();
         }
 

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -158,13 +158,10 @@ mod tests {
             },
             ..ConfigMap::default()
         };
-        reflector(
-            store_w,
-            stream::iter(vec![Ok(watcher::Event::Applied(cm.clone()))]),
-        )
-        .map(|_| ())
-        .collect::<()>()
-        .await;
+        reflector(store_w, stream::iter(vec![Ok(watcher::Event::Apply(cm.clone()))]))
+            .map(|_| ())
+            .collect::<()>()
+            .await;
         assert_eq!(store.get(&ObjectRef::from_obj(&cm)).as_deref(), Some(&cm));
     }
 
@@ -190,8 +187,8 @@ mod tests {
         reflector(
             store_w,
             stream::iter(vec![
-                Ok(watcher::Event::Applied(cm.clone())),
-                Ok(watcher::Event::Applied(updated_cm.clone())),
+                Ok(watcher::Event::Apply(cm.clone())),
+                Ok(watcher::Event::Apply(updated_cm.clone())),
             ]),
         )
         .map(|_| ())
@@ -214,8 +211,8 @@ mod tests {
         reflector(
             store_w,
             stream::iter(vec![
-                Ok(watcher::Event::Applied(cm.clone())),
-                Ok(watcher::Event::Deleted(cm.clone())),
+                Ok(watcher::Event::Apply(cm.clone())),
+                Ok(watcher::Event::Delete(cm.clone())),
             ]),
         )
         .map(|_| ())
@@ -245,10 +242,10 @@ mod tests {
         reflector(
             store_w,
             stream::iter(vec![
-                Ok(watcher::Event::Applied(cm_a.clone())),
-                Ok(watcher::Event::RestartedStart),
-                Ok(watcher::Event::RestartedPage(vec![cm_b.clone()])),
-                Ok(watcher::Event::RestartedDone),
+                Ok(watcher::Event::Apply(cm_a.clone())),
+                Ok(watcher::Event::RestartInit),
+                Ok(watcher::Event::RestartPage(vec![cm_b.clone()])),
+                Ok(watcher::Event::Restart),
             ]),
         )
         .map(|_| ())
@@ -279,9 +276,9 @@ mod tests {
                     ..ConfigMap::default()
                 };
                 Ok(if deleted {
-                    watcher::Event::Deleted(obj)
+                    watcher::Event::Delete(obj)
                 } else {
-                    watcher::Event::Applied(obj)
+                    watcher::Event::Apply(obj)
                 })
             })),
         )

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -12,7 +12,8 @@ use crate::watcher;
 use async_stream::stream;
 use futures::{Stream, StreamExt};
 use std::hash::Hash;
-#[cfg(feature = "unstable-runtime-subscribe")] pub use store::store_shared;
+#[cfg(feature = "unstable-runtime-subscribe")]
+pub use store::store_shared;
 pub use store::{store, Store};
 
 /// Cache objects from a [`watcher()`] stream into a local [`Store`]
@@ -245,7 +246,9 @@ mod tests {
             store_w,
             stream::iter(vec![
                 Ok(watcher::Event::Applied(cm_a.clone())),
-                Ok(watcher::Event::Restarted(vec![cm_b.clone()])),
+                Ok(watcher::Event::RestartedStart),
+                Ok(watcher::Event::RestartedPage(vec![cm_b.clone()])),
+                Ok(watcher::Event::RestartedDone),
             ]),
         )
         .map(|_| ())

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -12,8 +12,7 @@ use crate::watcher;
 use async_stream::stream;
 use futures::{Stream, StreamExt};
 use std::hash::Hash;
-#[cfg(feature = "unstable-runtime-subscribe")]
-pub use store::store_shared;
+#[cfg(feature = "unstable-runtime-subscribe")] pub use store::store_shared;
 pub use store::{store, Store};
 
 /// Cache objects from a [`watcher()`] stream into a local [`Store`]

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -157,8 +157,12 @@ where
                     dispatcher.broadcast(obj_ref).await;
                 }
 
-                watcher::Event::RestartPage(new_objs) => {
-                    let obj_refs = new_objs.iter().map(|obj| obj.to_object_ref(self.dyntype.clone()));
+                watcher::Event::Restart => {
+                    let obj_refs: Vec<_> = {
+                        let store = self.store.read();
+                        store.keys().cloned().collect()
+                    };
+
                     for obj_ref in obj_refs {
                         dispatcher.broadcast(obj_ref).await;
                     }

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -129,7 +129,7 @@ where
                 // This way, the old buffer is dropped.
                 self.buffer = AHashMap::new();
 
-                // Mark as ready after the RestartedDone, "releasing" any calls to Store::wait_until_ready()
+                // Mark as ready after the Restart, "releasing" any calls to Store::wait_until_ready()
                 if let Some(ready_tx) = self.ready_tx.take() {
                     ready_tx.init(())
                 }
@@ -164,10 +164,7 @@ where
                     }
                 }
 
-                watcher::Event::RestartInit
-                | watcher::Event::Restart
-                | watcher::Event::Delete(_)
-                | watcher::Event::RestartDelete(_) => {}
+                _ => {}
             }
         }
     }

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -125,6 +125,8 @@ where
                 std::mem::swap(&mut *store, &mut self.buffer);
 
                 // Clear the buffer
+                // This is preferred over self.buffer.clear(), as clear() will keep the allocated memory for reuse.
+                // This way, the old buffer is dropped.
                 self.buffer = AHashMap::new();
 
                 // Mark as ready after the RestartedDone, "releasing" any calls to Store::wait_until_ready()

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -150,7 +150,7 @@ where
     pub(crate) async fn dispatch_event(&mut self, event: &watcher::Event<K>) {
         if let Some(ref mut dispatcher) = self.dispatcher {
             match event {
-                watcher::Event::Apply(obj) | watcher::Event::RestartApply(obj) => {
+                watcher::Event::Apply(obj) => {
                     let obj_ref = obj.to_object_ref(self.dyntype.clone());
                     // TODO (matei): should this take a timeout to log when backpressure has
                     // been applied for too long, e.g. 10s

--- a/kube-runtime/src/utils/event_flatten.rs
+++ b/kube-runtime/src/utils/event_flatten.rs
@@ -37,10 +37,8 @@ where
                 break Some(Ok(item));
             }
             let var_name = match ready!(me.stream.as_mut().poll_next(cx)) {
-                Some(Ok(Event::Apply(obj) | Event::RestartApply(obj) | Event::RestartDelete(obj))) => {
-                    Some(Ok(obj))
-                }
-                Some(Ok(Event::Delete(obj))) => {
+                Some(Ok(Event::Apply(obj) | Event::RestartApply(obj))) => Some(Ok(obj)),
+                Some(Ok(Event::Delete(obj) | Event::RestartDelete(obj))) => {
                     if *me.emit_deleted {
                         Some(Ok(obj))
                     } else {

--- a/kube-runtime/src/utils/event_modify.rs
+++ b/kube-runtime/src/utils/event_modify.rs
@@ -54,9 +54,9 @@ pub(crate) mod test {
     #[tokio::test]
     async fn eventmodify_modifies_innner_value_of_event() {
         let st = stream::iter([
-            Ok(Event::Applied(0)),
+            Ok(Event::Apply(0)),
             Err(Error::TooManyObjects),
-            Ok(Event::RestartedPage(vec![10])),
+            Ok(Event::RestartPage(vec![10])),
         ]);
         let mut ev_modify = pin!(EventModify::new(st, |x| {
             *x += 1;
@@ -64,7 +64,7 @@ pub(crate) mod test {
 
         assert!(matches!(
             poll!(ev_modify.next()),
-            Poll::Ready(Some(Ok(Event::Applied(1))))
+            Poll::Ready(Some(Ok(Event::Apply(1))))
         ));
 
         assert!(matches!(
@@ -75,7 +75,7 @@ pub(crate) mod test {
         let restarted = poll!(ev_modify.next());
         assert!(matches!(
             restarted,
-            Poll::Ready(Some(Ok(Event::RestartedPage(vec)))) if vec == [11]
+            Poll::Ready(Some(Ok(Event::RestartPage(vec)))) if vec == [11]
         ));
 
         assert!(matches!(poll!(ev_modify.next()), Poll::Ready(None)));

--- a/kube-runtime/src/utils/event_modify.rs
+++ b/kube-runtime/src/utils/event_modify.rs
@@ -56,7 +56,7 @@ pub(crate) mod test {
         let st = stream::iter([
             Ok(Event::Applied(0)),
             Err(Error::TooManyObjects),
-            Ok(Event::Restarted(vec![10])),
+            Ok(Event::RestartedPage(vec![10])),
         ]);
         let mut ev_modify = pin!(EventModify::new(st, |x| {
             *x += 1;
@@ -75,7 +75,7 @@ pub(crate) mod test {
         let restarted = poll!(ev_modify.next());
         assert!(matches!(
             restarted,
-            Poll::Ready(Some(Ok(Event::Restarted(vec)))) if vec == [11]
+            Poll::Ready(Some(Ok(Event::RestartedPage(vec)))) if vec == [11]
         ));
 
         assert!(matches!(poll!(ev_modify.next()), Poll::Ready(None)));

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -4,8 +4,7 @@ mod backoff_reset_timer;
 pub(crate) mod delayed_init;
 mod event_flatten;
 mod event_modify;
-#[cfg(feature = "unstable-runtime-predicates")]
-mod predicate;
+#[cfg(feature = "unstable-runtime-predicates")] mod predicate;
 mod reflect;
 mod stream_backoff;
 mod watch_ext;

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -4,7 +4,8 @@ mod backoff_reset_timer;
 pub(crate) mod delayed_init;
 mod event_flatten;
 mod event_modify;
-#[cfg(feature = "unstable-runtime-predicates")] mod predicate;
+#[cfg(feature = "unstable-runtime-predicates")]
+mod predicate;
 mod reflect;
 mod stream_backoff;
 mod watch_ext;

--- a/kube-runtime/src/utils/reflect.rs
+++ b/kube-runtime/src/utils/reflect.rs
@@ -72,11 +72,11 @@ pub(crate) mod test {
         let foo = testpod("foo");
         let bar = testpod("bar");
         let st = stream::iter([
-            Ok(Event::Applied(foo.clone())),
+            Ok(Event::Apply(foo.clone())),
             Err(Error::TooManyObjects),
-            Ok(Event::RestartedStart),
-            Ok(Event::RestartedPage(vec![foo, bar])),
-            Ok(Event::RestartedDone),
+            Ok(Event::RestartInit),
+            Ok(Event::RestartPage(vec![foo, bar])),
+            Ok(Event::Restart),
         ]);
         let (reader, writer) = reflector::store();
 
@@ -85,7 +85,7 @@ pub(crate) mod test {
 
         assert!(matches!(
             poll!(reflect.next()),
-            Poll::Ready(Some(Ok(Event::Applied(_))))
+            Poll::Ready(Some(Ok(Event::Apply(_))))
         ));
         assert_eq!(reader.len(), 1);
 
@@ -97,20 +97,17 @@ pub(crate) mod test {
 
         assert!(matches!(
             poll!(reflect.next()),
-            Poll::Ready(Some(Ok(Event::RestartedStart)))
+            Poll::Ready(Some(Ok(Event::RestartInit)))
         ));
         assert_eq!(reader.len(), 1);
 
         let restarted = poll!(reflect.next());
-        assert!(matches!(
-            restarted,
-            Poll::Ready(Some(Ok(Event::RestartedPage(_))))
-        ));
+        assert!(matches!(restarted, Poll::Ready(Some(Ok(Event::RestartPage(_))))));
         assert_eq!(reader.len(), 1);
 
         assert!(matches!(
             poll!(reflect.next()),
-            Poll::Ready(Some(Ok(Event::RestartedDone)))
+            Poll::Ready(Some(Ok(Event::Restart)))
         ));
         assert_eq!(reader.len(), 2);
 

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -487,10 +487,9 @@ where
 {
     match state {
         State::Empty => match wc.initial_list_strategy {
-            InitialListStrategy::ListWatch => (
-                Some(Ok(Event::RestartInit)),
-                State::InitPage { continue_token: None },
-            ),
+            InitialListStrategy::ListWatch => (Some(Ok(Event::RestartInit)), State::InitPage {
+                continue_token: None,
+            }),
             InitialListStrategy::StreamingList => match api.watch(&wc.to_watch_params(), "0").await {
                 Ok(stream) => (None, State::InitialWatch { stream }),
                 Err(err) => {
@@ -509,19 +508,15 @@ where
             match api.list(&lp).await {
                 Ok(list) => {
                     if let Some(continue_token) = list.metadata.continue_.filter(|s| !s.is_empty()) {
-                        (
-                            Some(Ok(Event::RestartPage(list.items))),
-                            State::InitPage {
-                                continue_token: Some(continue_token),
-                            },
-                        )
+                        (Some(Ok(Event::RestartPage(list.items))), State::InitPage {
+                            continue_token: Some(continue_token),
+                        })
                     } else if let Some(resource_version) =
                         list.metadata.resource_version.filter(|s| !s.is_empty())
                     {
-                        (
-                            Some(Ok(Event::RestartPage(list.items))),
-                            State::InitPageDone { resource_version },
-                        )
+                        (Some(Ok(Event::RestartPage(list.items))), State::InitPageDone {
+                            resource_version,
+                        })
                     } else {
                         (Some(Err(Error::NoResourceVersion)), State::Empty)
                     }
@@ -544,20 +539,18 @@ where
                 Some(Ok(WatchEvent::Added(obj) | WatchEvent::Modified(obj))) => {
                     (Some(Ok(Event::RestartApply(obj))), State::InitialWatch { stream })
                 }
-                Some(Ok(WatchEvent::Deleted(obj))) => (
-                    Some(Ok(Event::RestartDelete(obj))),
-                    State::InitialWatch { stream },
-                ),
+                Some(Ok(WatchEvent::Deleted(obj))) => {
+                    (Some(Ok(Event::RestartDelete(obj))), State::InitialWatch {
+                        stream,
+                    })
+                }
                 Some(Ok(WatchEvent::Bookmark(bm))) => {
                     let marks_initial_end = bm.metadata.annotations.contains_key("k8s.io/initial-events-end");
                     if marks_initial_end {
-                        (
-                            Some(Ok(Event::Restart)),
-                            State::Watching {
-                                resource_version: bm.metadata.resource_version,
-                                stream,
-                            },
-                        )
+                        (Some(Ok(Event::Restart)), State::Watching {
+                            resource_version: bm.metadata.resource_version,
+                            stream,
+                        })
                     } else {
                         (None, State::InitialWatch { stream })
                     }
@@ -589,23 +582,19 @@ where
         }
         State::InitListed { resource_version } => {
             match api.watch(&wc.to_watch_params(), &resource_version).await {
-                Ok(stream) => (
-                    None,
-                    State::Watching {
-                        resource_version,
-                        stream,
-                    },
-                ),
+                Ok(stream) => (None, State::Watching {
+                    resource_version,
+                    stream,
+                }),
                 Err(err) => {
                     if std::matches!(err, ClientErr::Api(ErrorResponse { code: 403, .. })) {
                         warn!("watch initlist error with 403: {err:?}");
                     } else {
                         debug!("watch initlist error: {err:?}");
                     }
-                    (
-                        Some(Err(Error::WatchStartFailed(err))),
-                        State::InitListed { resource_version },
-                    )
+                    (Some(Err(Error::WatchStartFailed(err))), State::InitListed {
+                        resource_version,
+                    })
                 }
             }
         }
@@ -618,13 +607,10 @@ where
                 if resource_version.is_empty() {
                     (Some(Err(Error::NoResourceVersion)), State::default())
                 } else {
-                    (
-                        Some(Ok(Event::Apply(obj))),
-                        State::Watching {
-                            resource_version,
-                            stream,
-                        },
-                    )
+                    (Some(Ok(Event::Apply(obj))), State::Watching {
+                        resource_version,
+                        stream,
+                    })
                 }
             }
             Some(Ok(WatchEvent::Deleted(obj))) => {
@@ -632,22 +618,16 @@ where
                 if resource_version.is_empty() {
                     (Some(Err(Error::NoResourceVersion)), State::default())
                 } else {
-                    (
-                        Some(Ok(Event::Delete(obj))),
-                        State::Watching {
-                            resource_version,
-                            stream,
-                        },
-                    )
+                    (Some(Ok(Event::Delete(obj))), State::Watching {
+                        resource_version,
+                        stream,
+                    })
                 }
             }
-            Some(Ok(WatchEvent::Bookmark(bm))) => (
-                None,
-                State::Watching {
-                    resource_version: bm.metadata.resource_version,
-                    stream,
-                },
-            ),
+            Some(Ok(WatchEvent::Bookmark(bm))) => (None, State::Watching {
+                resource_version: bm.metadata.resource_version,
+                stream,
+            }),
             Some(Ok(WatchEvent::Error(err))) => {
                 // HTTP GONE, means we have desynced and need to start over and re-list :(
                 let new_state = if err.code == 410 {
@@ -671,13 +651,10 @@ where
                 } else {
                     debug!("watcher error: {err:?}");
                 }
-                (
-                    Some(Err(Error::WatchFailed(err))),
-                    State::Watching {
-                        resource_version,
-                        stream,
-                    },
-                )
+                (Some(Err(Error::WatchFailed(err))), State::Watching {
+                    resource_version,
+                    stream,
+                })
             }
             None => (None, State::InitListed { resource_version }),
         },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Fixes: #1487 

This PR reduces allocations when the watcher is paging/streaming the initial list. 
It updates the `watcher::Event` enum to emit events that can be used to update a buffer on the end side and it updated the reflector store accordingly. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

###  ListWatch  strategy
When starting the paginated API request, a `RestartedStart` is returned,
and the state is changed from `Empty` to `InitPage`.
When pages are received, `RestartedPage(objs)`events are returned till the end of the list, then the state is changed to `InitPageDone` and the  `RestartedDone` event is returned.
The Store is updated to react to the new events:
- On `RestartedStart` it initializes the buffer
- On `RestartedPage(objs)` it extends the buffer with the objects received.
- On `RestartDone` it swaps the buffer with the internal store. This allows 
to update the store atomically.

### StreamingList strategy
The `RestartedStart` event is returned when the `InitialWatch` is started, then `RestartedApplied(obj)` or `RestartedDelete(obj)` events are returned till bookmark with the `"k8s.io/initial-events-end"` annotation is received.
Then, the `RestartedDone` event is returned.
The store reacts to `RestartedApplied/RestartedDeleted` events by updating the buffer.

### Benchmarks
Watching 10000 RoleBindings:

`ListWatch` strategy:

|              | With Store | Without Store |
|--------------|------------|---------------|
| Patched      | ~58 Mb     | ~13 Mb        |
| Upstream     | ~92 Mb     | ~76 Mb        |


`StreamingList` strategy:

|              | With Store | Without Store |
|--------------|------------|---------------|
| Patched      | ~53 Mb     | ~7 Mb        |
| Upstream     | ~94 Mb     | ~76 Mb        |

NOTE:
This is a WIP, need to update tests. 







