### PR TITLE
Feature: Allow to pass selectableFields for CRD definition

### DIFF
--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
     shortname = "f",
     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#,
-    selectablefield = "spec.name"
+    selectable = "spec.name"
 )]
 pub struct MyFoo {
     name: String,

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -23,7 +23,8 @@ use serde::{Deserialize, Serialize};
     derive = "Default",
     shortname = "f",
     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
-    printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
+    printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#,
+    selectablefield = "spec.name"
 )]
 pub struct MyFoo {
     name: String,
@@ -118,6 +119,9 @@ fn verify_crd() {
                 "type": "string"
               }
             ],
+            "selectableFields": [{
+              "jsonPath": "spec.name",
+            }],
             "schema": {
               "openAPIV3Schema": {
                 "description": "Custom resource representing a Foo",

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -32,8 +32,8 @@ struct KubeAttrs {
     shortnames: Vec<String>,
     #[darling(multiple, rename = "printcolumn")]
     printcolums: Vec<String>,
-    #[darling(multiple, rename = "selectablefield")]
-    selectable_fields: Vec<String>,
+    #[darling(multiple)]
+    selectable: Vec<String>,
     scale: Option<String>,
     #[darling(default)]
     crates: Crates,
@@ -161,7 +161,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         categories,
         shortnames,
         printcolums,
-        selectable_fields,
+        selectable,
         scale,
         crates:
             Crates {
@@ -356,7 +356,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
 
     // Compute a bunch of crd props
     let printers = format!("[ {} ]", printcolums.join(",")); // hacksss
-    let fields: Vec<String> = selectable_fields
+    let fields: Vec<String> = selectable
         .iter()
         .map(|s| format!(r#"{{ "jsonPath": "{s}" }}"#))
         .collect();
@@ -405,7 +405,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         }
     };
 
-    let selectable = if !selectable_fields.is_empty() {
+    let selectable = if !selectable.is_empty() {
         quote! { "selectableFields": fields, }
     } else {
         quote! {}

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -32,6 +32,8 @@ struct KubeAttrs {
     shortnames: Vec<String>,
     #[darling(multiple, rename = "printcolumn")]
     printcolums: Vec<String>,
+    #[darling(multiple, rename = "selectablefield")]
+    selectable_fields: Vec<String>,
     scale: Option<String>,
     #[darling(default)]
     crates: Crates,
@@ -159,6 +161,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         categories,
         shortnames,
         printcolums,
+        selectable_fields,
         scale,
         crates:
             Crates {
@@ -353,6 +356,8 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
 
     // Compute a bunch of crd props
     let printers = format!("[ {} ]", printcolums.join(",")); // hacksss
+    let selectable_fields: Vec<String> = selectable_fields.iter().map(|s| format!(r#"{{ "jsonPath": "{s}" }}"#)).collect();
+    let selectable_fields = format!("[ {} ]", selectable_fields.join(","));
     let scale_code = if let Some(s) = scale { s } else { "".to_string() };
 
     // Ensure it generates for the correct CRD version (only v1 supported now)
@@ -420,6 +425,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
                         "openAPIV3Schema": schema,
                     },
                     "additionalPrinterColumns": columns,
+                    "selectableFields": selectable_fields,
                     "subresources": subres,
                 }],
             }
@@ -432,6 +438,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
 
             fn crd() -> #apiext::CustomResourceDefinition {
                 let columns : Vec<#apiext::CustomResourceColumnDefinition> = #serde_json::from_str(#printers).expect("valid printer column json");
+                let selectable_fields : Vec<#apiext::SelectableField> = #serde_json::from_str(#selectable_fields).expect("valid selectableField column json");
                 let scale: Option<#apiext::CustomResourceSubresourceScale> = if #scale_code.is_empty() {
                     None
                 } else {

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -166,6 +166,7 @@ mod resource;
 ///     shortname = "f",
 ///     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
 ///     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
+/// 
 /// )]
 /// #[serde(rename_all = "camelCase")]
 /// struct FooSpec {

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -166,7 +166,7 @@ mod resource;
 ///     shortname = "f",
 ///     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
 ///     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
-/// 
+///
 /// )]
 /// #[serde(rename_all = "camelCase")]
 /// struct FooSpec {

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -165,8 +165,8 @@ mod resource;
 ///     plural = "feetz",
 ///     shortname = "f",
 ///     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
-///     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
-///
+///     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#,
+///     selectable = "spec.replicasCount"
 /// )]
 /// #[serde(rename_all = "camelCase")]
 /// struct FooSpec {

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -140,6 +140,10 @@ mod resource;
 /// ## `#[kube(category = "apps")]`
 /// Add a single category to `crd.spec.names.categories`.
 ///
+/// ## `#[kube(selectable = "fieldSelectorPath")]`
+/// Adds a Kubernetes >=1.30 `selectableFields` property ([KEP-4358](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/4358-custom-resource-field-selectors/README.md)) to the schema.
+/// Unlocks `kubectl get kind --field-selector fieldSelectorPath`.
+///
 /// ## `#[kube(doc = "description")]`
 /// Sets the description of the schema in the generated CRD. If not specified
 /// `Auto-generated derived type for {customResourceName} via CustomResource` will be used instead.

--- a/kube-derive/tests/crd_enum_test.rs
+++ b/kube-derive/tests/crd_enum_test.rs
@@ -78,6 +78,7 @@ fn test_crd_schema_matches_expected() {
             "versions": [
               {
                 "additionalPrinterColumns": [],
+                "selectableFields": [],
                 "name": "v1",
                 "schema": {
                   "openAPIV3Schema": {

--- a/kube-derive/tests/crd_enum_test.rs
+++ b/kube-derive/tests/crd_enum_test.rs
@@ -78,7 +78,6 @@ fn test_crd_schema_matches_expected() {
             "versions": [
               {
                 "additionalPrinterColumns": [],
-                "selectableFields": [],
                 "name": "v1",
                 "schema": {
                   "openAPIV3Schema": {

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -18,7 +18,9 @@ use std::collections::{HashMap, HashSet};
     doc = "Custom resource representing a Foo",
     derive = "PartialEq",
     shortname = "fo",
-    shortname = "f"
+    shortname = "f",
+    selectablefield = ".spec.nonNullable",
+    selectablefield = ".spec.nullable",
 )]
 #[serde(rename_all = "camelCase")]
 struct FooSpec {
@@ -198,6 +200,11 @@ fn test_crd_schema_matches_expected() {
                         "served": true,
                         "storage": true,
                         "additionalPrinterColumns": [],
+                        "selectableFields": [{
+                            "jsonPath": ".spec.nonNullable"
+                        }, {
+                            "jsonPath": ".spec.nullable"
+                        }],
                         "schema": {
                             "openAPIV3Schema": {
                                 "description": "Custom resource representing a Foo",

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -19,8 +19,8 @@ use std::collections::{HashMap, HashSet};
     derive = "PartialEq",
     shortname = "fo",
     shortname = "f",
-    selectablefield = ".spec.nonNullable",
-    selectablefield = ".spec.nullable",
+    selectable = ".spec.nonNullable",
+    selectable = ".spec.nullable"
 )]
 #[serde(rename_all = "camelCase")]
 struct FooSpec {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
KEP [4358](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/4358-custom-resource-field-selectors/README.md) allows to define new field - `selectableFields` within the CRD schema, enabled by default ([beta](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#crd-selectable-fields)) in 1.31.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Expose the `selectable` key in `kube()` macro, allowing to provide a set of values into generated `CRD`.

Example:
```rust

#[kube(
    group = "clux.dev",
    version = "v1",
    kind = "Foo",
    namespaced,
    selectable = "spec.key",
    selectable = "spec.name"
)]

```

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
