### PR TITLE
cargo-deny-action from 1 to 2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check ${{ matrix.checks }}
 

--- a/deny.toml
+++ b/deny.toml
@@ -10,9 +10,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # these are deprecated, but not super helpful for us
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-version-field-optional
 # remove them when we have to
-unmaintained = "warn"
 yanked = "warn"
-notice = "warn"
 
 
 [licenses]


### PR DESCRIPTION
replaces #1553.
removes 2 deprecated attributes that causes build to fail only on top of the automated pr.