### PR TITLE
Remove reference to kubectl version --short from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
       description: |
         What type of kubernetes cluster you are running aginst (k3s/eks/aks/gke/other) and what is OS in your `Dockerfile`?
       placeholder: |
-        Output of `kubectl version --short`
+        Output of `kubectl version`
         Dockerfile OS
     validations:
       required: true


### PR DESCRIPTION
The --short flag was removed a while ago, kubectl v1.30.2 just gives an unknown flag error.
