### PR TITLE
Fix inconsistencies in rustfmt editions on CI and local

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: rustfmt +nightly --edition 2018 --check $(find . -type f -iname *.rs)
+      - run: rustfmt +nightly --edition 2021 --check $(find . -type f -iname *.rs)

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: rustfmt +nightly --edition 2018 $(find . -type f -iname *.rs)
+      - run: rustfmt +nightly --edition 2021 $(find . -type f -iname *.rs)
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
@@ -25,7 +25,7 @@ jobs:
           signoff: true
           title: rustfmt
           body: |
-            Changes from `rustfmt +nightly --edition 2018 $(find . -type f -iname *.rs)`.
+            Changes from `rustfmt +nightly --edition 2021 $(find . -type f -iname *.rs)`.
           branch: rustfmt
           # Delete branch when merged
           delete-branch: true

--- a/deny.toml
+++ b/deny.toml
@@ -91,3 +91,9 @@ name = "miniz_oxide"
 name = "thiserror"
 [[bans.skip]]
 name = "thiserror-impl"
+
+# 2 deps from 2 different version of rustls-native-certs not fully upgradeable yet
+[[bans.skip]]
+name = "security-framework"
+[[bans.skip]]
+name = "core-foundation"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
+# https://github.com/kube-rs/kube/issues/707
+unstable_features = true
 overflow_delimited_expr = true
 newline_style = "Unix"
 imports_granularity = "Crate"


### PR DESCRIPTION
We should be using at least edition 2021 everywhere.

(Noticed in https://github.com/kube-rs/kube/pull/1644)

Also allowlists a red deny error from two different version of `rustls-native-certs`, the oldest of which is pulled in by `hyper-http-proxy`.