### PR TITLE
docs: point out that Kubeconfig client_key structs are base64 encoded

### DIFF
--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -195,6 +195,7 @@ pub struct AuthInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_certificate: Option<String>,
     /// PEM-encoded data from a client cert file for TLS. Overrides `client_certificate`
+    /// this key should be base64 encoded instead of the decode string data
     #[serde(rename = "client-certificate-data")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_certificate_data: Option<String>,
@@ -204,6 +205,7 @@ pub struct AuthInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_key: Option<String>,
     /// PEM-encoded data from a client key file for TLS. Overrides `client_key`
+    /// this key should be base64 encoded instead of the decode string data
     #[serde(rename = "client-key-data")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[serde(


### PR DESCRIPTION
client_key_data and  client_certificate_data should be base64 encoded

## Motivation
use not friendly like this 
https://github.com/kube-rs/kube/issues/1522


## Solution
modify the doc for user to see the format should use
