### PR TITLE
Fix watcher not fully paginating on Init

### DIFF
--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -499,9 +499,12 @@ where
                     last_bookmark,
                 });
             }
-            if let Some(resource_version) = last_bookmark {
-                // we have drained the last page - move on to next stage
-                return (Some(Ok(Event::InitDone)), State::InitListed { resource_version });
+            // check if we need to perform more pages
+            if continue_token.is_none() {
+                if let Some(resource_version) = last_bookmark {
+                    // we have drained the last page - move on to next stage
+                    return (Some(Ok(Event::InitDone)), State::InitListed { resource_version });
+                }
             }
             let mut lp = wc.to_list_params();
             lp.continue_token = continue_token;


### PR DESCRIPTION
- fixes #1524
- extends the mock test to cover more than one page (test as is here would fail on `main`)

will cherry-pick to a 0.92.1 branch and release from there
cannot believe i missed this :(