### PR TITLE
Bump `rand` to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ pem = "3.0.1"
 pin-project = "1.0.4"
 proc-macro2 = "1.0.29"
 quote = "1.0.10"
-rand = "0.8.3"
+rand = "0.9.0"
 rustls = { version = "0.23.16", default-features = false }
 rustls-pemfile = "2.0.0"
 schemars = "0.8.6"

--- a/deny.toml
+++ b/deny.toml
@@ -97,3 +97,17 @@ name = "thiserror-impl"
 name = "security-framework"
 [[bans.skip]]
 name = "core-foundation"
+
+# currently tungstenite hasn't upgraded rand to 0.9 yet, all these are related
+[[bans.skip]]
+name = "rand"
+[[bans.skip]]
+name = "rand_core"
+[[bans.skip]]
+name = "rand_chacha"
+[[bans.skip]]
+name = "getrandom"
+[[bans.skip]]
+name = "wasi"
+[[bans.skip]]
+name = "zerocopy"

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -141,7 +141,7 @@ mod tests {
     use futures::{stream, StreamExt, TryStreamExt};
     use k8s_openapi::{api::core::v1::ConfigMap, apimachinery::pkg::apis::meta::v1::ObjectMeta};
     use rand::{
-        distributions::{Bernoulli, Uniform},
+        distr::{Bernoulli, Uniform},
         Rng,
     };
     use std::collections::{BTreeMap, HashMap};
@@ -257,7 +257,7 @@ mod tests {
     #[tokio::test]
     async fn reflector_store_should_not_contain_duplicates() {
         let mut rng = rand::rng();
-        let item_dist = Uniform::new(0_u8, 100);
+        let item_dist = Uniform::new(0_u8, 100).unwrap();
         let deleted_dist = Bernoulli::new(0.40).unwrap();
         let store_w = store::Writer::default();
         let store = store_w.as_reader();

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -12,7 +12,8 @@ use crate::watcher;
 use async_stream::stream;
 use futures::{Stream, StreamExt};
 use std::hash::Hash;
-#[cfg(feature = "unstable-runtime-subscribe")] pub use store::store_shared;
+#[cfg(feature = "unstable-runtime-subscribe")]
+pub use store::store_shared;
 pub use store::{store, Store};
 
 /// Cache objects from a [`watcher()`] stream into a local [`Store`]
@@ -256,7 +257,7 @@ mod tests {
 
     #[tokio::test]
     async fn reflector_store_should_not_contain_duplicates() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let item_dist = Uniform::new(0_u8, 100);
         let deleted_dist = Bernoulli::new(0.40).unwrap();
         let store_w = store::Writer::default();

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -12,8 +12,7 @@ use crate::watcher;
 use async_stream::stream;
 use futures::{Stream, StreamExt};
 use std::hash::Hash;
-#[cfg(feature = "unstable-runtime-subscribe")]
-pub use store::store_shared;
+#[cfg(feature = "unstable-runtime-subscribe")] pub use store::store_shared;
 pub use store::{store, Store};
 
 /// Cache objects from a [`watcher()`] stream into a local [`Store`]


### PR DESCRIPTION
and update renamed fn

replaces https://github.com/kube-rs/kube/pull/1684