### PR TITLE
runtime: remove deprecated default_backoff

### DIFF
--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -834,18 +834,6 @@ pub fn watch_object<K: Resource + Clone + DeserializeOwned + Debug + Send + 'sta
     })
 }
 
-/// Default watch [`Backoff`] inspired by Kubernetes' client-go.
-///
-/// This fn has been moved into [`DefaultBackoff`].
-#[must_use]
-#[deprecated(
-    since = "0.84.0",
-    note = "replaced by `watcher::DefaultBackoff`. This fn will be removed in 0.88.0."
-)]
-pub fn default_backoff() -> DefaultBackoff {
-    DefaultBackoff::default()
-}
-
 /// Default watcher backoff inspired by Kubernetes' client-go.
 ///
 /// The parameters currently optimize for being kind to struggling apiservers.


### PR DESCRIPTION
slated for removal 4 versions ago.

keeping in draft, and merging before next minor. EDIT: there's a patch branch now, so merging.