### PR TITLE
WIP: Native client apply support

### DIFF
--- a/kube-client/src/client/client_ext.rs
+++ b/kube-client/src/client/client_ext.rs
@@ -410,7 +410,7 @@ impl Client {
     /// let pod: Pod = client.get("some_pod", &Namespace::from("default")).await?;
     /// let pp = &PatchParams::apply("controller").force();
     /// // Perform an apply patch on the resource
-    /// client.apply(pod, pp).await?;
+    /// client.apply(&pod, pp).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -451,7 +451,7 @@ impl Client {
     /// let pod: Pod = client.get("some_pod", &Namespace::from("default")).await?;
     /// let pp = &PatchParams::apply("controller").force();
     /// // Perform an apply patch on the resource status
-    /// client.apply(pod, pp).await?;
+    /// client.apply_status(&pod, pp).await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -92,6 +92,12 @@ pub enum Error {
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-client")))]
     #[error("Reference resolve error: {0}")]
     RefResolve(String),
+
+    /// Error resolving resource name
+    #[cfg(feature = "unstable-client")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-client")))]
+    #[error("Resource has no name")]
+    NameResolve,
 }
 
 #[derive(Error, Debug)]

--- a/kube-core/src/metadata.rs
+++ b/kube-core/src/metadata.rs
@@ -28,10 +28,10 @@ impl TypeMeta {
     /// assert_eq!(type_meta.kind, "PodList");
     /// assert_eq!(type_meta.api_version, "v1");
     /// ```
-    pub fn list<K: Resource<DynamicType = ()>>() -> Self {
+    pub fn list<K: Resource<DynamicType = impl Default>>() -> Self {
         TypeMeta {
-            api_version: K::api_version(&()).into(),
-            kind: K::kind(&()).to_string() + "List",
+            api_version: K::api_version(&Default::default()).into(),
+            kind: K::kind(&Default::default()).to_string() + "List",
         }
     }
 

--- a/kube-core/src/metadata.rs
+++ b/kube-core/src/metadata.rs
@@ -45,10 +45,10 @@ impl TypeMeta {
     /// assert_eq!(type_meta.kind, "Pod");
     /// assert_eq!(type_meta.api_version, "v1");
     /// ```
-    pub fn resource<K: Resource<DynamicType = ()>>() -> Self {
+    pub fn resource<K: Resource<DynamicType = impl Default>>() -> Self {
         TypeMeta {
-            api_version: K::api_version(&()).into(),
-            kind: K::kind(&()).into(),
+            api_version: K::api_version(&Default::default()).into(),
+            kind: K::kind(&Default::default()).into(),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
Add support for resource apply using `unstable-client` implementation.

This implementation addresses the need for https://pkg.go.dev/k8s.io/client-go/applyconfigurations, where the need for a custom DSL is justified by limitations of default values for the go structures.

It seems with exception of some resources where API is not designed to use SSA patch, and a separate patch definition needed, this abstraction can simplify usage of the SSA in general cases. 

Equivalent structs in rust allow to distinguish a `nil` value from an `””` (empty string), as a pointer value is wrapped in `Option<V>`, thus rendering current state of structures sufficient to address limitation in native to object SSA patch usage.

```rust
None -> nil
Some(“”) -> “”
Some(“other”) -> “other”
```

However there is a second problem with `TypeMeta`. When constructing an object from a type, like `&Pod::default()`, the structure does not contain `type` meta from the beginning, although generated or `k8s-openapi` definitions have all the necessary information for constructing the field.

```rust
R::kind() -> kind
R::api_version() -> apiVersion
```

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Provide a native to the client `.apply` and `.apply_status` methods. These can be used to pass a subset of resource changes to be applied via SSA patch.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
