### PR TITLE
Upgrade garde to 0.19 for examples

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,7 +24,7 @@ latest = ["k8s-openapi/latest"]
 [dev-dependencies]
 tokio-util.workspace = true
 assert-json-diff.workspace = true
-garde = { version = "0.18.0", default-features = false, features = ["derive"] }
+garde = { version = "0.19.0", default-features = false, features = ["derive"] }
 anyhow.workspace = true
 futures = { workspace = true, features = ["async-await"] }
 jsonpath-rust.workspace = true

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -204,7 +204,7 @@ async fn main() -> Result<()> {
         replicas: 1,
     });
     // using derived Validate rules locally:
-    assert!(fx.spec.validate(&()).is_err());
+    assert!(fx.spec.validate().is_err());
     // check rejection from apiserver (validation rules embedded in JsonSchema)
     match foos.create(&pp, &fx).await {
         Err(kube::Error::Api(ae)) => {


### PR DESCRIPTION
replaces #1512 due to a change in their api