### PR TITLE
Fix docs mentioning Event::Restarted

### DIFF
--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -748,7 +748,7 @@ where
 /// [resource version](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes)
 /// that we have seen on the stream. If this is successful then the stream is simply resumed from where it left off.
 /// If this fails because the resource version is no longer valid then we start over with a new stream, starting with
-/// an [`Event::Restarted`]. The internals mechanics of recovery should be considered an implementation detail.
+/// an [`Event::Init`]. The internals mechanics of recovery should be considered an implementation detail.
 pub fn watcher<K: Resource + Clone + DeserializeOwned + Debug + Send + 'static>(
     api: Api<K>,
     watcher_config: Config,
@@ -811,7 +811,7 @@ pub fn watcher<K: Resource + Clone + DeserializeOwned + Debug + Send + 'static>(
 /// [resource version](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes)
 /// that we have seen on the stream. If this is successful then the stream is simply resumed from where it left off.
 /// If this fails because the resource version is no longer valid then we start over with a new stream, starting with
-/// an [`Event::Restarted`]. The internals mechanics of recovery should be considered an implementation detail.
+/// an [`Event::Init`]. The internals mechanics of recovery should be considered an implementation detail.
 #[allow(clippy::module_name_repetitions)]
 pub fn metadata_watcher<K: Resource + Clone + DeserializeOwned + Debug + Send + 'static>(
     api: Api<K>,


### PR DESCRIPTION
Replace leftovers of Event::Restarted with
Event::Init in watcher code documentation.

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

The code documentation in [watcher.rs](https://github.com/kube-rs/kube/blob/main/kube-runtime/src/watcher.rs) still mentions events of type `Event::Restarted`, although it seems not to exist anymore since https://github.com/kube-rs/kube/pull/1499 was merged. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

Replace both occurrences of `Event::Restarted` with `Event::Init`.
