### PR TITLE
 Rename new watcher Event names and remove one that cannot happen

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1763,7 +1763,7 @@ mod tests {
             queue_rx.map(Result::<_, Infallible>::Ok),
             Config::default(),
         ));
-        store_tx.apply_watcher_event(&watcher::Event::Ready);
+        store_tx.apply_watcher_event(&watcher::Event::InitDone);
         for i in 0..items {
             let obj = ConfigMap {
                 metadata: ObjectMeta {

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1750,7 +1750,7 @@ mod tests {
         let (queue_tx, queue_rx) = futures::channel::mpsc::unbounded::<ObjectRef<ConfigMap>>();
         let (store_rx, mut store_tx) = reflector::store();
         let mut applier = pin!(applier(
-            |obj, _| {
+            |_obj, _| {
                 Box::pin(async move {
                     // Try to flood the rescheduling buffer buffer by just putting it back in the queue immediately
                     //println!("reconciling {:?}", obj.metadata.name);
@@ -1763,7 +1763,7 @@ mod tests {
             queue_rx.map(Result::<_, Infallible>::Ok),
             Config::default(),
         ));
-        store_tx.apply_watcher_event(&watcher::Event::Restart);
+        store_tx.apply_watcher_event(&watcher::Event::Ready);
         for i in 0..items {
             let obj = ConfigMap {
                 metadata: ObjectMeta {

--- a/kube-runtime/src/reflector/dispatcher.rs
+++ b/kube-runtime/src/reflector/dispatcher.rs
@@ -169,7 +169,7 @@ pub(crate) mod test {
             Err(Error::TooManyObjects),
             Ok(Event::Init),
             Ok(Event::InitPage(vec![foo, bar])),
-            Ok(Event::Ready),
+            Ok(Event::InitDone),
         ]);
 
         let (reader, writer) = reflector::store_shared(10);
@@ -200,7 +200,7 @@ pub(crate) mod test {
         assert_eq!(reader.len(), 1);
 
         let restarted = poll!(reflect.next());
-        assert!(matches!(restarted, Poll::Ready(Some(Ok(Event::Ready)))));
+        assert!(matches!(restarted, Poll::Ready(Some(Ok(Event::InitDone)))));
         assert_eq!(reader.len(), 2);
 
         assert!(matches!(poll!(reflect.next()), Poll::Ready(None)));
@@ -221,7 +221,7 @@ pub(crate) mod test {
             Err(Error::TooManyObjects),
             Ok(Event::Init),
             Ok(Event::InitPage(vec![foo.clone(), bar.clone()])),
-            Ok(Event::Ready),
+            Ok(Event::InitDone),
         ]);
 
         let foo = Arc::new(foo);
@@ -267,7 +267,7 @@ pub(crate) mod test {
 
         assert!(matches!(
             poll!(reflect.next()),
-            Poll::Ready(Some(Ok(Event::Ready)))
+            Poll::Ready(Some(Ok(Event::InitDone)))
         ));
 
         // these don't come back in order atm:
@@ -289,7 +289,7 @@ pub(crate) mod test {
             Ok(Event::Apply(foo.clone())),
             Ok(Event::Init),
             Ok(Event::InitPage(vec![foo.clone(), bar.clone()])),
-            Ok(Event::Ready),
+            Ok(Event::InitDone),
         ]);
 
         let foo = Arc::new(foo);
@@ -326,7 +326,7 @@ pub(crate) mod test {
 
         assert!(matches!(
             poll!(reflect.next()),
-            Poll::Ready(Some(Ok(Event::Ready)))
+            Poll::Ready(Some(Ok(Event::InitDone)))
         ));
         drop(reflect);
 

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -244,7 +244,7 @@ mod tests {
                 Ok(watcher::Event::Apply(cm_a.clone())),
                 Ok(watcher::Event::Init),
                 Ok(watcher::Event::InitPage(vec![cm_b.clone()])),
-                Ok(watcher::Event::Ready),
+                Ok(watcher::Event::InitDone),
             ]),
         )
         .map(|_| ())

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -12,7 +12,8 @@ use crate::watcher;
 use async_stream::stream;
 use futures::{Stream, StreamExt};
 use std::hash::Hash;
-#[cfg(feature = "unstable-runtime-subscribe")] pub use store::store_shared;
+#[cfg(feature = "unstable-runtime-subscribe")]
+pub use store::store_shared;
 pub use store::{store, Store};
 
 /// Cache objects from a [`watcher()`] stream into a local [`Store`]
@@ -242,9 +243,9 @@ mod tests {
             store_w,
             stream::iter(vec![
                 Ok(watcher::Event::Apply(cm_a.clone())),
-                Ok(watcher::Event::RestartInit),
-                Ok(watcher::Event::RestartPage(vec![cm_b.clone()])),
-                Ok(watcher::Event::Restart),
+                Ok(watcher::Event::Init),
+                Ok(watcher::Event::InitPage(vec![cm_b.clone()])),
+                Ok(watcher::Event::Ready),
             ]),
         )
         .map(|_| ())

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -12,8 +12,7 @@ use crate::watcher;
 use async_stream::stream;
 use futures::{Stream, StreamExt};
 use std::hash::Hash;
-#[cfg(feature = "unstable-runtime-subscribe")]
-pub use store::store_shared;
+#[cfg(feature = "unstable-runtime-subscribe")] pub use store::store_shared;
 pub use store::{store, Store};
 
 /// Cache objects from a [`watcher()`] stream into a local [`Store`]

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -122,7 +122,7 @@ where
                 let obj = Arc::new(obj.clone());
                 self.buffer.insert(key, obj);
             }
-            watcher::Event::Ready => {
+            watcher::Event::InitDone => {
                 let mut store = self.store.write();
 
                 // Swap the buffer into the store
@@ -152,7 +152,7 @@ where
                     dispatcher.broadcast(obj_ref).await;
                 }
 
-                watcher::Event::Ready => {
+                watcher::Event::InitDone => {
                     let obj_refs: Vec<_> = {
                         let store = self.store.read();
                         store.keys().cloned().collect()

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -114,8 +114,7 @@ where
             watcher::Event::InitPage(new_objs) => {
                 let new_objs = new_objs
                     .iter()
-                    .map(|obj| (obj.to_object_ref(self.dyntype.clone()), Arc::new(obj.clone())))
-                    .collect::<AHashMap<_, _>>();
+                    .map(|obj| (obj.to_object_ref(self.dyntype.clone()), Arc::new(obj.clone())));
                 self.buffer.extend(new_objs);
             }
             watcher::Event::InitApply(obj) => {

--- a/kube-runtime/src/utils/event_flatten.rs
+++ b/kube-runtime/src/utils/event_flatten.rs
@@ -49,7 +49,7 @@ where
                     *me.queue = objs.into_iter();
                     continue;
                 }
-                Some(Ok(Event::Init | Event::Ready)) => continue,
+                Some(Ok(Event::Init | Event::InitDone)) => continue,
                 Some(Err(err)) => Some(Err(err)),
                 None => return Poll::Ready(None),
             };

--- a/kube-runtime/src/utils/event_flatten.rs
+++ b/kube-runtime/src/utils/event_flatten.rs
@@ -37,19 +37,19 @@ where
                 break Some(Ok(item));
             }
             let var_name = match ready!(me.stream.as_mut().poll_next(cx)) {
-                Some(Ok(Event::Apply(obj) | Event::RestartApply(obj))) => Some(Ok(obj)),
-                Some(Ok(Event::Delete(obj) | Event::RestartDelete(obj))) => {
+                Some(Ok(Event::Apply(obj) | Event::InitApply(obj))) => Some(Ok(obj)),
+                Some(Ok(Event::Delete(obj))) => {
                     if *me.emit_deleted {
                         Some(Ok(obj))
                     } else {
                         continue;
                     }
                 }
-                Some(Ok(Event::RestartPage(objs))) => {
+                Some(Ok(Event::InitPage(objs))) => {
                     *me.queue = objs.into_iter();
                     continue;
                 }
-                Some(Ok(Event::RestartInit | Event::Restart)) => continue,
+                Some(Ok(Event::Init | Event::Ready)) => continue,
                 Some(Err(err)) => Some(Err(err)),
                 None => return Poll::Ready(None),
             };
@@ -72,7 +72,7 @@ pub(crate) mod tests {
             Ok(Event::Apply(1)),
             Ok(Event::Delete(0)),
             Ok(Event::Apply(2)),
-            Ok(Event::RestartPage(vec![1, 2])),
+            Ok(Event::InitPage(vec![1, 2])),
             Err(Error::TooManyObjects),
             Ok(Event::Apply(2)),
         ]);

--- a/kube-runtime/src/utils/event_modify.rs
+++ b/kube-runtime/src/utils/event_modify.rs
@@ -56,7 +56,7 @@ pub(crate) mod test {
         let st = stream::iter([
             Ok(Event::Apply(0)),
             Err(Error::TooManyObjects),
-            Ok(Event::RestartPage(vec![10])),
+            Ok(Event::InitPage(vec![10])),
         ]);
         let mut ev_modify = pin!(EventModify::new(st, |x| {
             *x += 1;
@@ -75,7 +75,7 @@ pub(crate) mod test {
         let restarted = poll!(ev_modify.next());
         assert!(matches!(
             restarted,
-            Poll::Ready(Some(Ok(Event::RestartPage(vec)))) if vec == [11]
+            Poll::Ready(Some(Ok(Event::InitPage(vec)))) if vec == [11]
         ));
 
         assert!(matches!(poll!(ev_modify.next()), Poll::Ready(None)));

--- a/kube-runtime/src/utils/reflect.rs
+++ b/kube-runtime/src/utils/reflect.rs
@@ -74,9 +74,9 @@ pub(crate) mod test {
         let st = stream::iter([
             Ok(Event::Apply(foo.clone())),
             Err(Error::TooManyObjects),
-            Ok(Event::RestartInit),
-            Ok(Event::RestartPage(vec![foo, bar])),
-            Ok(Event::Restart),
+            Ok(Event::Init),
+            Ok(Event::InitPage(vec![foo, bar])),
+            Ok(Event::Ready),
         ]);
         let (reader, writer) = reflector::store();
 
@@ -97,17 +97,17 @@ pub(crate) mod test {
 
         assert!(matches!(
             poll!(reflect.next()),
-            Poll::Ready(Some(Ok(Event::RestartInit)))
+            Poll::Ready(Some(Ok(Event::Init)))
         ));
         assert_eq!(reader.len(), 1);
 
         let restarted = poll!(reflect.next());
-        assert!(matches!(restarted, Poll::Ready(Some(Ok(Event::RestartPage(_))))));
+        assert!(matches!(restarted, Poll::Ready(Some(Ok(Event::InitPage(_))))));
         assert_eq!(reader.len(), 1);
 
         assert!(matches!(
             poll!(reflect.next()),
-            Poll::Ready(Some(Ok(Event::Restart)))
+            Poll::Ready(Some(Ok(Event::Ready)))
         ));
         assert_eq!(reader.len(), 2);
 

--- a/kube-runtime/src/utils/reflect.rs
+++ b/kube-runtime/src/utils/reflect.rs
@@ -76,7 +76,7 @@ pub(crate) mod test {
             Err(Error::TooManyObjects),
             Ok(Event::Init),
             Ok(Event::InitPage(vec![foo, bar])),
-            Ok(Event::Ready),
+            Ok(Event::InitDone),
         ]);
         let (reader, writer) = reflector::store();
 
@@ -107,7 +107,7 @@ pub(crate) mod test {
 
         assert!(matches!(
             poll!(reflect.next()),
-            Poll::Ready(Some(Ok(Event::Ready)))
+            Poll::Ready(Some(Ok(Event::InitDone)))
         ));
         assert_eq!(reader.len(), 2);
 

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -48,28 +48,24 @@ pub enum Event<K> {
     Delete(K),
     /// The watch stream was restarted.
     ///
-    /// If using the `ListWatch` strategy, `RestartPage` events will follow this event.
-    /// If using the `StreamingList` strategy, this event will be followed by `RestartApply` or `RestartDelete` events.
-    RestartInit,
-    /// A page of objects was received during the restart.
+    /// If using the `ListWatch` strategy, this is a relist, and indicates that `InitlPage` events will follow.
+    /// If using the `StreamingList` strategy, this event will be followed by `InitApply` + `InitDelete` events.
+    Init,
+    /// A page of objects was received during `Init` with the `ListWatch` strategy.
     ///
-    /// This event is only returned when using the `ListWatch` strategy.
+    /// Any objects that were previously [`Applied`](Event::Applied) but are not listed in any of
+    /// the `InitPage` events should be assumed to have been [`Deleted`](Event::Deleted).
+    InitPage(Vec<K>),
+    /// An object received during `Init` with the `StreamingList` strategy.
     ///
-    /// Any objects that were previously [`Applied`](Event::Applied) but are not listed in any of the pages
-    /// should be assumed to have been [`Deleted`](Event::Deleted).
-    RestartPage(Vec<K>),
-    /// An object was added or modified during the initial watch.
-    ///
-    /// This event is only returned when using the `StreamingList` strategy.
-    RestartApply(K),
-    /// An object was deleted during the initial watch.
-    ///
-    /// This event is only returned when using the `StreamingList` strategy.
-    RestartDelete(K),
-    /// The restart is complete.
+    /// Any objects that were previously [`Applied`](Event::Applied) but are not listed in any of
+    /// the `InitAdd` events should be assumed to have been [`Deleted`](Event::Deleted).
+    InitApply(K),
+    /// The initialisation is complete.
     ///
     /// Should be used as a signal to replace the store contents atomically.
-    Restart,
+    /// No more `InitPage` / `InitApply` events will happen until the next `Init` event.
+    Ready,
 }
 
 impl<K> Event<K> {
@@ -79,13 +75,9 @@ impl<K> Event<K> {
     /// emitted individually.
     pub fn into_iter_applied(self) -> impl Iterator<Item = K> {
         match self {
-            Event::Apply(obj) => SmallVec::from_buf([obj]),
-            Event::Delete(_)
-            | Event::RestartInit
-            | Event::Restart
-            | Self::RestartApply(_)
-            | Self::RestartDelete(_) => SmallVec::new(),
-            Event::RestartPage(objs) => SmallVec::from_vec(objs),
+            Self::Apply(obj) => SmallVec::from_buf([obj]),
+            Self::Delete(_) | Self::Init | Self::Ready | Self::InitApply(_) => SmallVec::new(),
+            Self::InitPage(objs) => SmallVec::from_vec(objs),
         }
         .into_iter()
     }
@@ -97,11 +89,9 @@ impl<K> Event<K> {
     /// deleted objects.
     pub fn into_iter_touched(self) -> impl Iterator<Item = K> {
         match self {
-            Event::Apply(obj) | Event::Delete(obj) | Event::RestartApply(obj) | Event::RestartDelete(obj) => {
-                SmallVec::from_buf([obj])
-            }
-            Event::RestartInit | Event::Restart => SmallVec::new(),
-            Event::RestartPage(objs) => SmallVec::from_vec(objs),
+            Self::Apply(obj) | Self::Delete(obj) | Self::InitApply(obj) => SmallVec::from_buf([obj]),
+            Self::Init | Self::Ready => SmallVec::new(),
+            Self::InitPage(objs) => SmallVec::from_vec(objs),
         }
         .into_iter()
     }
@@ -126,11 +116,9 @@ impl<K> Event<K> {
     #[must_use]
     pub fn modify(mut self, mut f: impl FnMut(&mut K)) -> Self {
         match &mut self {
-            Event::Apply(obj) | Event::Delete(obj) | Event::RestartApply(obj) | Event::RestartDelete(obj) => {
-                (f)(obj)
-            }
-            Event::RestartInit | Event::Restart => {}
-            Event::RestartPage(objs) => {
+            Self::Apply(obj) | Self::Delete(obj) | Self::InitApply(obj) => (f)(obj),
+            Self::Init | Self::Ready => {} // markers, nothing to modify
+            Self::InitPage(objs) => {
                 for k in objs {
                     (f)(k)
                 }
@@ -487,9 +475,9 @@ where
 {
     match state {
         State::Empty => match wc.initial_list_strategy {
-            InitialListStrategy::ListWatch => (Some(Ok(Event::RestartInit)), State::InitPage {
-                continue_token: None,
-            }),
+            InitialListStrategy::ListWatch => {
+                (Some(Ok(Event::Init)), State::InitPage { continue_token: None })
+            }
             InitialListStrategy::StreamingList => match api.watch(&wc.to_watch_params(), "0").await {
                 Ok(stream) => (None, State::InitialWatch { stream }),
                 Err(err) => {
@@ -508,15 +496,19 @@ where
             match api.list(&lp).await {
                 Ok(list) => {
                     if let Some(continue_token) = list.metadata.continue_.filter(|s| !s.is_empty()) {
-                        (Some(Ok(Event::RestartPage(list.items))), State::InitPage {
-                            continue_token: Some(continue_token),
-                        })
+                        (
+                            Some(Ok(Event::InitPage(list.items))),
+                            State::InitPage {
+                                continue_token: Some(continue_token),
+                            },
+                        )
                     } else if let Some(resource_version) =
                         list.metadata.resource_version.filter(|s| !s.is_empty())
                     {
-                        (Some(Ok(Event::RestartPage(list.items))), State::InitPageDone {
-                            resource_version,
-                        })
+                        (
+                            Some(Ok(Event::InitPage(list.items))),
+                            State::InitPageDone { resource_version },
+                        )
                     } else {
                         (Some(Err(Error::NoResourceVersion)), State::Empty)
                     }
@@ -532,25 +524,29 @@ where
             }
         }
         State::InitPageDone { resource_version } => {
-            (Some(Ok(Event::Restart)), State::InitListed { resource_version })
+            (Some(Ok(Event::Ready)), State::InitListed { resource_version })
         }
         State::InitialWatch { mut stream } => {
             match stream.next().await {
                 Some(Ok(WatchEvent::Added(obj) | WatchEvent::Modified(obj))) => {
-                    (Some(Ok(Event::RestartApply(obj))), State::InitialWatch { stream })
+                    (Some(Ok(Event::InitApply(obj))), State::InitialWatch { stream })
                 }
-                Some(Ok(WatchEvent::Deleted(obj))) => {
-                    (Some(Ok(Event::RestartDelete(obj))), State::InitialWatch {
-                        stream,
-                    })
+                Some(Ok(WatchEvent::Deleted(_obj))) => {
+                    // Kubernetes claims these events are impossible
+                    // https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
+                    error!("got deleted event during initial watch. this is a bug");
+                    (None, State::InitialWatch { stream })
                 }
                 Some(Ok(WatchEvent::Bookmark(bm))) => {
                     let marks_initial_end = bm.metadata.annotations.contains_key("k8s.io/initial-events-end");
                     if marks_initial_end {
-                        (Some(Ok(Event::Restart)), State::Watching {
-                            resource_version: bm.metadata.resource_version,
-                            stream,
-                        })
+                        (
+                            Some(Ok(Event::Ready)),
+                            State::Watching {
+                                resource_version: bm.metadata.resource_version,
+                                stream,
+                            },
+                        )
                     } else {
                         (None, State::InitialWatch { stream })
                     }
@@ -582,19 +578,23 @@ where
         }
         State::InitListed { resource_version } => {
             match api.watch(&wc.to_watch_params(), &resource_version).await {
-                Ok(stream) => (None, State::Watching {
-                    resource_version,
-                    stream,
-                }),
+                Ok(stream) => (
+                    None,
+                    State::Watching {
+                        resource_version,
+                        stream,
+                    },
+                ),
                 Err(err) => {
                     if std::matches!(err, ClientErr::Api(ErrorResponse { code: 403, .. })) {
                         warn!("watch initlist error with 403: {err:?}");
                     } else {
                         debug!("watch initlist error: {err:?}");
                     }
-                    (Some(Err(Error::WatchStartFailed(err))), State::InitListed {
-                        resource_version,
-                    })
+                    (
+                        Some(Err(Error::WatchStartFailed(err))),
+                        State::InitListed { resource_version },
+                    )
                 }
             }
         }
@@ -607,10 +607,13 @@ where
                 if resource_version.is_empty() {
                     (Some(Err(Error::NoResourceVersion)), State::default())
                 } else {
-                    (Some(Ok(Event::Apply(obj))), State::Watching {
-                        resource_version,
-                        stream,
-                    })
+                    (
+                        Some(Ok(Event::Apply(obj))),
+                        State::Watching {
+                            resource_version,
+                            stream,
+                        },
+                    )
                 }
             }
             Some(Ok(WatchEvent::Deleted(obj))) => {
@@ -618,16 +621,22 @@ where
                 if resource_version.is_empty() {
                     (Some(Err(Error::NoResourceVersion)), State::default())
                 } else {
-                    (Some(Ok(Event::Delete(obj))), State::Watching {
-                        resource_version,
-                        stream,
-                    })
+                    (
+                        Some(Ok(Event::Delete(obj))),
+                        State::Watching {
+                            resource_version,
+                            stream,
+                        },
+                    )
                 }
             }
-            Some(Ok(WatchEvent::Bookmark(bm))) => (None, State::Watching {
-                resource_version: bm.metadata.resource_version,
-                stream,
-            }),
+            Some(Ok(WatchEvent::Bookmark(bm))) => (
+                None,
+                State::Watching {
+                    resource_version: bm.metadata.resource_version,
+                    stream,
+                },
+            ),
             Some(Ok(WatchEvent::Error(err))) => {
                 // HTTP GONE, means we have desynced and need to start over and re-list :(
                 let new_state = if err.code == 410 {
@@ -651,10 +660,13 @@ where
                 } else {
                     debug!("watcher error: {err:?}");
                 }
-                (Some(Err(Error::WatchFailed(err))), State::Watching {
-                    resource_version,
-                    stream,
-                })
+                (
+                    Some(Err(Error::WatchFailed(err))),
+                    State::Watching {
+                        resource_version,
+                        stream,
+                    },
+                )
             }
             None => (None, State::InitListed { resource_version }),
         },
@@ -817,16 +829,16 @@ pub fn watch_object<K: Resource + Clone + DeserializeOwned + Debug + Send + 'sta
 ) -> impl Stream<Item = Result<Option<K>>> + Send {
     watcher(api, Config::default().fields(&format!("metadata.name={name}"))).filter_map(|event| async {
         match event {
-            Ok(Event::Delete(_) | Event::RestartDelete(_)) => Some(Ok(None)),
+            Ok(Event::Delete(_)) => Some(Ok(None)),
             // We're filtering by object name, so getting more than one object means that either:
             // 1. The apiserver is accepting multiple objects with the same name, or
             // 2. The apiserver is ignoring our query
             // In either case, the K8s apiserver is broken and our API will return invalid data, so
             // we had better bail out ASAP.
-            Ok(Event::RestartPage(objs)) if objs.len() > 1 => Some(Err(Error::TooManyObjects)),
-            Ok(Event::RestartPage(mut objs)) => Some(Ok(objs.pop())),
-            Ok(Event::Apply(obj) | Event::RestartApply(obj)) => Some(Ok(Some(obj))),
-            Ok(Event::Restart | Event::RestartInit) => None,
+            Ok(Event::InitPage(objs)) if objs.len() > 1 => Some(Err(Error::TooManyObjects)),
+            Ok(Event::InitPage(mut objs)) => Some(Ok(objs.pop())),
+            Ok(Event::Apply(obj) | Event::InitApply(obj)) => Some(Ok(Some(obj))),
+            Ok(Event::Init | Event::Ready) => None,
             Err(err) => Some(Err(err)),
         }
     })

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -49,7 +49,7 @@ pub enum Event<K> {
     /// The watch stream was restarted.
     ///
     /// If using the `ListWatch` strategy, this is a relist, and indicates that `InitlPage` events will follow.
-    /// If using the `StreamingList` strategy, this event will be followed by `InitApply` + `InitDelete` events.
+    /// If using the `StreamingList` strategy, this event will be followed by `InitApply` events.
     Init,
     /// A page of objects was received during `Init` with the `ListWatch` strategy.
     ///
@@ -75,8 +75,8 @@ impl<K> Event<K> {
     /// emitted individually.
     pub fn into_iter_applied(self) -> impl Iterator<Item = K> {
         match self {
-            Self::Apply(obj) => SmallVec::from_buf([obj]),
-            Self::Delete(_) | Self::Init | Self::Ready | Self::InitApply(_) => SmallVec::new(),
+            Self::Apply(obj) | Self::InitApply(obj) => SmallVec::from_buf([obj]),
+            Self::Delete(_) | Self::Init | Self::Ready => SmallVec::new(),
             Self::InitPage(objs) => SmallVec::from_vec(objs),
         }
         .into_iter()


### PR DESCRIPTION
Follow-up to the unreleased #1494. Make names more easy to read and clear which one signifies start and which is end:

1. `Event::Init` now marks start, it is followed by one/more of:
2. `Event::InitApply` xor `EventInitPage`
3. `Event::InitDone` marks init complete

removed `Event::RestartDelete` because by docs it cannot happen
https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
> Provided that the WatchList [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) is enabled, this can be achieved by specifying sendInitialEvents=true as query string parameter in a watch request. If set, the API server **starts the watch stream with synthetic init events (of type ADDED)** to build the whole state of all existing objects followed by a [BOOKMARK event](https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks) (if requested via allowWatchBookmarks=true option). The bookmark event includes the resource version to which is synced. After sending the bookmark event, the API server continues as for any other watch request.

have inserted a big error in case they break their own docs for this alpha feature.