### PR TITLE
Update hyper-rustls minimum version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ http-body-util = "0.1.2"
 hyper = "1.2.0"
 hyper-util = "0.1.3"
 hyper-openssl = "0.10.2"
-hyper-rustls = { version = "0.27.0", default-features = false }
+hyper-rustls = { version = "0.27.1", default-features = false }
 hyper-socks2 = { version = "0.9.0", default-features = false }
 hyper-timeout = "0.5.1"
 json-patch = "2.0.0"


### PR DESCRIPTION
## Motivation

I updated `kube-client` in an existing project to v0.94.0, and got the compilation errors <code>error[E0432]: unresolved import \`hyper_rustls::FixedServerNameResolver\`</code> and ``error[E0599]: no method named `with_server_name_resolver` found for struct `HttpsConnectorBuilder` in the current scope``.

## Solution

This struct and method were introduced in [hyper-rustls v0.27.1](https://github.com/rustls/hyper-rustls/releases/tag/v%2F0.27.1), so I bumped the minimum dependency version accordingly.