### PR TITLE
Warn when trying to use an unsupported proxy protocol

### DIFF
--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -91,9 +91,12 @@ impl TryFrom<Config> for ClientBuilder<GenericService> {
             }
         }
 
+        const PROXY_SCHEME_SOCKS5: &str = "socks5";
+        const PROXY_SCHEME_HTTP: &str = "http";
+
         match config.proxy_url.as_ref() {
             #[cfg(feature = "socks5")]
-            Some(proxy_url) if proxy_url.scheme_str() == Some("socks5") => {
+            Some(proxy_url) if proxy_url.scheme_str() == Some(PROXY_SCHEME_SOCKS5) => {
                 let connector = hyper_socks2::SocksConnector {
                     proxy_addr: proxy_url.clone(),
                     auth: None,
@@ -104,14 +107,36 @@ impl TryFrom<Config> for ClientBuilder<GenericService> {
             }
 
             #[cfg(feature = "http-proxy")]
-            Some(proxy_url) if proxy_url.scheme_str() == Some("http") => {
+            Some(proxy_url) if proxy_url.scheme_str() == Some(PROXY_SCHEME_HTTP) => {
                 let proxy = hyper_http_proxy::Proxy::new(hyper_http_proxy::Intercept::All, proxy_url.clone());
                 let connector = hyper_http_proxy::ProxyConnector::from_proxy_unsecured(connector, proxy);
 
                 make_generic_builder(connector, config)
             }
 
-            _ => make_generic_builder(connector, config),
+            proxy_url => {
+                if let Some(proxy_url) = proxy_url {
+                    let missing_proxy_feature = match proxy_url.scheme_str() {
+                        Some(PROXY_SCHEME_SOCKS5) => Some("kube/socks5"),
+                        Some(PROXY_SCHEME_HTTP) => Some("kube/http-proxy"),
+                        _ => None,
+                    };
+                    if let Some(missing_proxy_feature) = missing_proxy_feature {
+                        tracing::warn!(
+                            ?proxy_url,
+                            missing_proxy_feature,
+                            "proxy URL is set but kube was built without support for that protocol, ignoring..."
+                        );
+                    } else {
+                        tracing::warn!(
+                            ?proxy_url,
+                            "proxy URL is set but kube does not support that protocol, ignoring..."
+                        );
+                    }
+                }
+
+                make_generic_builder(connector, config)
+            }
         }
     }
 }

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -1,4 +1,5 @@
 //! Error handling and error types
+use http::Uri;
 use thiserror::Error;
 
 pub use kube_core::ErrorResponse;
@@ -24,6 +25,21 @@ pub enum Error {
     #[cfg(feature = "client")]
     #[error("ServiceError: {0}")]
     Service(#[source] tower::BoxError),
+
+    /// Returned when the configured proxy uses an unsupported protocol.
+    #[error("configured proxy {proxy_url:?} uses an unsupported protocol")]
+    ProxyProtocolUnsupported {
+        /// The URL of the proxy.
+        proxy_url: Uri,
+    },
+    /// Returned when the configured proxy uses a protocol that requires a Cargo feature that is currently disabled
+    #[error("configured proxy {proxy_url:?} requires the disabled feature {protocol_feature:?}")]
+    ProxyProtocolDisabled {
+        /// The URL of the proxy.
+        proxy_url: Uri,
+        /// The Cargo feature that the proxy protocol requires.
+        protocol_feature: &'static str,
+    },
 
     /// UTF-8 Error
     #[error("UTF-8 Error: {0}")]


### PR DESCRIPTION
It's confusing when users try to use it but end up unable because they don't know about the feature flags. Especially since this also isn't super visible in the API docs (since it's typically picked up from the environment variables or the kubeconfig).