### PR TITLE
add support for CRD annotations and labels in kube-derive

### DIFF
--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -148,6 +148,12 @@ mod resource;
 /// Sets the description of the schema in the generated CRD. If not specified
 /// `Auto-generated derived type for {customResourceName} via CustomResource` will be used instead.
 ///
+/// ## `#[kube(annotation("ANNOTATION_KEY", "ANNOTATION_VALUE"))]`
+/// Add a single annotation to the generated CRD.
+///
+/// ## `#[kube(label("LABEL_KEY", "LABEL_VALUE"))]`
+/// Add a single label to the generated CRD.
+///
 /// ## Example with all properties
 ///
 /// ```rust

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -20,7 +20,11 @@ use std::collections::{HashMap, HashSet};
     shortname = "fo",
     shortname = "f",
     selectable = ".spec.nonNullable",
-    selectable = ".spec.nullable"
+    selectable = ".spec.nullable",
+    annotation("clux.dev", "cluxingv1"),
+    annotation("clux.dev/firewall", "enabled"),
+    label("clux.dev", "cluxingv1"),
+    label("clux.dev/persistence", "disabled")
 )]
 #[serde(rename_all = "camelCase")]
 struct FooSpec {
@@ -150,6 +154,14 @@ fn test_serialized_matches_expected() {
             "apiVersion": "clux.dev/v1",
             "kind": "Foo",
             "metadata": {
+                "annotations": {
+                    "clux.dev": "cluxingv1",
+                    "clux.dev/firewall": "enabled",
+                },
+                "labels": {
+                    "clux.dev": "cluxingv1",
+                    "clux.dev/persistence": "disabled",
+                },
                 "name": "bar",
             },
             "spec": {
@@ -182,6 +194,14 @@ fn test_crd_schema_matches_expected() {
             "apiVersion": "apiextensions.k8s.io/v1",
             "kind": "CustomResourceDefinition",
             "metadata": {
+                "annotations": {
+                    "clux.dev": "cluxingv1",
+                    "clux.dev/firewall": "enabled",
+                },
+                "labels": {
+                    "clux.dev": "cluxingv1",
+                    "clux.dev/persistence": "disabled",
+                },
                 "name": "foos.clux.dev"
             },
             "spec": {


### PR DESCRIPTION
This PR adds support for setting annotations and labels on kube-derive generated CRDs.

## Motivation

Writing Cluster API providers requires setting specific labels on the CRD: https://cluster-api.sigs.k8s.io/developer/providers/contracts#api-version-labels

## Solution

New `annotation` and `label` fields are added to kube-derive which can take a tuple of two strings as an argument.
