### PR TITLE
Implement client native object reference fetching

### DIFF
--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -86,6 +86,12 @@ pub enum Error {
     #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
     #[error("auth error: {0}")]
     Auth(#[source] crate::client::AuthError),
+
+    /// Error resolving resource reference
+    #[cfg(feature = "unstable-client")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-client")))]
+    #[error("Reference resolve error: {0}")]
+    RefResolve(String),
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

One of the ways custom resources are declaring dependency on each other, is by providing and ObjectReference field. Having one, still requires to manually prepare an appropriate client/api setup, extract namespace and name and validate the kind, api_version fields. This PR allows to make `ObjectReferences` native to client, and simplify their use. Additionally it provides similar handling for `OwnerReferences`.

## Solution

Implement a `client.fetch` method, allowing for the use of the following syntax:
```rust
// Actual ObjectReference content is intended to come from a CR
let svc: Service = client.fetch(&ObjectReference::default())
let node: Node = client.fetch(&OwnerReference::default()).await?;
let pod: Pod = client.fetch(&OwnerReference::default().within("default".into())).await?;
// Still the same pod
let pod: DynamicObject = client.fetch(&pod.object_ref(&())).await?;
let local_ref = LocalObjectReference {name: svc.name_any().into()};
let svc: Service = client.fetch(&local_ref.within(svc.namespace())).await?;
```
Current implementation also constants ability for specifying namespace for the `OwnerReference` from the resource. This is only allowed on non-cluster scoped resources.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
