### PR TITLE
Bump `k8s-openapi` for Kubernetes `v1_32` support and MSRV

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.77.2-bullseye
+FROM docker.io/rust:1.81.0-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: "${{ env.K3S.MAX }}"
+          version: latest
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       matrix:
         # Run these tests against older clusters as well
         k8s:
-        - "1.27" # MK8SV
+        - "v1.28" # MK8SV
         - "latest"
     steps:
       - uses: actions/checkout@v4
@@ -200,7 +200,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: "1.27" # MK8SV
+          version: "v1.28" # MK8SV
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run these tests against older clusters as well
-        k8s: [v1.26, v1.30]
+        k8s: [v1.27, v1.31]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -198,7 +198,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.26
+          version: v1.27
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,10 +186,6 @@ jobs:
             echo "mk8sv not set correctly in tests"
             exit 1
           fi
-          if ! grep "${{ steps.mk8sv.outputs.mk8svdash }}" e2e/Cargo.toml | grep mk8sv; then
-            echo "mk8sv not set correctly in e2e features"
-            exit 1
-          fi
 
       - uses: dtolnay/rust-toolchain@stable
       # Smart caching for Rust projects.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,9 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run these tests against older clusters as well
-        k8s:
-        - "${{ env.K3S_MIN }}"
-        - "${{ env.K3S_MAX }}"
+        k8s: ["${{env.K3S_MIN}}", "${{env.K3S_MAX}}"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  K3S_MAX: "latest"
-  K3S_MIN: "v1.28"
 
 # Spend CI time only on latest ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -134,7 +132,9 @@ jobs:
       fail-fast: false
       matrix:
         # Run these tests against older clusters as well
-        k8s: ["${{env.K3S_MIN}}", "${{env.K3S_MAX}}"]
+        k8s:
+        - "1.27" # MK8SV
+        - "latest"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -200,7 +200,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: "${{ env.K3S_MIN }}"
+          version: "1.27" # MK8SV
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
 
 env:
   RUST_BACKTRACE: 1
+  K3S_MAX: "latest"
+  K3S_MIN: "v1.28"
 
 # Spend CI time only on latest ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -132,7 +134,9 @@ jobs:
       fail-fast: false
       matrix:
         # Run these tests against older clusters as well
-        k8s: [v1.27, v1.31]
+        k8s:
+        - "${{ env.K3S_MIN }}"
+        - "${{ env.K3S_MAX }}"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -198,7 +202,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.27
+          version: "${{ env.K3S_MIN }}"
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.
@@ -240,7 +244,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: latest
+          version: "${{ env.K3S.MAX }}"
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,8 +12,6 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  K3S_MAX: "latest"
-  K3S_MIN: "v1.28"
 
 jobs:
   tarpaulin-codecov:
@@ -31,7 +29,7 @@ jobs:
           tool: cargo-tarpaulin@0.28.0
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: "${{ env.K3S_MIN }}"
+          version: "v1.27" # MK8SV
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,11 @@ on:
       - "**.toml"
       - "**.yml"
 
+env:
+  RUST_BACKTRACE: 1
+  K3S_MAX: "latest"
+  K3S_MIN: "v1.28"
+
 jobs:
   tarpaulin-codecov:
     runs-on: ubuntu-latest
@@ -26,7 +31,7 @@ jobs:
           tool: cargo-tarpaulin@0.28.0
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.27
+          version: "${{ env.K3S_MIN }}"
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
           tool: cargo-tarpaulin@0.28.0
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: "v1.27" # MK8SV
+          version: "v1.28" # MK8SV
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,9 +10,6 @@ on:
       - "**.toml"
       - "**.yml"
 
-env:
-  RUST_BACKTRACE: 1
-
 jobs:
   tarpaulin-codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
           tool: cargo-tarpaulin@0.28.0
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.26
+          version: v1.27
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.77.2"
+rust-version = "1.81.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ hyper-util = "0.1.9"
 json-patch = "3"
 jsonpath-rust = "0.7.3"
 jsonptr = "0.6"
-k8s-openapi = { version = "0.23.0", default-features = false }
+k8s-openapi = { version = "0.24.0", default-features = false }
 openssl = "0.10.36"
 parking_lot = "0.12.0"
 pem = "3.0.1"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
 [![Rust 1.77](https://img.shields.io/badge/MSRV-1.77-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.77.2)
-[![Tested against Kubernetes v1_26 and above](https://img.shields.io/badge/MK8SV-v1_26-326ce5.svg)](https://kube.rs/kubernetes-version)
+[![Tested against Kubernetes v1_27 and above](https://img.shields.io/badge/MK8SV-v1_27-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
 [![Rust 1.77](https://img.shields.io/badge/MSRV-1.77-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.77.2)
-[![Tested against Kubernetes v1_27 and above](https://img.shields.io/badge/MK8SV-v1_27-326ce5.svg)](https://kube.rs/kubernetes-version)
+[![Tested against Kubernetes v1.28 and above](https://img.shields.io/badge/MK8SV-v1.28-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kube-rs
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
-[![Rust 1.77](https://img.shields.io/badge/MSRV-1.77-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.77.2)
+[![Rust 1.81](https://img.shields.io/badge/MSRV-1.81-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.81.0)
 [![Tested against Kubernetes v1.28 and above](https://img.shields.io/badge/MK8SV-v1.28-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -19,7 +19,7 @@ path = "boot.rs"
 
 [features]
 latest = ["k8s-openapi/latest"]
-mk8sv = ["k8s-openapi/v1_27"]
+mk8sv = ["k8s-openapi/v1_28"]
 rustls = ["kube/rustls-tls"]
 openssl = ["kube/openssl-tls"]
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -19,7 +19,7 @@ path = "boot.rs"
 
 [features]
 latest = ["k8s-openapi/latest"]
-mk8sv = ["k8s-openapi/v1_26"]
+mk8sv = ["k8s-openapi/v1_27"]
 rustls = ["kube/rustls-tls"]
 openssl = ["kube/openssl-tls"]
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -19,7 +19,7 @@ path = "boot.rs"
 
 [features]
 latest = ["k8s-openapi/latest"]
-mk8sv = ["k8s-openapi/v1_28"]
+mk8sv = ["k8s-openapi/earliest"]
 rustls = ["kube/rustls-tls"]
 openssl = ["kube/openssl-tls"]
 

--- a/justfile
+++ b/justfile
@@ -122,8 +122,8 @@ bump-k8s:
   min_feat="${earliest::-2}${earliest:3}"
   min_dots="${min_feat/_/.}"
   echo "Setting MK8SV to $min_dots using feature $min_feat"
-  # workflow pins for k3s
-  sd '^.+K3S_MIN\: .*$' "  K3S_MIN: \"${min_dots}\"" .github/workflows/*.yml
+  # workflow pins for k3s (any line with key/array suffixed by # MK8SV)
+  sd "(.*)([\:\-]{1}) .* # MK8SV$" "\$1\$2 \"${min_dots}\" # MK8SV" .github/workflows/*.yml
   # bump mk8sv badge
   badge="[![Tested against Kubernetes ${min_dots} and above](https://img.shields.io/badge/MK8SV-${min_dots}-326ce5.svg)](https://kube.rs/kubernetes-version)"
   sd "^.+badge/MK8SV.+$" "${badge}" README.md


### PR DESCRIPTION
1. Upgrades Kubernetes structs and our latest test version to the earliest k8s-openapi supports; `v1_28`. Technically [breaks our MK8SV policy](https://kube.rs/kubernetes-version/) slightly, as we only have structs up to `1.28`. Will make a note in the docs.

2. Upgrades MSRV to `1.81.0` (2 version behind stable) to fix CI. Red since a patch version of home v0.5.11 released 6 days ago. Follows our [best-effort policy](https://kube.rs/rust-version/#minimum-supported-rust-version).

## CI Details

Fixes up `just bump-k8s` to become an idempotent __setter__ and pin other CI stuff to `k8s-openapi/earliest` to ease the logic (we have historically bumped +1 each time, but this time k8s-openapi dropped two versions, so can't really rely on it - also the script was super racey anyway).

We were usually 1 or 0 versions ahead of k8s-openapi in bumping, but this time it's actually the other way around. Not going to think about it much right now. Maybe we need to revisit the policy.

MSRV error via last red build before msrv fix: https://github.com/kube-rs/kube/actions/runs/12452623215/job/34761812169

> error: package `home v0.5.11` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.77.2
