### PR TITLE
fix new doc clippy lint

### DIFF
--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -543,8 +543,8 @@ impl AuthInfo {
     }
 }
 
-/// Cluster stores information to connect Kubernetes cluster used with auth plugins
-/// that have `provideClusterInfo`` enabled.
+/// Connection information for auth plugins that have `provideClusterInfo` enabled.
+///
 /// This is a copy of [`kube::config::Cluster`] with certificate_authority passed as bytes without the path.
 /// Taken from [clientauthentication/types.go#Cluster](https://github.com/kubernetes/client-go/blob/477cb782cf024bc70b7239f0dca91e5774811950/pkg/apis/clientauthentication/types.go#L73-L129)
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -1,4 +1,7 @@
-//! Kubernetes configuration objects from `~/.kube/config`, `$KUBECONFIG`, or the [cluster environment](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod).
+//! Kubernetes configuration objects.
+//!
+//! Reads locally from `$KUBECONFIG` or `~/.kube/config`,
+//! and in-cluster from the [pod environment](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/#accessing-the-api-from-within-a-pod).
 //!
 //! # Usage
 //! The [`Config`] has several constructors plus logic to infer environment.


### PR DESCRIPTION
complaints about https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph as can be seen in other prs: https://github.com/kube-rs/kube/pull/1566/files