### PR TITLE
Add a `kube::k8s` re-export module for stable apis

### DIFF
--- a/examples/cert_check.rs
+++ b/examples/cert_check.rs
@@ -1,12 +1,10 @@
 use std::borrow::Cow;
 
-use k8s_openapi::{
-    api::core::v1::{ConfigMap, Namespace as Ns},
-    NamespaceResourceScope,
-};
 use kube::{
     api::ObjectMeta,
     client::scope::{Cluster, Namespace},
+    core::NamespaceResourceScope,
+    k8s::corev1::{ConfigMap, Namespace as Ns},
     Client, Resource,
 };
 use serde::{Deserialize, Serialize};
@@ -20,7 +18,7 @@ struct CaConfigMapData {
     ca_crt: String,
 }
 
-// Method 1 :: inherit resource implementation from k8s_openapi's ConfigMap
+// Method 1 :: inherit resource implementation from the official ConfigMap
 #[derive(Resource, Serialize, Deserialize, Debug, Clone)]
 #[resource(inherit = ConfigMap)]
 struct CaConfigMap {

--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -3,9 +3,9 @@
 
 use anyhow::Result;
 use futures::StreamExt;
-use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
     api::{Api, ObjectMeta, Patch, PatchParams, Resource},
+    k8s::corev1::ConfigMap,
     runtime::{
         controller::{Action, Config, Controller},
         watcher,

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -8,10 +8,10 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tracing::*;
 
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::{
     api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams, ResourceExt},
     core::crd::CustomResourceExt,
+    k8s::apiextensionsv1::CustomResourceDefinition,
     Client, CustomResource,
 };
 

--- a/examples/crd_apply.rs
+++ b/examples/crd_apply.rs
@@ -4,11 +4,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::*;
 
-use apiexts::CustomResourceDefinition;
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiexts;
-
 use kube::{
     api::{Api, Patch, PatchParams, ResourceExt},
+    k8s::apiextensionsv1::CustomResourceDefinition,
     runtime::wait::{await_condition, conditions},
     Client, CustomResource, CustomResourceExt,
 };

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -1,6 +1,6 @@
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::{
     core::object::{HasSpec, HasStatus},
+    k8s::metav1::Condition,
     CustomResource, CustomResourceExt, Resource,
 };
 use schemars::JsonSchema;

--- a/examples/crd_derive_multi.rs
+++ b/examples/crd_derive_multi.rs
@@ -1,7 +1,7 @@
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::{
     api::{Api, Patch, PatchParams},
     core::crd::merge_crds,
+    k8s::apiextensionsv1::CustomResourceDefinition,
     runtime::wait::{await_condition, conditions},
     Client, CustomResource, CustomResourceExt, ResourceExt,
 };

--- a/examples/crd_derive_no_schema.rs
+++ b/examples/crd_derive_no_schema.rs
@@ -1,7 +1,5 @@
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
-    CustomResourceDefinition, CustomResourceValidation, JSONSchemaProps,
-};
-use kube_derive::CustomResource;
+use apiext::{CustomResourceDefinition, CustomResourceValidation, JSONSchemaProps};
+use kube::{k8s::apiextensionsv1 as apiext, CustomResource};
 use serde::{Deserialize, Serialize};
 
 /// CustomResource with manually implemented schema

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -1,11 +1,11 @@
 use anyhow::{anyhow, Result};
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::{
     api::{
         Api, ApiResource, DeleteParams, DynamicObject, GroupVersionKind, Patch, PatchParams, PostParams,
         WatchEvent, WatchParams,
     },
+    k8s::apiextensionsv1::CustomResourceDefinition,
     runtime::wait::{await_condition, conditions},
     Client, CustomResource, CustomResourceExt,
 };

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -1,9 +1,9 @@
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use tracing::*;
 
 use kube::{
     api::{Api, Patch, PatchParams, ResourceExt},
+    k8s::apiextensionsv1::CustomResourceDefinition,
     runtime::{reflector, watcher, WatchStreamExt},
     Client, CustomResource, CustomResourceExt,
 };

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -1,6 +1,5 @@
 use hyper_util::rt::TokioExecutor;
 // Minimal custom client example.
-use k8s_openapi::api::core::v1::Pod;
 use tower::BoxError;
 use tracing::*;
 
@@ -20,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
         .service(hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(https));
     let client = Client::new(service, config.default_namespace);
 
-    let pods: Api<Pod> = Api::default_namespaced(client);
+    let pods: Api<kube::k8s::corev1::Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {
         info!("{}", p.name_any());
     }

--- a/examples/custom_client_tls.rs
+++ b/examples/custom_client_tls.rs
@@ -2,7 +2,6 @@ use hyper_util::rt::TokioExecutor;
 // Custom client supporting both openssl-tls and rustls-tls
 // Must enable `rustls-tls` feature to run this.
 // Run with `USE_RUSTLS=1` to pick rustls.
-use k8s_openapi::api::core::v1::Pod;
 use tower::ServiceBuilder;
 use tracing::*;
 
@@ -32,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
         Client::new(service, config.default_namespace)
     };
 
-    let pods: Api<Pod> = Api::default_namespaced(client);
+    let pods: Api<kube::k8s::corev1::Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {
         info!("{}", p.name_any());
     }

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -2,7 +2,6 @@
 use http::{Request, Response};
 use hyper::body::Incoming;
 use hyper_util::rt::TokioExecutor;
-use k8s_openapi::api::core::v1::Pod;
 use std::time::Duration;
 use tower::{BoxError, ServiceBuilder};
 use tower_http::{decompression::DecompressionLayer, trace::TraceLayer};
@@ -59,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
 
     let client = Client::new(service, config.default_namespace);
 
-    let pods: Api<Pod> = Api::default_namespaced(client);
+    let pods: Api<kube::k8s::corev1::Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {
         info!("{}", p.name_any());
     }

--- a/examples/dynamic_jsonpath.rs
+++ b/examples/dynamic_jsonpath.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Error};
 use jsonpath_rust::JsonPathInst;
-use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{Api, ListParams},
+    k8s::corev1::Pod,
     Client,
 };
 use tracing::*;

--- a/examples/dynamic_pod.rs
+++ b/examples/dynamic_pod.rs
@@ -1,6 +1,6 @@
 use kube::{
     api::{Api, ApiResource, NotUsed, Object, ResourceExt},
-    Client,
+    k8s::corev1::Pod,
 };
 use serde::Deserialize;
 use tracing::*;
@@ -8,9 +8,9 @@ use tracing::*;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
-    // Here we replace heavy type k8s_openapi::api::core::v1::PodSpec with
+    // A slimmed down k8s::corev1::PodSpec
     #[derive(Clone, Deserialize, Debug)]
     struct PodSpecSimple {
         containers: Vec<ContainerSimple>,
@@ -22,8 +22,8 @@ async fn main() -> anyhow::Result<()> {
     }
     type PodSimple = Object<PodSpecSimple, NotUsed>;
 
-    // Here we simply steal the type info from k8s_openapi, but we could create this from scratch.
-    let ar = ApiResource::erase::<k8s_openapi::api::core::v1::Pod>(&());
+    // Steal the type info, to avoid hand-typing / using discovery.
+    let ar = ApiResource::erase::<Pod>(&());
 
     let pods: Api<PodSimple> = Api::default_namespaced_with(client, &ar);
     for p in pods.list(&Default::default()).await? {

--- a/examples/errorbounded_configmap_watcher.rs
+++ b/examples/errorbounded_configmap_watcher.rs
@@ -1,8 +1,8 @@
 use futures::prelude::*;
-use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
     api::{Api, ObjectMeta},
     core::DeserializeGuard,
+    k8s::corev1::ConfigMap,
     runtime::{reflector::ObjectRef, watcher, WatchStreamExt},
     Client, Resource,
 };

--- a/examples/event_watcher.rs
+++ b/examples/event_watcher.rs
@@ -1,12 +1,9 @@
 use std::pin::pin;
 
 use futures::TryStreamExt;
-use k8s_openapi::{
-    api::{core::v1::ObjectReference, events::v1::Event},
-    apimachinery::pkg::apis::meta::v1::Time,
-    chrono::Utc,
-};
+use k8s_openapi::chrono::Utc;
 use kube::{
+    k8s::{corev1::ObjectReference, eventsv1::Event, metav1::Time},
     runtime::{watcher, WatchStreamExt},
     Api, Client, ResourceExt,
 };

--- a/examples/job_api.rs
+++ b/examples/job_api.rs
@@ -1,6 +1,6 @@
-use k8s_openapi::api::batch::v1::Job;
 use kube::{
     api::{Api, DeleteParams, PostParams},
+    k8s::batchv1::Job,
     runtime::wait::{await_condition, conditions},
     Client,
 };

--- a/examples/kubectl.rs
+++ b/examples/kubectl.rs
@@ -3,11 +3,12 @@
 //! with labels and namespace selectors supported.
 use anyhow::{bail, Context, Result};
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::{apimachinery::pkg::apis::meta::v1::Time, chrono::Utc};
+use k8s_openapi::chrono::Utc;
 use kube::{
     api::{Api, DynamicObject, ListParams, Patch, PatchParams, ResourceExt},
     core::GroupVersionKind,
     discovery::{ApiCapabilities, ApiResource, Discovery, Scope},
+    k8s::metav1::Time,
     runtime::{
         wait::{await_condition, conditions::is_deleted},
         watcher, WatchStreamExt,

--- a/examples/log_stream.rs
+++ b/examples/log_stream.rs
@@ -1,11 +1,8 @@
 use futures::{AsyncBufReadExt, TryStreamExt};
-use k8s_openapi::{
-    api::core::v1::Pod,
-    chrono::{DateTime, Utc},
-};
+use k8s_openapi::chrono::{DateTime, Utc};
 use kube::{
     api::{Api, LogParams},
-    Client,
+    k8s::corev1::Pod,
 };
 use tracing::*;
 
@@ -39,7 +36,7 @@ struct App {
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let app: App = clap::Parser::parse();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
     info!("Fetching logs for {:?}", app.pod);
     let pods: Api<Pod> = Api::default_namespaced(client);

--- a/examples/multi_watcher.rs
+++ b/examples/multi_watcher.rs
@@ -1,19 +1,18 @@
 use futures::{stream, StreamExt, TryStreamExt};
-use k8s_openapi::api::{
-    apps::v1::Deployment,
-    core::v1::{ConfigMap, Secret},
-};
 use kube::{
     api::{Api, ResourceExt},
+    k8s::{
+        appsv1::Deployment,
+        corev1::{ConfigMap, Secret},
+    },
     runtime::{watcher, WatchStreamExt},
-    Client,
 };
 use tracing::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
     let deploys: Api<Deployment> = Api::default_namespaced(client.clone());
     let cms: Api<ConfigMap> = Api::default_namespaced(client.clone());

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -1,18 +1,17 @@
 use std::pin::pin;
 
 use futures::TryStreamExt;
-use k8s_openapi::api::core::v1::Node;
 use kube::{
     api::{Api, ResourceExt},
+    k8s::corev1::Node,
     runtime::{predicates, reflector, watcher, Predicate, WatchStreamExt},
-    Client,
 };
 use tracing::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
     let nodes: Api<Node> = Api::all(client.clone());
     let wc = watcher::Config::default()

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -1,10 +1,10 @@
 use std::pin::pin;
 
 use futures::TryStreamExt;
-use k8s_openapi::api::core::v1::{Event, Node};
 use kube::{
     api::{Api, ListParams, ResourceExt},
     client::{scope, Client},
+    k8s::corev1::{Event, Node},
     runtime::{watcher, WatchStreamExt},
 };
 use tracing::*;

--- a/examples/pod_api.rs
+++ b/examples/pod_api.rs
@@ -1,17 +1,16 @@
-use k8s_openapi::api::core::v1::Pod;
 use serde_json::json;
 use tracing::*;
 
 use kube::{
     api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams, ResourceExt},
+    k8s::corev1::Pod,
     runtime::wait::{await_condition, conditions::is_pod_running},
-    Client,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
     // Manage pods
     let pods: Api<Pod> = Api::default_namespaced(client);

--- a/examples/pod_attach.rs
+++ b/examples/pod_attach.rs
@@ -2,19 +2,17 @@ use std::io::Write;
 use tracing::*;
 
 use futures::{join, stream, StreamExt, TryStreamExt};
-use k8s_openapi::api::core::v1::Pod;
 
 use kube::{
-    api::{
-        Api, AttachParams, AttachedProcess, DeleteParams, PostParams, ResourceExt, WatchEvent, WatchParams,
-    },
-    Client,
+    api::{AttachParams, AttachedProcess, DeleteParams, PostParams, WatchEvent, WatchParams},
+    k8s::corev1::Pod,
+    Api, ResourceExt,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
     info!("Creating a Pod that outputs numbers for 15s");
     let p: Pod = serde_json::from_value(serde_json::json!({

--- a/examples/pod_cp.rs
+++ b/examples/pod_cp.rs
@@ -1,5 +1,5 @@
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::api::core::v1::Pod;
+use kube::k8s::corev1::Pod;
 use tracing::*;
 
 use kube::{

--- a/examples/pod_evict.rs
+++ b/examples/pod_evict.rs
@@ -1,17 +1,16 @@
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::api::core::v1::Pod;
 use serde_json::json;
 use tracing::*;
 
 use kube::{
     api::{Api, EvictParams, PostParams, ResourceExt, WatchEvent, WatchParams},
-    Client,
+    k8s::corev1::Pod,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
     // Create a Job
     let pod_name = "empty-pod";

--- a/examples/pod_exec.rs
+++ b/examples/pod_exec.rs
@@ -1,19 +1,17 @@
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::api::core::v1::Pod;
 use tracing::*;
 
 use kube::{
-    api::{
-        Api, AttachParams, AttachedProcess, DeleteParams, PostParams, ResourceExt, WatchEvent, WatchParams,
-    },
-    Client,
+    api::{Api, AttachParams, AttachedProcess, DeleteParams, PostParams, WatchEvent, WatchParams},
+    k8s::corev1::Pod,
+    ResourceExt,
 };
 use tokio::io::AsyncWriteExt;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
     let p: Pod = serde_json::from_value(serde_json::json!({
         "apiVersion": "v1",

--- a/examples/pod_log_kubelet_debug.rs
+++ b/examples/pod_log_kubelet_debug.rs
@@ -1,5 +1,4 @@
 use futures::TryStreamExt;
-use k8s_openapi::api::core::v1::Pod;
 use tracing::*;
 
 use futures::AsyncBufReadExt;
@@ -7,6 +6,7 @@ use hyper::Uri;
 use kube::{
     api::{Api, DeleteParams, ResourceExt},
     core::{kubelet_debug::KubeletDebugParams, subresource::LogParams},
+    k8s::corev1::Pod,
     Client, Config,
 };
 use serde_json::json;

--- a/examples/pod_paged.rs
+++ b/examples/pod_paged.rs
@@ -1,7 +1,6 @@
-use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{Api, ListParams, ResourceExt},
-    Client,
+    k8s::corev1::Pod,
 };
 use tracing::*;
 
@@ -14,7 +13,7 @@ const PAGE_SIZE: u32 = 5;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
     let api = Api::<Pod>::default_namespaced(client);
 
     let mut continue_token: Option<String> = None;

--- a/examples/pod_portforward.rs
+++ b/examples/pod_portforward.rs
@@ -1,9 +1,9 @@
 use futures::StreamExt;
-use k8s_openapi::api::core::v1::Pod;
 use tracing::*;
 
 use kube::{
     api::{Api, DeleteParams, PostParams},
+    k8s::corev1::Pod,
     runtime::wait::{await_condition, conditions::is_pod_running},
     Client, ResourceExt,
 };

--- a/examples/pod_portforward_bind.rs
+++ b/examples/pod_portforward_bind.rs
@@ -10,9 +10,9 @@ use tokio::{
 use tokio_stream::wrappers::TcpListenerStream;
 use tracing::*;
 
-use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{Api, DeleteParams, PostParams},
+    k8s::corev1::Pod,
     runtime::wait::{await_condition, conditions::is_pod_running},
     Client, ResourceExt,
 };

--- a/examples/pod_portforward_hyper_http.rs
+++ b/examples/pod_portforward_hyper_http.rs
@@ -1,8 +1,8 @@
 use bytes::Bytes;
 use hyper_util::rt::TokioIo;
-use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{Api, DeleteParams, PostParams},
+    k8s::corev1::Pod,
     runtime::wait::{await_condition, conditions::is_pod_running},
     Client, ResourceExt,
 };

--- a/examples/pod_reflector.rs
+++ b/examples/pod_reflector.rs
@@ -1,11 +1,10 @@
 use std::pin::pin;
 
 use futures::TryStreamExt;
-use k8s_openapi::api::core::v1::Pod;
 use kube::{
-    api::Api,
+    k8s::corev1::Pod,
     runtime::{predicates, reflector, watcher, WatchStreamExt},
-    Client, ResourceExt,
+    Api, Client, ResourceExt,
 };
 use tracing::*;
 

--- a/examples/pod_shell.rs
+++ b/examples/pod_shell.rs
@@ -1,16 +1,15 @@
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::api::core::v1::Pod;
 use tracing::*;
 
 use kube::{
     api::{Api, AttachParams, DeleteParams, PostParams, ResourceExt, WatchEvent, WatchParams},
-    Client,
+    k8s::corev1::Pod,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
     let p: Pod = serde_json::from_value(serde_json::json!({
         "apiVersion": "v1",

--- a/examples/pod_shell_crossterm.rs
+++ b/examples/pod_shell_crossterm.rs
@@ -1,10 +1,9 @@
 use futures::{channel::mpsc::Sender, SinkExt, StreamExt};
-use k8s_openapi::api::core::v1::Pod;
 
 use kube::{
     api::{Api, AttachParams, AttachedProcess, DeleteParams, PostParams, ResourceExt, TerminalSize},
+    k8s::corev1::Pod,
     runtime::wait::{await_condition, conditions::is_pod_running},
-    Client,
 };
 #[cfg(unix)] use tokio::signal;
 use tokio::{io::AsyncWriteExt, select};
@@ -39,7 +38,7 @@ async fn handle_terminal_size(mut channel: Sender<TerminalSize>) -> Result<(), a
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     let p: Pod = serde_json::from_value(serde_json::json!({

--- a/examples/pod_watcher.rs
+++ b/examples/pod_watcher.rs
@@ -1,16 +1,15 @@
 use futures::prelude::*;
-use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{Api, ResourceExt},
+    k8s::corev1::Pod,
     runtime::{watcher, WatchStreamExt},
-    Client,
 };
 use tracing::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
     let api = Api::<Pod>::default_namespaced(client);
     let use_watchlist = std::env::var("WATCHLIST").map(|s| s == "1").unwrap_or(false);
     let wc = if use_watchlist {

--- a/examples/request_raw.rs
+++ b/examples/request_raw.rs
@@ -6,8 +6,11 @@
 //! By default, node summary metrics data is fetched by Kubernetes from the
 //! kubelet. The kubelet itself supports statistics access through CRI, or
 //! through cAdvisor.
-use k8s_openapi::{api::core::v1::Node, apimachinery::pkg::api::resource::Quantity};
-use kube::{api::ListParams, Api, ResourceExt};
+use kube::{
+    api::ListParams,
+    k8s::{apimachinery::pkg::api::resource::Quantity, corev1::Node},
+    Api, ResourceExt,
+};
 use serde::Deserialize;
 
 #[tokio::main]

--- a/examples/request_raw.rs
+++ b/examples/request_raw.rs
@@ -6,11 +6,8 @@
 //! By default, node summary metrics data is fetched by Kubernetes from the
 //! kubelet. The kubelet itself supports statistics access through CRI, or
 //! through cAdvisor.
-use kube::{
-    api::ListParams,
-    k8s::{apimachinery::pkg::api::resource::Quantity, corev1::Node},
-    Api, ResourceExt,
-};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use kube::{api::ListParams, k8s::corev1::Node, Api, ResourceExt};
 use serde::Deserialize;
 
 #[tokio::main]

--- a/examples/secret_reflector.rs
+++ b/examples/secret_reflector.rs
@@ -1,9 +1,8 @@
 use futures::TryStreamExt;
-use k8s_openapi::api::core::v1::Secret;
 use kube::{
     api::{Api, ResourceExt},
+    k8s::corev1::Secret,
     runtime::{reflector, reflector::Store, watcher, WatchStreamExt},
-    Client,
 };
 use std::collections::BTreeMap;
 use tracing::*;
@@ -51,7 +50,7 @@ fn spawn_periodic_reader(reader: Store<Secret>) {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let client = Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
 
     let secrets: Api<Secret> = Api::default_namespaced(client);
     let wc = watcher::Config::default().timeout(10); // short watch timeout in this example

--- a/examples/secret_syncer.rs
+++ b/examples/secret_syncer.rs
@@ -4,10 +4,10 @@
 // If you actually want to clean up other Kubernetes objects then you should use `ownerReferences` instead and let
 // k8s garbage collect the children.
 use futures::StreamExt;
-use k8s_openapi::api::core::v1::{ConfigMap, Secret};
 use kube::{
     api::{Api, DeleteParams, ObjectMeta, Patch, PatchParams, Resource},
     error::ErrorResponse,
+    k8s::corev1::{ConfigMap, Secret},
     runtime::{
         controller::{Action, Controller},
         finalizer::{finalizer, Event},

--- a/examples/shared_stream_controllers.rs
+++ b/examples/shared_stream_controllers.rs
@@ -1,8 +1,8 @@
 use std::{ops::Deref, sync::Arc, time::Duration};
 
 use futures::{future, StreamExt};
-use k8s_openapi::api::{apps::v1::Deployment, core::v1::Pod};
 use kube::{
+    k8s::{appsv1::Deployment, corev1::Pod},
     runtime::{
         controller::Action,
         predicates,

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -1,10 +1,8 @@
 //! Traits and tyes for CustomResources
 
-use crate::k8s::apiextensions_apiserver::pkg::apis::apiextensions as apiexts;
-
 /// Types for v1 CustomResourceDefinitions
 pub mod v1 {
-    use super::apiexts::v1::CustomResourceDefinition as Crd;
+    use crate::k8s::apiextensionsv1::CustomResourceDefinition as Crd;
     /// Extension trait that is implemented by kube-derive
     pub trait CustomResourceExt {
         /// Helper to generate the CRD including the JsonSchema

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -1,6 +1,6 @@
 //! Traits and tyes for CustomResources
 
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions as apiexts;
+use crate::k8s::apiextensions_apiserver::pkg::apis::apiextensions as apiexts;
 
 /// Types for v1 CustomResourceDefinitions
 pub mod v1 {

--- a/kube-core/src/dynamic.rs
+++ b/kube-core/src/dynamic.rs
@@ -7,7 +7,7 @@ use crate::{
     resource::{DynamicResourceScope, Resource},
 };
 
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use crate::k8s::metav1::ObjectMeta;
 use std::borrow::Cow;
 use thiserror::Error;
 
@@ -113,11 +113,11 @@ mod test {
     use crate::{
         dynamic::{ApiResource, DynamicObject},
         gvk::GroupVersionKind,
+        k8s::corev1::Pod,
         params::{Patch, PatchParams, PostParams},
         request::Request,
         resource::Resource,
     };
-    use k8s_openapi::api::core::v1::Pod;
 
     #[test]
     fn raw_custom_resource() {

--- a/kube-core/src/gvk.rs
+++ b/kube-core/src/gvk.rs
@@ -1,8 +1,10 @@
 //! Type information structs for dynamic resources.
 use std::str::FromStr;
 
-use crate::TypeMeta;
-use k8s_openapi::{api::core::v1::ObjectReference, apimachinery::pkg::apis::meta::v1::OwnerReference};
+use crate::{
+    k8s::{corev1::ObjectReference, metav1::OwnerReference},
+    TypeMeta,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/kube-core/src/k8s.rs
+++ b/kube-core/src/k8s.rs
@@ -31,6 +31,6 @@ pub use k8s_openapi::{
 };
 
 // Names with version gates
-k8s_openapi::k8s_if_ge_1_26! {
+k8s_openapi::k8s_if_ge_1_29! {
     pub use k8s_openapi::api::flowcontrol::v1 as flowcontrolv1;
 }

--- a/kube-core/src/k8s.rs
+++ b/kube-core/src/k8s.rs
@@ -19,7 +19,6 @@ pub use {
     api::core::v1 as corev1,
     api::discovery::v1 as discoveryv1,
     api::events::v1 as eventsv1,
-    api::flowcontrol::v1 as flowcontrolv1,
     api::networking::v1 as networkingv1,
     api::node::v1 as nodev1,
     api::policy::v1 as policyv1,
@@ -29,3 +28,8 @@ pub use {
     apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiextensionsv1,
     apimachinery::pkg::apis::meta::v1 as metav1,
 };
+
+// Names with version gates
+k8s_openapi::k8s_if_ge_1_26! {
+    pub use api::flowcontrol::v1 as flowcontrolv1;
+}

--- a/kube-core/src/k8s.rs
+++ b/kube-core/src/k8s.rs
@@ -1,12 +1,13 @@
-//! Indirection layer for generated structs for easier imports
+//! Flat indirection layer of stable apis for generated structs
+//!
+//! These are exclusively the generated **modules** found in [`k8s-openapi`](https://docs.rs/k8s_openapi).
+#![allow(unused_imports)]
 
-/// Re-export k8s-openapi root modules
-pub use k8s_openapi::{api, apiextensions_apiserver, apimachinery};
 /// Re-export versioned stable modules as the client-go like equivalent names
 ///
 /// Names should generally match https://pkg.go.dev/k8s.io/client-go/kubernetes/typed
 #[rustfmt::skip]
-pub use {
+pub use k8s_openapi::{
     api::admissionregistration::v1 as admissionregistrationv1,
     api::apps::v1 as appsv1,
     api::authentication::v1 as authenticationv1,
@@ -31,5 +32,5 @@ pub use {
 
 // Names with version gates
 k8s_openapi::k8s_if_ge_1_26! {
-    pub use api::flowcontrol::v1 as flowcontrolv1;
+    pub use k8s_openapi::api::flowcontrol::v1 as flowcontrolv1;
 }

--- a/kube-core/src/k8s.rs
+++ b/kube-core/src/k8s.rs
@@ -1,0 +1,31 @@
+//! Indirection layer for generated structs for easier imports
+
+/// Re-export k8s-openapi root modules
+pub use k8s_openapi::{api, apiextensions_apiserver, apimachinery};
+/// Re-export versioned stable modules as the client-go like equivalent names
+///
+/// Names should generally match https://pkg.go.dev/k8s.io/client-go/kubernetes/typed
+#[rustfmt::skip]
+pub use {
+    api::admissionregistration::v1 as admissionregistrationv1,
+    api::apps::v1 as appsv1,
+    api::authentication::v1 as authenticationv1,
+    api::authorization::v1 as authorizationv1,
+    api::autoscaling::v1 as autoscalingv1,
+    api::autoscaling::v2 as autoscalingv2,
+    api::batch::v1 as batchv1,
+    api::certificates::v1 as certificatesv1,
+    api::coordination::v1 as coordinationv1,
+    api::core::v1 as corev1,
+    api::discovery::v1 as discoveryv1,
+    api::events::v1 as eventsv1,
+    api::flowcontrol::v1 as flowcontrolv1,
+    api::networking::v1 as networkingv1,
+    api::node::v1 as nodev1,
+    api::policy::v1 as policyv1,
+    api::rbac::v1 as rbacv1,
+    api::scheduling::v1 as schedulingv1,
+    api::storage::v1 as storagev1,
+    apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiextensionsv1,
+    apimachinery::pkg::apis::meta::v1 as metav1,
+};

--- a/kube-core/src/labels.rs
+++ b/kube-core/src/labels.rs
@@ -1,6 +1,6 @@
 //! Type safe label selector logic
+use crate::k8s::metav1::{LabelSelector, LabelSelectorRequirement};
 use core::fmt;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement};
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::PartialEq,

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -8,6 +8,8 @@
 //! (even with zero features) under [`kube::core`]((https://docs.rs/kube/*/kube/core/index.html)).
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+pub mod k8s;
+
 #[cfg_attr(docsrs, doc(cfg(feature = "admission")))]
 #[cfg(feature = "admission")]
 pub mod admission;

--- a/kube-core/src/metadata.rs
+++ b/kube-core/src/metadata.rs
@@ -1,7 +1,7 @@
 //! Metadata structs used in traits, lists, and dynamic objects.
 use std::{borrow::Cow, marker::PhantomData};
 
-pub use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ListMeta, ObjectMeta};
+pub use crate::k8s::metav1::{ListMeta, ObjectMeta};
 use serde::{Deserialize, Serialize};
 
 use crate::{DynamicObject, Resource};
@@ -178,8 +178,7 @@ impl<K: Resource> Resource for PartialObjectMeta<K> {
 #[cfg(test)]
 mod test {
     use super::{ObjectMeta, PartialObjectMeta, PartialObjectMetaExt};
-    use crate::Resource;
-    use k8s_openapi::api::core::v1::Pod;
+    use crate::{k8s::corev1::Pod, Resource};
 
     #[test]
     fn can_convert_and_derive_partial_metadata() {

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -1,6 +1,6 @@
 //! Utilities for managing [`CustomResourceDefinition`] schemas
 //!
-//! [`CustomResourceDefinition`]: `k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition`
+//! [`CustomResourceDefinition`]: `crate::k8s::apiextensionsv1::CustomResourceDefinition`
 
 // Used in docs
 #[allow(unused_imports)] use schemars::gen::SchemaSettings;

--- a/kube-core/src/util.rs
+++ b/kube-core/src/util.rs
@@ -1,11 +1,11 @@
 //! Utils and helpers
 
 use crate::{
+    k8s::appsv1::{DaemonSet, Deployment, ReplicaSet, StatefulSet},
     params::{Patch, PatchParams},
     request, Request,
 };
 use chrono::Utc;
-use k8s_openapi::api::apps::v1::{DaemonSet, Deployment, ReplicaSet, StatefulSet};
 
 /// Restartable Resource marker trait
 pub trait Restart {}
@@ -61,12 +61,15 @@ impl Request {
 
 #[cfg(test)]
 mod test {
-    use crate::{params::Patch, request::Request, resource::Resource};
+    use crate::{
+        k8s::{appsv1, corev1},
+        params::Patch,
+        request::Request,
+        resource::Resource,
+    };
 
     #[test]
     fn restart_patch_is_correct() {
-        use k8s_openapi::api::apps::v1 as appsv1;
-
         let url = appsv1::Deployment::url_path(&(), Some("ns"));
         let req = Request::new(url).restart("mydeploy").unwrap();
         assert_eq!(req.uri(), "/apis/apps/v1/namespaces/ns/deployments/mydeploy?");
@@ -79,9 +82,7 @@ mod test {
 
     #[test]
     fn cordon_patch_is_correct() {
-        use k8s_openapi::api::core::v1::Node;
-
-        let url = Node::url_path(&(), Some("ns"));
+        let url = corev1::Node::url_path(&(), Some("ns"));
         let req = Request::new(url).cordon("mynode").unwrap();
         assert_eq!(req.uri(), "/api/v1/namespaces/ns/nodes/mynode?");
         assert_eq!(req.method(), "PATCH");

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -173,7 +173,7 @@ pub use kube_derive::Resource;
 #[doc(inline)]
 pub use kube_runtime as runtime;
 
-pub use crate::core::{CustomResourceExt, Resource, ResourceExt};
+pub use crate::core::{k8s, CustomResourceExt, Resource, ResourceExt};
 #[doc(inline)] pub use kube_core as core;
 
 // Mock tests for the runtime


### PR DESCRIPTION
Adds [kube_core/src/k8s.rs](https://github.com/kube-rs/kube/pull/1613/files#diff-fb122394c4efbe65ed23a4d0b8c53862a08a9c0d93f4013709ed436337c48479) and makes examples and kube use those imports internally.

- Allows easier imports that bypasses the heavier `k8s-openapi` directory structure
- Only exposes stable apis from Kubernetes
- Single flat module re-export from `kube::core::` showing available stable modules:

![grim-area-2024-10-19-17_43_56](https://github.com/user-attachments/assets/ff4d782e-0718-4035-adab-d4ebe3a642b0)

Will propagate to kube_client / kube_runtime later if people are happy with this idea and the naming convention  (`module_name + version` no delimiter).

Have been thinking about this before, but was a bit unsure of a) how to do it, and b) if it would make `k8s-pb` usage harder (it would not - it's kind of necessary for it).

EDIT: sorry, i pinged all of you basically. looking for quick opinions / gut feelings. if you have none, feel free to ignore this.