### PR TITLE
Stabilise runtime predicates

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -12,9 +12,8 @@ keywords = ["kubernetes", "runtime", "reflector", "watcher", "controller"]
 categories = ["web-programming::http-client", "caching", "network-programming"]
 
 [features]
-unstable-runtime = ["unstable-runtime-subscribe", "unstable-runtime-predicates", "unstable-runtime-stream-control", "unstable-runtime-reconcile-on"]
+unstable-runtime = ["unstable-runtime-subscribe", "unstable-runtime-stream-control", "unstable-runtime-reconcile-on"]
 unstable-runtime-subscribe = []
-unstable-runtime-predicates = []
 unstable-runtime-stream-control = []
 unstable-runtime-reconcile-on = []
 

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -35,6 +35,5 @@ pub use scheduler::scheduler;
 pub use utils::WatchStreamExt;
 pub use watcher::{metadata_watcher, watcher};
 
-#[cfg(feature = "unstable-runtime-predicates")]
 pub use utils::{predicates, Predicate};
 pub use wait::conditions;

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -4,6 +4,7 @@ mod backoff_reset_timer;
 pub(crate) mod delayed_init;
 mod event_flatten;
 mod event_modify;
+mod predicate;
 mod reflect;
 mod stream_backoff;
 mod watch_ext;

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -4,7 +4,6 @@ mod backoff_reset_timer;
 pub(crate) mod delayed_init;
 mod event_flatten;
 mod event_modify;
-#[cfg(feature = "unstable-runtime-predicates")] mod predicate;
 mod reflect;
 mod stream_backoff;
 mod watch_ext;
@@ -12,7 +11,6 @@ mod watch_ext;
 pub use backoff_reset_timer::ResetTimerBackoff;
 pub use event_flatten::EventFlatten;
 pub use event_modify::EventModify;
-#[cfg(feature = "unstable-runtime-predicates")]
 pub use predicate::{predicates, Predicate, PredicateFilter};
 pub use reflect::Reflect;
 pub use stream_backoff::StreamBackoff;

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -97,8 +97,6 @@ pub trait WatchStreamExt: Stream {
     /// Common use case for this is to avoid repeat events for status updates
     /// by filtering on [`predicates::generation`](crate::predicates::generation).
     ///
-    /// **NB**: This is constructor requires an [`unstable`](https://github.com/kube-rs/kube/blob/main/kube-runtime/Cargo.toml#L17-L21) feature.
-    ///
     /// ## Usage
     /// ```no_run
     /// # use std::pin::pin;

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -1,7 +1,10 @@
-#[cfg(feature = "unstable-runtime-predicates")]
-use crate::utils::predicate::{Predicate, PredicateFilter};
 use crate::{
-    utils::{event_flatten::EventFlatten, event_modify::EventModify, stream_backoff::StreamBackoff},
+    utils::{
+        event_flatten::EventFlatten,
+        event_modify::EventModify,
+        predicate::{Predicate, PredicateFilter},
+        stream_backoff::StreamBackoff,
+    },
     watcher,
 };
 use kube_client::Resource;
@@ -116,7 +119,6 @@ pub trait WatchStreamExt: Stream {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(feature = "unstable-runtime-predicates")]
     fn predicate_filter<K, P>(self, predicate: P) -> PredicateFilter<Self, K, P>
     where
         Self: Stream<Item = Result<K, watcher::Error>> + Sized,
@@ -272,7 +274,6 @@ pub trait WatchStreamExt: Stream {
 impl<St: ?Sized> WatchStreamExt for St where St: Stream {}
 
 // Compile tests
-#[cfg(feature = "unstable-runtime-predicates")]
 #[cfg(test)]
 pub(crate) mod tests {
     use super::watcher;


### PR DESCRIPTION
These are unlikely to undergo much changes (and they are basically a completely separate part in the codebase). This should be an easy feature cleanup in runtime, and one less need for unstable-runtime for common setups (i use this all the time).

This removes the `kube_runtime/unstable-runtime-predicates` feature and thus removes the need for users to use `kube/unstable-runtime` if they only are using `predicates`.

Public api wise; this exposes the `Predicate` trait, the `WatchStreamExt::predicate_filter` fn, and by necessity the (unconstructible) `PredicateFilter` stream wrapper type.

(Not planning on merging until near the release cycle in case any more fixes come in).
Idea via https://github.com/kube-rs/controller-rs/pull/50#issuecomment-2345879240