### PR TITLE
add missing feature gate on ConfigExt for no-features build

### DIFF
--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -194,7 +194,9 @@ pub mod prelude {
     //!
     //! The prelude may grow over time as additional items see ubiquitous use.
 
-    #[allow(unreachable_pub)] pub use crate::client::ConfigExt as _;
+    #[cfg(feature = "client")]
+    #[allow(unreachable_pub)]
+    pub use crate::client::ConfigExt as _;
 
     #[cfg(feature = "unstable-client")] pub use crate::client::scope::NamespacedRef;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

Fixes #1548 

## Solution

In `kube/src/lib.rs:L197`,

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

### Before

```rust
pub mod prelude {
    #[allow(unreachable_pub)] pub use crate::client::ConfigExt as _;
    ...
}
```

### After

```rust
pub mod prelude {
    #[cfg(feature = "client")]
    #[allow(unreachable_pub)]
    pub use crate::client::ConfigExt as _;
    ...
}
```
