### PR TITLE
feat: Add storage and served argument to derive macro

### DIFF
--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -41,6 +41,18 @@ struct KubeAttrs {
     annotations: Vec<KVTuple>,
     #[darling(multiple, rename = "label")]
     labels: Vec<KVTuple>,
+
+    /// Sets the `storage` property to `true` or `false`.
+    ///
+    /// Defaults to `true`.
+    #[darling(default = default_storage_arg)]
+    storage: bool,
+
+    /// Sets the `served` property to `true` or `false`.
+    ///
+    /// Defaults to `true`.
+    #[darling(default = default_served_arg)]
+    served: bool,
 }
 
 #[derive(Debug)]
@@ -75,6 +87,16 @@ impl ToTokens for KVTuple {
         let (k, v) = (&self.0, &self.1);
         tokens.append_all(quote! { (#k, #v) });
     }
+}
+
+fn default_storage_arg() -> bool {
+    // This defaults to true to be backwards compatible.
+    true
+}
+
+fn default_served_arg() -> bool {
+    // This defaults to true to be backwards compatible.
+    true
 }
 
 #[derive(Debug, FromMeta)]
@@ -201,6 +223,8 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         printcolums,
         selectable,
         scale,
+        storage,
+        served,
         crates:
             Crates {
                 kube_core,
@@ -505,8 +529,8 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
                 },
                 "versions": [{
                     "name": #version,
-                    "served": true,
-                    "storage": true,
+                    "served": #served,
+                    "storage": #storage,
                     "schema": {
                         "openAPIV3Schema": schema,
                     },

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -1,8 +1,7 @@
 //! A crate for kube's derive macros.
 #![recursion_limit = "1024"]
 extern crate proc_macro;
-#[macro_use]
-extern crate quote;
+#[macro_use] extern crate quote;
 
 mod custom_resource;
 mod resource;

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -1,7 +1,8 @@
 //! A crate for kube's derive macros.
 #![recursion_limit = "1024"]
 extern crate proc_macro;
-#[macro_use] extern crate quote;
+#[macro_use]
+extern crate quote;
 
 mod custom_resource;
 mod resource;
@@ -153,6 +154,12 @@ mod resource;
 ///
 /// ## `#[kube(label("LABEL_KEY", "LABEL_VALUE"))]`
 /// Add a single label to the generated CRD.
+///
+/// ## `#[kube(storage = true)]`
+/// Sets the `storage` property to `true` or `false`.
+///
+/// ## `#[kube(served = true)]`
+/// Sets the `served` property to `true` or `false`.
 ///
 /// ## Example with all properties
 ///

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -136,24 +136,21 @@ fn test_shortnames() {
 #[test]
 fn test_serialized_matches_expected() {
     assert_json_eq!(
-        serde_json::to_value(Foo::new(
-            "bar",
-            FooSpec {
-                non_nullable: "asdf".to_string(),
-                non_nullable_with_default: "asdf".to_string(),
-                nullable_skipped: None,
-                nullable: None,
-                nullable_skipped_with_default: None,
-                nullable_with_default: None,
-                timestamp: DateTime::from_timestamp(0, 0).unwrap(),
-                complex_enum: ComplexEnum::VariantOne { int: 23 },
-                untagged_enum_person: UntaggedEnumPerson::GenderAndAge(GenderAndAge {
-                    age: 42,
-                    gender: Gender::Male,
-                }),
-                set: HashSet::from(["foo".to_owned()])
-            }
-        ))
+        serde_json::to_value(Foo::new("bar", FooSpec {
+            non_nullable: "asdf".to_string(),
+            non_nullable_with_default: "asdf".to_string(),
+            nullable_skipped: None,
+            nullable: None,
+            nullable_skipped_with_default: None,
+            nullable_with_default: None,
+            timestamp: DateTime::from_timestamp(0, 0).unwrap(),
+            complex_enum: ComplexEnum::VariantOne { int: 23 },
+            untagged_enum_person: UntaggedEnumPerson::GenderAndAge(GenderAndAge {
+                age: 42,
+                gender: Gender::Male,
+            }),
+            set: HashSet::from(["foo".to_owned()])
+        }))
         .unwrap(),
         serde_json::json!({
             "apiVersion": "clux.dev/v1",

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -19,6 +19,8 @@ use std::collections::{HashMap, HashSet};
     derive = "PartialEq",
     shortname = "fo",
     shortname = "f",
+    served = false,
+    storage = false,
     selectable = ".spec.nonNullable",
     selectable = ".spec.nullable",
     annotation("clux.dev", "cluxingv1"),
@@ -134,21 +136,24 @@ fn test_shortnames() {
 #[test]
 fn test_serialized_matches_expected() {
     assert_json_eq!(
-        serde_json::to_value(Foo::new("bar", FooSpec {
-            non_nullable: "asdf".to_string(),
-            non_nullable_with_default: "asdf".to_string(),
-            nullable_skipped: None,
-            nullable: None,
-            nullable_skipped_with_default: None,
-            nullable_with_default: None,
-            timestamp: DateTime::from_timestamp(0, 0).unwrap(),
-            complex_enum: ComplexEnum::VariantOne { int: 23 },
-            untagged_enum_person: UntaggedEnumPerson::GenderAndAge(GenderAndAge {
-                age: 42,
-                gender: Gender::Male,
-            }),
-            set: HashSet::from(["foo".to_owned()])
-        }))
+        serde_json::to_value(Foo::new(
+            "bar",
+            FooSpec {
+                non_nullable: "asdf".to_string(),
+                non_nullable_with_default: "asdf".to_string(),
+                nullable_skipped: None,
+                nullable: None,
+                nullable_skipped_with_default: None,
+                nullable_with_default: None,
+                timestamp: DateTime::from_timestamp(0, 0).unwrap(),
+                complex_enum: ComplexEnum::VariantOne { int: 23 },
+                untagged_enum_person: UntaggedEnumPerson::GenderAndAge(GenderAndAge {
+                    age: 42,
+                    gender: Gender::Male,
+                }),
+                set: HashSet::from(["foo".to_owned()])
+            }
+        ))
         .unwrap(),
         serde_json::json!({
             "apiVersion": "clux.dev/v1",
@@ -217,8 +222,8 @@ fn test_crd_schema_matches_expected() {
                 "versions": [
                     {
                         "name": "v1",
-                        "served": true,
-                        "storage": true,
+                        "served": false,
+                        "storage": false,
                         "additionalPrinterColumns": [],
                         "selectableFields": [{
                             "jsonPath": ".spec.nonNullable"


### PR DESCRIPTION
This PR adds two new arguments to the derive macro: `storage` and `served`. This allows users to customize these two values in the schema.

## Motivation

Currently it is not possible to customize these two properties using the derive macro because they are hard-coded to be both `true`. Adding support for setting these two properties is highly valuable when a CRD with multiple versions is used.

## Solution

Add two new arguments to make the properties customizable.
