### PR TITLE
Add ObjectRef::from as alias for ::from_obj

### DIFF
--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -168,11 +168,17 @@ where
     }
 
     #[must_use]
-    pub fn from_obj(obj: &K) -> Self
-    where
-        K: Lookup,
-    {
+    pub fn from_obj(obj: &K) -> Self {
         obj.to_object_ref(Default::default())
+    }
+}
+
+impl<K: Lookup> From<&K> for ObjectRef<K>
+where
+    K::DynamicType: Default,
+{
+    fn from(obj: &K) -> Self {
+        Self::from_obj(obj)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

This allows things that rely on `From`/`Into` to perform the conversion implicitly. For example, we (@stackabletech) use `ObjectRef`s to normalize object path formatting in errors. When using SNAFU, this would simplify the error annotations from:

```rust
do_stuff().with_context(|_| ErrorCaseSnafu { pod: ObjectRef::from_obj(&pod) })?
```

to:

```rust
do_stuff().context(ErrorCaseSnafu { pod: &pod })?
```

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

The `From` impl just delegates to `::from_obj()`. Maybe it would even make sense to deprecate `::from_obj`, but I think it makes sense to keep it to highlight it as a first-class operation.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
