### PR TITLE
upgrade to hashbrown 0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ educe = { version = "0.6.0", default-features = false }
 either = "1.6.1"
 form_urlencoded = "1.2.0"
 futures = { version = "0.3.17", default-features = false }
-hashbrown = "0.14.0"
+hashbrown = "0.15.0"
 home = "0.5.4"
 http = "1.1.0"
 http-body = "1.0.0"

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,8 @@ allow = [
     # Pulled in via aws_lc_rs when using rustls-tls and aws-lc-rs features
     # https://openssl-library.org/source/license/index.html
     "OpenSSL",
+    # Pulled in via hashbrown through its foldhash dependency
+    "Zlib",
 ]
 
 exceptions = [
@@ -63,10 +65,6 @@ multiple-versions = "deny"
 
 [[bans.skip]]
 name = "rustls-native-certs"
-
-[[bans.skip]]
-# blocked on us swapping out serde_yaml
-name = "hashbrown"
 
 [[bans.skip]]
 # base64 did some annoying breaking changes


### PR DESCRIPTION
Hashbrown 0.15.0 has reworked the entry API which requires the use of a raw entry builder to replace keys.

Closes https://github.com/kube-rs/kube/issues/1597

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Upgrade to hashbrown 0.15.0
<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

As a result of a reworked entry API in hashbrown 0.15.0, we cannot longer use the `replace_key()` function to replace an entry's key directly. This uses a raw entry builder for the HashMap instead.
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
