### PR TITLE
Fix errors and warnings for the `.reflect_shared()` example

### DIFF
--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -238,6 +238,13 @@ pub trait WatchStreamExt: Stream {
     ///     }
     /// });
     ///
+    /// tokio::spawn(async move {
+    ///     // subscriber can be used to receive applied_objects
+    ///     subscriber.for_each(|obj| async move {
+    ///         info!("saw in subscriber {}", &obj.name_any())
+    ///     }).await;
+    /// });
+    ///
     /// // configure the watcher stream and populate the store while polling
     /// watcher(deploys, watcher::Config::default())
     ///     .reflect_shared(writer)
@@ -249,11 +256,6 @@ pub trait WatchStreamExt: Stream {
     ///         }
     ///     })
     ///     .await;
-    ///
-    /// // subscriber can be used to receive applied_objects
-    /// subscriber.for_each(|obj| async move {
-    ///     info!("saw in subscriber {}", &obj.name_any())
-    /// }).await;
     ///
     /// # Ok(())
     /// # }

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -214,10 +214,10 @@ pub trait WatchStreamExt: Stream {
     /// [`ReflectHandle`]: crate::reflector::dispatcher::ReflectHandle
     /// ## Usage
     /// ```no_run
-    /// # use futures::{pin_mut, Stream, StreamExt, TryStreamExt};
+    /// # use futures::StreamExt;
     /// # use std::time::Duration;
     /// # use tracing::{info, warn};
-    /// use kube::{Api, Client, ResourceExt};
+    /// use kube::{Api, ResourceExt};
     /// use kube_runtime::{watcher, WatchStreamExt, reflector};
     /// use k8s_openapi::api::apps::v1::Deployment;
     /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
@@ -226,7 +226,7 @@ pub trait WatchStreamExt: Stream {
     /// let deploys: Api<Deployment> = Api::default_namespaced(client);
     /// let subscriber_buf_sz = 100;
     /// let (reader, writer) = reflector::store_shared::<Deployment>(subscriber_buf_sz);
-    /// let subscriber = &writer.subscribe().unwrap();
+    /// let subscriber = writer.subscribe().unwrap();
     ///
     /// tokio::spawn(async move {
     ///     // start polling the store once the reader is ready


### PR DESCRIPTION
Doesn't compile with the `&` (nonsense both type-wise and lifetime-wise), might as well fix the other warnings while at it. Also moved the subscription into a concurrent task since it's unreachable otherwise.

Also not sure about whether we want to add a tracing init too.. on one hand it's kind of tangential to the main thing being demonstrated, on the other hand it's easy to get confused by the empty output if you're not used to how tracing works.

Discovered while looking into https://discord.com/channels/500028886025895936/1302071483585269771.