### PR TITLE
Add prelude for blanket and extension traits across sub-crates

### DIFF
--- a/kube-client/src/client/client_ext.rs
+++ b/kube-client/src/client/client_ext.rs
@@ -243,8 +243,9 @@ pub enum NamespaceError {
 /// ```no_run
 /// # use k8s_openapi::api::core::v1::Pod;
 /// # use k8s_openapi::api::core::v1::Service;
-/// # use kube::client::scope::{Cluster, Namespace};
-/// # use kube::{ResourceExt, api::ListParams};
+/// # use kube::client::scope::{Namespace, Cluster};
+/// # use kube::prelude::*;
+/// # use kube::api::ListParams;
 /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 /// # let client: kube::Client = todo!();
 /// let lp = ListParams::default();
@@ -264,8 +265,9 @@ impl Client {
     /// ```no_run
     /// # use k8s_openapi::api::rbac::v1::ClusterRole;
     /// # use k8s_openapi::api::core::v1::Service;
-    /// # use kube::client::scope::{Cluster, Namespace};
-    /// # use kube::{ResourceExt, api::GetParams};
+    /// # use kube::client::scope::{Namespace, Cluster};
+    /// # use kube::prelude::*;
+    /// # use kube::api::GetParams;
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
     /// let cr = client.get::<ClusterRole>("cluster-admin", &Cluster).await?;
@@ -296,8 +298,8 @@ impl Client {
     /// # use k8s_openapi::api::core::v1::ObjectReference;
     /// # use k8s_openapi::api::core::v1::LocalObjectReference;
     /// # use k8s_openapi::api::core::v1::{Node, Pod};
-    /// # use kube::{Resource, ResourceExt, api::GetParams};
-    /// # use kube::client::scope::NamespacedRef;
+    /// # use kube::api::GetParams;
+    /// # use kube::prelude::*;
     /// # use kube::api::DynamicObject;
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
@@ -355,8 +357,9 @@ impl Client {
     /// ```no_run
     /// # use k8s_openapi::api::core::v1::Pod;
     /// # use k8s_openapi::api::core::v1::Service;
-    /// # use kube::client::scope::{Cluster, Namespace};
-    /// # use kube::{ResourceExt, api::ListParams};
+    /// # use kube::client::scope::{Namespace, Cluster};
+    /// # use kube::prelude::*;
+    /// # use kube::api::ListParams;
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
     /// let lp = ListParams::default();
@@ -400,14 +403,17 @@ fn url_path(r: &ApiResource, namespace: Option<String>) -> String {
 
 #[cfg(test)]
 mod test {
-    use crate::client::client_ext::NamespacedRef;
-
-    use super::{
-        scope::{Cluster, Namespace},
-        Client, ListParams,
+    use crate::{
+        client::{
+            client_ext::NamespacedRef as _,
+            scope::{Cluster, Namespace},
+        },
+        Client,
     };
+
+    use super::ListParams;
     use k8s_openapi::api::core::v1::LocalObjectReference;
-    use kube_core::{DynamicObject, Resource, ResourceExt};
+    use kube_core::{DynamicObject, Resource as _, ResourceExt as _};
 
     #[tokio::test]
     #[ignore = "needs cluster (will list/get namespaces, pods, jobs, svcs, clusterroles)"]

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -275,9 +275,9 @@ impl<St: ?Sized> WatchStreamExt for St where St: Stream {}
 #[cfg(feature = "unstable-runtime-predicates")]
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::*;
-    use crate::predicates;
-    use futures::StreamExt;
+    use super::watcher;
+    use crate::{predicates, WatchStreamExt as _};
+    use futures::prelude::*;
     use k8s_openapi::api::core::v1::Pod;
     use kube_client::{Api, Resource};
 

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -181,6 +181,29 @@ pub use kube_core as core;
 #[cfg(all(feature = "derive", feature = "runtime"))]
 mod mock_tests;
 
+pub mod prelude {
+    //! A "prelude" for kube client crate. Reduces the number of duplicated imports.
+    //!
+    //! This prelude is similar to the standard library's prelude in that you'll
+    //! almost always want to import its entire contents, but unlike the
+    //! standard library's prelude you'll have to do so manually:
+    //!
+    //! ```
+    //! use kube::prelude::*;
+    //! ```
+    //!
+    //! The prelude may grow over time as additional items see ubiquitous use.
+
+    #[allow(unreachable_pub)] pub use crate::client::ConfigExt as _;
+
+    #[cfg(feature = "unstable-client")] pub use crate::client::scope::NamespacedRef;
+
+    #[allow(unreachable_pub)] pub use crate::core::PartialObjectMetaExt as _;
+    pub use crate::{core::crd::CustomResourceExt as _, Resource as _, ResourceExt as _};
+
+    #[cfg(feature = "runtime")] pub use crate::runtime::utils::WatchStreamExt as _;
+}
+
 // Tests that require a cluster and the complete feature set
 // Can be run with `cargo test -p kube --lib --features=runtime,derive -- --ignored`
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Slight follow up on proposed changes in https://github.com/kube-rs/kube/pull/1511#discussion_r1630973243

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Include prelude into `kube` crate, exporting all blanket implementations, such as:
- `client::ConfigExt` - client configuration options.
- `client::scope::NamespacedRef` - namespace scoped resource fetching via `client.fetch` (under `unstable-client` feature).
- `core::PartialObjectMetaExt` - useful for cache size reduction in cases when only watched object type and metadata are required.
- `core::crd::CustomResourceExt` - providing methods such as `.crd()` for custom resource generation.
- `core::crd::{Resource, ResourceExt}` - base and extension functionality on top of any valid kubernetes resource.
- `runtime::utils::WatchStreamExt` - utility methods for watcher streams, providing predicate capabilities, stream sharing with `reflect` and `reflect_shared` (under `runtime` feature)

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
