### PR TITLE
conditionally install `aws-lc-rs`

### DIFF
--- a/kube-client/src/client/auth/oidc.rs
+++ b/kube-client/src/client/auth/oidc.rs
@@ -309,9 +309,13 @@ impl Refresher {
         let client_secret = get_field(Self::CONFIG_CLIENT_SECRET)?.into();
 
         #[cfg(all(feature = "rustls-tls", feature = "aws-lc-rs"))]
-        rustls::crypto::aws_lc_rs::default_provider()
-            .install_default()
-            .unwrap();
+        {
+            if rustls::crypto::CryptoProvider::get_default().is_none() {
+                // the only error here is if it's been initialized in between: we can ignore it
+                // since our semantic is only to set the default value if it does not exist.
+                let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+            }
+        }
 
         #[cfg(feature = "rustls-tls")]
         let https = hyper_rustls::HttpsConnectorBuilder::new()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

There was a recent panic on our app ( https://github.com/aptakube/aptakube/issues/319 ) and it was caused by this `unwrap`

## Solution

I suppose we should always check if there's a CryptoProvider already installed before installing another one. That's how it's done here https://github.com/kube-rs/kube/blob/ecbdafc214538aadc78ec8447f2fa12d0057492b/kube-client/src/client/builder.rs#L85-L92 but for some reason the oidc.rs did not

I'm also explicitly installing aws_lc_rs (with a fallback to ring) on my app, so I would expect kube to just skip it as it's already installed

cc @mcluseau 