### PR TITLE
Add a way to debug the Body contents with tracing

### DIFF
--- a/kube-client/src/client/body.rs
+++ b/kube-client/src/client/body.rs
@@ -10,10 +10,11 @@ use http_body::{Body as HttpBody, Frame, SizeHint};
 use http_body_util::{combinators::UnsyncBoxBody, BodyExt};
 
 /// A request body.
+#[derive(Debug)]
 pub struct Body {
     kind: Kind,
 }
-
+/*
 impl fmt::Debug for Body {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("Body");
@@ -23,8 +24,9 @@ impl fmt::Debug for Body {
         };
         builder.finish()
     }
-}
+}*/
 
+#[derive(Debug)]
 enum Kind {
     Once(Option<Bytes>),
     Wrap(UnsyncBoxBody<Bytes, Box<dyn StdError + Send + Sync>>),


### PR DESCRIPTION
WIP. Kind of non-trivial to get this right. Still exploring.

RN i am getting:
```
2024-11-23T14:50:02.419306Z TRACE kube_client::client: actual send body: Body { kind: Once(Some(b"{\"apiVersion\":\"clux.dev/v1\",\"kind\":\"Foo\",\"metadata\":{\"name\":\"x\"},\"spec\":{\"name\":\"x\",\"info\":\"failing validation obj\",\"replicas\":1}}")) }
```