### PR TITLE
Bump `secrecy` to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ rand = "0.8.3"
 rustls = { version = "0.23.0", default-features = false }
 rustls-pemfile = "2.0.0"
 schemars = "0.8.6"
-secrecy = "0.8.0"
+secrecy = "0.10.2"
 serde = "1.0.130"
 serde_json = "1.0.68"
 serde-value = "0.7.0"

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -73,7 +73,7 @@ tower-http = { workspace = true, features = ["auth", "map-response-body", "trace
 hyper-timeout = { workspace = true, optional = true }
 tame-oauth = { workspace = true, features = ["gcp"], optional = true }
 rand = { workspace = true, optional = true }
-secrecy = { workspace = true, features = ["alloc", "serde"] }
+secrecy = { workspace = true }
 tracing = { workspace = true, features = ["log"], optional = true }
 hyper-openssl = { workspace = true, features = ["client-legacy"], optional = true }
 form_urlencoded = { workspace = true, optional = true }

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -144,7 +144,7 @@ impl TokenFile {
 
     /// Get the cached token. Returns `None` if it's expiring.
     fn cached_token(&self) -> Option<&str> {
-        (!self.is_expiring()).then(|| self.token.expose_secret().as_ref())
+        (!self.is_expiring()).then(|| self.token.expose_secret())
     }
 
     /// Get a token. Reloads from file if the cached token is expiring.

--- a/kube-client/src/client/auth/oidc.rs
+++ b/kube-client/src/client/auth/oidc.rs
@@ -187,7 +187,7 @@ impl Oidc {
     /// Retrieve the ID token. If the stored ID token is or will soon be expired, try refreshing it first.
     pub async fn id_token(&mut self) -> Result<String, errors::Error> {
         if self.token_valid()? {
-            return Ok(self.id_token.expose_secret().clone());
+            return Ok(self.id_token.expose_secret().to_string());
         }
 
         let id_token = self.refresher.as_mut().map_err(|e| e.clone())?.id_token().await?;
@@ -394,8 +394,8 @@ impl Refresher {
             }
             AuthStyle::Params => {
                 params.extend([
-                    ("client_id", self.client_id.expose_secret().as_str()),
-                    ("client_secret", self.client_secret.expose_secret().as_str()),
+                    ("client_id", self.client_id.expose_secret()),
+                    ("client_secret", self.client_secret.expose_secret()),
                 ]);
             }
         };

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -149,7 +149,7 @@ where
     D: Deserializer<'de>,
 {
     match Option::<String>::deserialize(deserializer) {
-        Ok(Some(secret)) => Ok(Some(SecretString::new(secret))),
+        Ok(Some(secret)) => Ok(Some(SecretString::new(secret.into()))),
         Ok(None) => Ok(None),
         Err(e) => Err(e),
     }
@@ -533,10 +533,7 @@ impl AuthInfo {
         // TODO Shouldn't error when `self.client_key_data.is_none() && self.client_key.is_none()`
 
         load_from_base64_or_file(
-            &self
-                .client_key_data
-                .as_ref()
-                .map(|secret| secret.expose_secret().as_str()),
+            &self.client_key_data.as_ref().map(|secret| secret.expose_secret()),
             &self.client_key,
         )
         .map_err(KubeconfigError::LoadClientKey)

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -661,7 +661,6 @@ mod tests {
 
     use super::*;
     use serde_json::{json, Value};
-    use std::str::FromStr;
 
     #[test]
     fn kubeconfig_merge() {
@@ -670,7 +669,7 @@ mod tests {
             auth_infos: vec![NamedAuthInfo {
                 name: "red-user".into(),
                 auth_info: Some(AuthInfo {
-                    token: Some(SecretString::from_str("first-token").unwrap()),
+                    token: Some(SecretString::new("first-token".into())),
                     ..Default::default()
                 }),
             }],
@@ -682,7 +681,7 @@ mod tests {
                 NamedAuthInfo {
                     name: "red-user".into(),
                     auth_info: Some(AuthInfo {
-                        token: Some(SecretString::from_str("second-token").unwrap()),
+                        token: Some(SecretString::new("second-token".into())),
                         username: Some("red-user".into()),
                         ..Default::default()
                     }),
@@ -690,7 +689,7 @@ mod tests {
                 NamedAuthInfo {
                     name: "green-user".into(),
                     auth_info: Some(AuthInfo {
-                        token: Some(SecretString::from_str("new-token").unwrap()),
+                        token: Some(SecretString::new("new-token".into())),
                         ..Default::default()
                     }),
                 },
@@ -710,8 +709,8 @@ mod tests {
                 .unwrap()
                 .token
                 .as_ref()
-                .map(|t| t.expose_secret().to_string()),
-            Some("first-token".to_string())
+                .map(|t| t.expose_secret()),
+            Some("first-token")
         );
         // Even if it's not conflicting
         assert_eq!(merged.auth_infos[0].auth_info.as_ref().unwrap().username, None);
@@ -907,7 +906,7 @@ password: kube_rs
         let authinfo_debug_output = format!("{authinfo:?}");
         let expected_output = "AuthInfo { \
         username: Some(\"user\"), \
-        password: Some(Secret([REDACTED alloc::string::String])), \
+        password: Some(SecretBox<str>([REDACTED])), \
         token: None, token_file: None, client_certificate: None, \
         client_certificate_data: None, client_key: None, \
         client_key_data: None, impersonate: None, \


### PR DESCRIPTION
Updates `secrecy` manually, replacing dependabot pr #1586 by removing now default hard features, and fixes to breaking changes.

changes noted from https://github.com/iqlusioninc/crates/blob/main/secrecy/CHANGELOG.md#0100-2024-09-17

`SecretString` internals is now a `SecretBox`, and this needs an `.into()` call to convert to a `Box<S>`.
See https://docs.rs/secrecy/0.10.2/secrecy/type.SecretString.html

This brings with it a small breaking change to the disk configuration format (since we [export types containing the secrecy types](https://docs.rs/kube/latest/kube/config/struct.AuthInfo.html#structfield.token)).