### PR TITLE
Propagate delete events in shared streams

### DIFF
--- a/kube-runtime/src/reflector/dispatcher.rs
+++ b/kube-runtime/src/reflector/dispatcher.rs
@@ -73,7 +73,7 @@ where
 
     // Return a number of active subscribers to this shared sender.
     pub(crate) fn subscribers(&self) -> usize {
-        self.dispatch_tx.receiver_count() - 1
+        self.dispatch_tx.receiver_count()
     }
 }
 
@@ -241,6 +241,7 @@ pub(crate) mod test {
 
         let (_, writer) = reflector::store_shared(10);
         let mut subscriber = pin!(writer.subscribe().unwrap());
+        let mut other_subscriber = pin!(writer.subscribe().unwrap());
         let mut reflect = pin!(st.reflect_shared(writer));
 
         // Deleted events should be skipped by subscriber.
@@ -248,7 +249,8 @@ pub(crate) mod test {
             poll!(reflect.next()),
             Poll::Ready(Some(Ok(Event::Delete(_))))
         ));
-        assert_eq!(poll!(subscriber.next()), Poll::Pending);
+        assert_eq!(poll!(subscriber.next()), Poll::Ready(Some(foo.clone())));
+        assert_eq!(poll!(other_subscriber.next()), Poll::Ready(Some(foo.clone())));
 
         assert!(matches!(
             poll!(reflect.next()),

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -57,6 +57,7 @@ pub trait Lookup {
             extra: Extra {
                 resource_version: self.resource_version().map(Cow::into_owned),
                 uid: self.uid().map(Cow::into_owned),
+                remaining_lookups: None,
             },
         }
     }
@@ -156,6 +157,8 @@ pub struct Extra {
     pub resource_version: Option<String>,
     /// The uid of the object
     pub uid: Option<String>,
+    /// Number of remaining cache lookups on this reference
+    pub remaining_lookups: Option<usize>,
 }
 
 impl<K: Lookup> ObjectRef<K>
@@ -225,6 +228,7 @@ impl<K: Lookup> ObjectRef<K> {
                 extra: Extra {
                     resource_version: None,
                     uid: Some(owner.uid.clone()),
+                    remaining_lookups: None,
                 },
             })
         } else {
@@ -271,6 +275,7 @@ impl<K: Lookup> From<ObjectRef<K>> for ObjectReference {
             extra: Extra {
                 resource_version,
                 uid,
+                ..
             },
         } = val;
         ObjectReference {
@@ -351,6 +356,7 @@ mod tests {
             extra: Extra {
                 resource_version: Some("123".to_string()),
                 uid: Some("638ffacd-f666-4402-ba10-7848c66ef576".to_string()),
+                remaining_lookups: None,
             },
             ..minimal.clone()
         };

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -272,11 +272,12 @@ impl<K: Lookup> From<ObjectRef<K>> for ObjectReference {
             dyntype: dt,
             name,
             namespace,
-            extra: Extra {
-                resource_version,
-                uid,
-                ..
-            },
+            extra:
+                Extra {
+                    resource_version,
+                    uid,
+                    ..
+                },
         } = val;
         ObjectReference {
             api_version: Some(K::api_version(&dt).into_owned()),

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -251,13 +251,12 @@ where
     #[must_use]
     pub fn remove(&self, key: &ObjectRef<K>) -> Option<Arc<K>> {
         let mut store = self.store.write();
-        store.remove_entry(key).map(|(k, obj)| {
-            let mut k = k.clone();
-            match k.extra.remaining_lookups {
+        store.remove_entry(key).map(|(mut key, obj)| {
+            match key.extra.remaining_lookups {
                 Some(..=1) | None => (),
                 Some(lookups) => {
-                    k.extra.remaining_lookups = Some(lookups - 1);
-                    store.insert(k, obj.clone());
+                    key.extra.remaining_lookups = Some(lookups - 1);
+                    store.insert(key, obj.clone());
                 }
             };
 

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -258,7 +258,7 @@ where
                     key.extra.remaining_lookups = Some(lookups - 1);
                     store.insert(key, obj.clone());
                 }
-            };
+            }
 
             obj
         })

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -112,7 +112,7 @@ where
                 store.remove(&key);
                 if self.dispatcher.is_some() {
                     // Re-insert the entry with updated key, as insert on its own doesnt modify the key
-                    key.extra.remaining_lookups = self.dispatcher.as_ref().map(|d| d.subscribers());
+                    key.extra.remaining_lookups = self.dispatcher.as_ref().map(Dispatcher::subscribers);
                     store.insert(key, Arc::new(obj.clone()));
                 }
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Current implementation of shared stream controllers does not account for `Delete` events.

Ref: #1590

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Add `Delete` event processing, with support for removing object from cache after all streams received the final object in a deletion event.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
