### PR TITLE
Get rid of rand dependency in favor of tungstenite builtin fn

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -17,7 +17,7 @@ rustls-tls = ["rustls", "hyper-rustls", "hyper-http-proxy?/rustls-tls-native-roo
 webpki-roots = ["hyper-rustls/webpki-roots"]
 aws-lc-rs = ["rustls?/aws-lc-rs"]
 openssl-tls = ["openssl", "hyper-openssl"]
-ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws", "tokio/macros"]
+ws = ["client", "tokio-tungstenite", "kube-core/ws", "tokio/macros"]
 kubelet-debug = ["ws", "kube-core/kubelet-debug"]
 oauth = ["client", "tame-oauth"]
 oidc = ["client", "form_urlencoded"]
@@ -72,7 +72,6 @@ tower = { workspace = true, features = ["buffer", "filter", "util"], optional = 
 tower-http = { workspace = true, features = ["auth", "map-response-body", "trace"], optional = true }
 hyper-timeout = { workspace = true, optional = true }
 tame-oauth = { workspace = true, features = ["gcp"], optional = true }
-rand = { workspace = true, optional = true }
 secrecy = { workspace = true }
 tracing = { workspace = true, features = ["log"], optional = true }
 hyper-openssl = { workspace = true, features = ["client-legacy"], optional = true }

--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -206,7 +206,7 @@ impl Client {
             http::header::SEC_WEBSOCKET_VERSION,
             HeaderValue::from_static("13"),
         );
-        let key = upgrade::sec_websocket_key();
+        let key = tokio_tungstenite::tungstenite::handshake::client::generate_key();
         parts.headers.insert(
             http::header::SEC_WEBSOCKET_KEY,
             key.parse().expect("valid header value"),

--- a/kube-client/src/client/upgrade.rs
+++ b/kube-client/src/client/upgrade.rs
@@ -86,11 +86,3 @@ pub fn verify_response(res: &Response<Body>, key: &str) -> Result<(), UpgradeCon
 
     Ok(())
 }
-
-/// Generate a random key for the `Sec-WebSocket-Key` header.
-/// This must be nonce consisting of a randomly selected 16-byte value in base64.
-pub fn sec_websocket_key() -> String {
-    use base64::Engine;
-    let r: [u8; 16] = rand::random();
-    base64::engine::general_purpose::STANDARD.encode(r)
-}


### PR DESCRIPTION
Found [tungstenite::handshake::client::generate_key](https://docs.rs/tungstenite/latest/tungstenite/handshake/client/fn.generate_key.html) which is [blanket re-exported via tokio-tungstenite](https://docs.rs/tokio-tungstenite/latest/tokio_tungstenite/#reexports).

we still use rand as a dev dependency, but less explicit things on users, and less re-implementing the same logic.