### PR TITLE
clippy fixes

### DIFF
--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -148,7 +148,6 @@ where
     /// ```no_run
     /// # use kube::Api;
     /// use k8s_openapi::api::core::v1::Pod;
-
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
     /// let pods: Api<Pod> = Api::namespaced(client, "apps");
@@ -262,10 +261,8 @@ where
     /// use kube::api::{Api, DeleteParams};
     /// use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiexts;
     /// use apiexts::CustomResourceDefinition;
-
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client: kube::Client = todo!();
-
     /// let crds: Api<CustomResourceDefinition> = Api::all(client);
     /// crds.delete("foos.clux.dev", &DeleteParams::default()).await?
     ///     .map_left(|o| println!("Deleting CRD: {:?}", o.status))

--- a/kube-core/src/duration.rs
+++ b/kube-core/src/duration.rs
@@ -171,7 +171,7 @@ impl<'de> Deserialize<'de> for Duration {
         D: Deserializer<'de>,
     {
         struct Visitor;
-        impl<'de> de::Visitor<'de> for Visitor {
+        impl de::Visitor<'_> for Visitor {
             type Value = Duration;
 
             fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -100,7 +100,6 @@ impl<T: Clone> ObjectList<T> {
     ///     *elem = 2;
     ///     println!("First element: {:?}", elem); // prints "First element: 2"
     /// }
-
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
         self.items.iter_mut()
     }

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -332,6 +332,7 @@ const APPLIER_REQUEUE_BUF_SIZE: usize = 100;
 /// This is the "hard-mode" version of [`Controller`], which allows you some more customization
 /// (such as triggering from arbitrary [`Stream`]s), at the cost of being a bit more verbose.
 #[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::type_complexity)]
 pub fn applier<K, QueueStream, ReconcilerFut, Ctx>(
     mut reconciler: impl FnMut(Arc<K>, Arc<Ctx>) -> ReconcilerFut,
     error_policy: impl Fn(Arc<K>, &ReconcilerFut::Error, Arc<Ctx>) -> Action,

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -1,4 +1,6 @@
-use super::{dispatcher::Dispatcher, Lookup, ObjectRef, ReflectHandle};
+use super::{dispatcher::Dispatcher, Lookup, ObjectRef};
+#[cfg(feature = "unstable-runtime-subscribe")]
+use crate::reflector::ReflectHandle;
 use crate::{
     utils::delayed_init::{self, DelayedInit},
     watcher,

--- a/kube-runtime/src/scheduler.rs
+++ b/kube-runtime/src/scheduler.rs
@@ -65,7 +65,7 @@ impl<T, R: Stream> Scheduler<T, R> {
     }
 }
 
-impl<'a, T: Hash + Eq + Clone, R> SchedulerProj<'a, T, R> {
+impl<T: Hash + Eq + Clone, R> SchedulerProj<'_, T, R> {
     /// Attempt to schedule a message into the queue.
     ///
     /// If the message is already in the queue then the earlier `request.run_at` takes precedence.
@@ -147,7 +147,7 @@ pub struct Hold<'a, T, R> {
     scheduler: Pin<&'a mut Scheduler<T, R>>,
 }
 
-impl<'a, T, R> Stream for Hold<'a, T, R>
+impl<T, R> Stream for Hold<'_, T, R>
 where
     T: Eq + Hash + Clone,
     R: Stream<Item = ScheduleRequest<T>>,
@@ -177,7 +177,7 @@ pub struct HoldUnless<'a, T, R, C> {
     can_take_message: C,
 }
 
-impl<'a, T, R, C> Stream for HoldUnless<'a, T, R, C>
+impl<T, R, C> Stream for HoldUnless<'_, T, R, C>
 where
     T: Eq + Hash + Clone,
     R: Stream<Item = ScheduleRequest<T>>,

--- a/kube-runtime/src/utils/delayed_init.rs
+++ b/kube-runtime/src/utils/delayed_init.rs
@@ -61,7 +61,7 @@ impl<T: Clone + Send + Sync> DelayedInit<T> {
 // Using a manually implemented future because we don't want to hold the lock across poll calls
 // since that would mean that an unpolled writer would stall all other tasks from being able to poll it
 struct Get<'a, T>(&'a DelayedInit<T>);
-impl<'a, T> Future for Get<'a, T>
+impl<T> Future for Get<'_, T>
 where
     T: Clone,
 {


### PR DESCRIPTION
CI red again from new clippy versions and new lints.

- clippy +nightly --fix on runtime + core
- one manual allow in runtime
- two stray warnings (excess whitespace)