### PR TITLE
Fix: Tighten json-patch and jsonptr versions (#1700)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,9 @@ hyper-rustls = { version = "0.27.1", default-features = false }
 hyper-socks2 = { version = "0.9.0", default-features = false }
 hyper-timeout = "0.5.1"
 hyper-util = "0.1.9"
-json-patch = "3"
+json-patch = "3.0.1"
 jsonpath-rust = "0.7.3"
-jsonptr = "0.6"
+jsonptr = "0.6.3"
 k8s-openapi = { version = "0.24.0", default-features = false }
 openssl = "0.10.36"
 parking_lot = "0.12.0"


### PR DESCRIPTION
This fixes the conflict introduced by `json-patch` 3.1.0.

## Motivation

See #1700.

## Solution

Changed `Cargo.toml` to have tighter versions, to prevent the latest version of `json-patch` being used, which introduces a later version of `jsonptr` than is expected.

Note that the versions don't need pinning, just tightening.

Note also that they have been set to the last-known working versions, rather than the latest versions. These can be updated at leisure later, when appropriate.