### PR TITLE
add `valid_until` to Client

### DIFF
--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -12,13 +12,13 @@ async fn main() -> anyhow::Result<()> {
 
     let config = Config::infer().await?;
 
-    let https = config.rustls_https_connector()?;
+    let https = config.rustls_https_connector(None)?;
     let service = tower::ServiceBuilder::new()
         .layer(config.base_uri_layer())
         .option_layer(config.auth_layer()?)
         .map_err(BoxError::from)
         .service(hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(https));
-    let client = Client::new(service, config.default_namespace);
+    let client = Client::new(service, config.default_namespace, None);
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let config = Config::infer().await?;
-    let https = config.rustls_https_connector()?;
+    let https = config.rustls_https_connector(None)?;
     let service = ServiceBuilder::new()
         .layer(config.base_uri_layer())
         // showcase rate limiting; max 10rps, and 4 concurrent
@@ -57,7 +57,7 @@ async fn main() -> anyhow::Result<()> {
         .map_err(BoxError::from)
         .service(hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(https));
 
-    let client = Client::new(service, config.default_namespace);
+    let client = Client::new(service, config.default_namespace, None);
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -256,7 +256,7 @@ mod test {
     #[tokio::test]
     async fn scopes_should_allow_correct_interface() {
         let (mock_service, _handle) = mock::pair::<Request<Body>, Response<Body>>();
-        let client = Client::new(mock_service, "default");
+        let client = Client::new(mock_service, "default", None);
 
         let _: Api<corev1::Node> = Api::all(client.clone());
         let _: Api<corev1::Pod> = Api::default_namespaced(client.clone());

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -153,11 +153,11 @@ mod test {
         use hyper_util::rt::TokioExecutor;
 
         let config = Config::infer().await?;
-        let https = config.rustls_https_connector()?;
+        let https = config.rustls_https_connector(None)?;
         let service = ServiceBuilder::new()
             .layer(config.base_uri_layer())
             .service(hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(https));
-        let client = Client::new(service, config.default_namespace);
+        let client = Client::new(service, config.default_namespace, None);
         let pods: Api<Pod> = Api::default_namespaced(client);
         pods.list(&Default::default()).await?;
         Ok(())

--- a/kube/src/mock_tests.rs
+++ b/kube/src/mock_tests.rs
@@ -154,6 +154,6 @@ impl ApiServerVerifier {
 // Create a test context with a mocked kube client
 fn testcontext() -> (Client, ApiServerVerifier) {
     let (mock_service, handle) = tower_test::mock::pair::<Request<Body>, Response<Body>>();
-    let mock_client = Client::new(mock_service, "default");
+    let mock_client = Client::new(mock_service, "default", None);
     (mock_client, ApiServerVerifier(handle))
 }


### PR DESCRIPTION
fixes #1675 

I found 3 different ways of doing this, but I'm not sure which one is the best.

This PR implements Option 1, but I'm fine with other options too (except maybe 3, my least favorite)

- **Option 1:** Fetch the `identity_pem` during the `make_generic_builder` and pass that onto both rustls and openssl HttpsConnector functions as an arg. This is a breaking change for those who are NOT using the `make_generic_builder` function.
- **Option 2:** Keep the `exec_identity_pem` call in both rustls and openssl connector builder as an arg, and bubble up the expiration datetime to the `make_generic_builder` function. This is also a breaking change for those who are using the `make_generic_builder` function as the return type for the HttpsConnector functions will change.
- **Option 3:** Call `exec_identity_pem` twice, once in the `make_generic_builder` function just to get the expiration date, and again inside the rustls and openssl HttpsConnector functions (as it is currently). This is NOT a breaking change, but it is inefficient as we are calling the `exec_identity_pem` function twice as this is a blocking system call.
