### PR TITLE
remove using HTTP PROXY from environment variable

### DIFF
--- a/kube-client/src/config/file_loader.rs
+++ b/kube-client/src/config/file_loader.rs
@@ -117,8 +117,6 @@ impl ConfigLoader {
         let nonempty = |o: Option<String>| o.filter(|s| !s.is_empty());
 
         if let Some(proxy) = nonempty(self.cluster.proxy_url.clone())
-            .or_else(|| nonempty(std::env::var("HTTP_PROXY").ok()))
-            .or_else(|| nonempty(std::env::var("http_proxy").ok()))
             .or_else(|| nonempty(std::env::var("HTTPS_PROXY").ok()))
             .or_else(|| nonempty(std::env::var("https_proxy").ok()))
         {


### PR DESCRIPTION
remove using HTTP PROXY from environment variable, matching kubectl's behavior.

I found out that kubectl doesn't care for the `HTTP_PROXY` environment variable, probably for security reasons (a way to have plaintext requests?)
