### PR TITLE
Add a compile_error if setting selectable fields on K8s < 1.30

### DIFF
--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -411,6 +411,17 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         quote! {}
     };
 
+    // Known constraints that are hard to enforce elsewhere
+    let compile_constraints = if !selectable.is_empty() {
+        quote! {
+            #k8s_openapi::k8s_if_le_1_29! {
+                compile_error!("selectable fields require Kubernetes >= 1.30");
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     let jsondata = quote! {
         #schemagen
 
@@ -493,6 +504,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
 
     // Concat output
     quote! {
+        #compile_constraints
         #root_obj
         #impl_resource
         #impl_default


### PR DESCRIPTION
As it is not available on older Kubernetes versions.

Doing this now causes:

```sh
error: selectable fields require Kubernetes >= 1.30
  --> examples/crd_derive.rs:12:10
   |
12 | #[derive(CustomResource, Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone, JsonSchema)]
   |          ^^^^^^^^^^^^^^
   |
   = note: this error originates in the derive macro `CustomResource` (in Nightly builds, run with -Z macro-backtrace for more info)
```

(can be seen if hacking examples/cargo.toml to use `earliest` from k8s-openapi)

Follow-up to #1610