### PR TITLE
Shift edition to 2024 and upgrade `schemars`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ authors = [
 repository = "https://github.com/kube-rs/kube"
 readme = "README.md"
 license = "Apache-2.0"
-edition = "2021"
-rust-version = "1.77.2"
+edition = "2024"
+rust-version = "1.85.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
@@ -70,7 +70,7 @@ quote = "1.0.10"
 rand = "0.8.3"
 rustls = { version = "0.23.16", default-features = false }
 rustls-pemfile = "2.0.0"
-schemars = "0.8.6"
+schemars = { version = "1.0.0-alpha.17" }
 secrecy = "0.10.2"
 serde = "1.0.130"
 serde_json = "1.0.68"

--- a/kube-core/src/duration.rs
+++ b/kube-core/src/duration.rs
@@ -273,15 +273,15 @@ impl PartialOrd<time::Duration> for Duration {
 impl schemars::JsonSchema for Duration {
     // see
     // https://github.com/kubernetes/apimachinery/blob/756e2227bf3a486098f504af1a0ffb736ad16f4c/pkg/apis/meta/v1/duration.go#L61
-    fn schema_name() -> String {
-        "Duration".to_owned()
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "Duration"
     }
 
     fn is_referenceable() -> bool {
         false
     }
 
-    fn json_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_: &mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::String.into()),
             // the format should *not* be "duration", because "duration" means

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -3,7 +3,7 @@
 //! [`CustomResourceDefinition`]: `k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition`
 
 // Used in docs
-#[allow(unused_imports)] use schemars::gen::SchemaSettings;
+#[allow(unused_imports)] use schemars::generate::SchemaSettings;
 
 use schemars::{
     schema::{InstanceType, Metadata, ObjectValidation, Schema, SchemaObject, SingleOrVec},

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -29,7 +29,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_yaml.workspace = true
 kube = { path = "../kube", version = "<1.0.0, >=0.61.0", features = ["derive", "client"] }
 k8s-openapi = { workspace = true, features = ["latest"] }
-schemars = { workspace = true, features = ["chrono"] }
+schemars = { workspace = true, features = ["chrono04"] }
 chrono.workspace = true
 trybuild.workspace = true
 assert-json-diff.workspace = true


### PR DESCRIPTION
Schemars is the big thing we need for 2024 edition due to it needing to rename the gen module.

WIP: sketch.

See https://github.com/kube-rs/kube/issues/1663
Hopefully they'll have a 1.0 release properly soon.

Not sure what to do with `SchemaObject` being gone and visitor stuff being changed yet.

EDIT: see https://github.com/kube-rs/kube/issues/1367#issuecomment-2506961874 point 3.