### PR TITLE
Missed doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The `runtime` module exports the `kube_runtime` crate and contains higher level 
 
 ### Watchers
 
-A low level streaming interface (similar to informers) that presents `Applied`, `Deleted` or `Restarted` events.
+A streaming interface (similar to informers) that presents [`watcher::Event`](https://docs.rs/kube/latest/kube/runtime/watcher/enum.Event.html)s and does automatic relists under the hood.
 
 ```rust
 let api = Api::<Pod>::default_namespaced(client);
@@ -113,7 +113,7 @@ while let Some(event) = stream.try_next().await? {
 }
 ```
 
-NB: the plain items in a `watcher` stream are different from `WatchEvent`. If you are following along to "see what changed", you should flatten it with one of the utilities from [`WatchStreamExt`](https://docs.rs/kube/latest/kube/runtime/trait.WatchStreamExt.html), such as `applied_objects`.
+Note the base items from a `watcher` stream are an abstraction above the native `WatchEvent` to allow for store buffering. If you are following along to "see what changed", you can use utilities from [`WatchStreamExt`](https://docs.rs/kube/latest/kube/runtime/trait.WatchStreamExt.html), such as `applied_objects` to get a more conventional stream.
 
 ## Reflectors
 

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -14,7 +14,7 @@
 //! - [`runtime`] with a [`Controller`](crate::runtime::Controller) / [`watcher`](crate::runtime::watcher()) / [`reflector`](crate::runtime::reflector::reflector) / [`Store`](crate::runtime::reflector::Store)
 //! - [`core`] with generics from `apimachinery`
 //!
-//! You can use each of these as you need with the help of the [exported features](https://github.com/kube-rs/kube/blob/main/kube/Cargo.toml#L18).
+//! You can use each of these as you need with the help of the [exported features](https://kube.rs/features/).
 //!
 //! # Using the Client
 //! ```no_run


### PR DESCRIPTION
broken references to `Restarted`, outdated references to flattening, mispointing links.
follow-up to #1546