### PR TITLE
fix(kube-runtime): setup backoff with builder pattern

### DIFF
--- a/kube-runtime/src/utils/backoff_reset_timer.rs
+++ b/kube-runtime/src/utils/backoff_reset_timer.rs
@@ -83,10 +83,4 @@ mod tests {
             tokio::time::Instant::now().into_std()
         }
     }
-
-    impl<B: Backoff> ResetTimerBackoff<B> {
-        pub fn get_backoff(&self) -> &B {
-            &self.backoff
-        }
-    }
 }

--- a/kube-runtime/src/utils/backoff_reset_timer.rs
+++ b/kube-runtime/src/utils/backoff_reset_timer.rs
@@ -83,4 +83,10 @@ mod tests {
             tokio::time::Instant::now().into_std()
         }
     }
+
+    impl<B: Backoff> ResetTimerBackoff<B> {
+        pub fn get_backoff(&self) -> &B {
+            &self.backoff
+        }
+    }
 }

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -898,14 +898,13 @@ type Strategy = ResetTimerBackoff<ExponentialBackoff>;
 impl Default for DefaultBackoff {
     fn default() -> Self {
         Self(ResetTimerBackoff::new(
-            backoff::ExponentialBackoff {
-                initial_interval: Duration::from_millis(800),
-                max_interval: Duration::from_secs(30),
-                randomization_factor: 1.0,
-                multiplier: 2.0,
-                max_elapsed_time: None,
-                ..ExponentialBackoff::default()
-            },
+            backoff::ExponentialBackoffBuilder::new()
+            .with_initial_interval(Duration::from_millis(800))
+            .with_max_interval(Duration::from_secs(30))
+            .with_randomization_factor(1.0)
+            .with_multiplier(2.0)
+            .with_max_elapsed_time(None)
+            .build(),
             Duration::from_secs(120),
         ))
     }

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -899,12 +899,12 @@ impl Default for DefaultBackoff {
     fn default() -> Self {
         Self(ResetTimerBackoff::new(
             backoff::ExponentialBackoffBuilder::new()
-            .with_initial_interval(Duration::from_millis(800))
-            .with_max_interval(Duration::from_secs(30))
-            .with_randomization_factor(1.0)
-            .with_multiplier(2.0)
-            .with_max_elapsed_time(None)
-            .build(),
+                .with_initial_interval(Duration::from_millis(800))
+                .with_max_interval(Duration::from_secs(30))
+                .with_randomization_factor(1.0)
+                .with_multiplier(2.0)
+                .with_max_elapsed_time(None)
+                .build(),
             Duration::from_secs(120),
         ))
     }

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -919,13 +919,3 @@ impl Backoff for DefaultBackoff {
         self.0.reset()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn backoff_start_interval() {
-        let default_backoff = super::DefaultBackoff::default().0;
-        let default_backoff = default_backoff.get_backoff();
-        assert_eq!(default_backoff.current_interval, default_backoff.initial_interval);
-    }
-}

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -919,3 +919,13 @@ impl Backoff for DefaultBackoff {
         self.0.reset()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn backoff_start_interval() {
+        let default_backoff = super::DefaultBackoff::default().0;
+        let default_backoff = default_backoff.get_backoff();
+        assert_eq!(default_backoff.current_interval, default_backoff.initial_interval);
+    }
+}


### PR DESCRIPTION
Filling the fields manually and leaving the current_interval out meant that the current_interval is set to its default rather than track the initial_interval
The builder addresses this for us by setting it on the build method.

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->
Noticed that the current_interval of the watcher backoff is left empty, which may lead to unintended behaviour.
Granted the difference is currently minimal (800ms to 500ms)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
Using the builder pattern method from the backoff crate can be used to set the fields appropriately rather than simply the default value.
