### PR TITLE
`CustomResource` derive; allow `status` attribute to take a path

### DIFF
--- a/examples/crd_derive_multi.rs
+++ b/examples/crd_derive_multi.rs
@@ -13,17 +13,33 @@ mod v1 {
     use super::*;
     // spec that is forwards compatible with v2 (can upgrade by truncating)
     #[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone, JsonSchema)]
-    #[kube(group = "kube.rs", version = "v1", kind = "ManyDerive", namespaced)]
+    #[kube(
+        group = "kube.rs",
+        version = "v1",
+        kind = "ManyDerive",
+        status = "ManyDeriveStatus",
+        namespaced
+    )]
     pub struct ManyDeriveSpec {
         pub name: String,
         pub oldprop: u32,
+    }
+    #[derive(Serialize, Deserialize, Default, Debug, Clone, JsonSchema)]
+    pub struct ManyDeriveStatus {
+        pub condition: Option<bool>,
     }
 }
 mod v2 {
     // spec that is NOT backwards compatible with v1 (cannot retrieve oldprop if truncated)
     use super::*;
     #[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone, JsonSchema)]
-    #[kube(group = "kube.rs", version = "v2", kind = "ManyDerive", namespaced)]
+    #[kube(
+        group = "kube.rs",
+        version = "v2",
+        kind = "ManyDerive",
+        namespaced,
+        status = "v1::ManyDeriveStatus" // cross-referencing from v1 module
+    )]
     pub struct ManyDeriveSpec {
         pub name: String,
         pub extra: Option<String>,

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -812,8 +812,7 @@ fn process_status(
     visibility: &Visibility,
     kube_core: &Path,
 ) -> StatusInformation {
-    if let Some(status_path) = &status {
-        let pth = quote! { #status_path };
+    if let Some(pth) = &status {
         StatusInformation {
             field: quote! {
                 #[serde(skip_serializing_if = "Option::is_none")]

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -25,7 +25,7 @@ struct KubeAttrs {
     #[darling(multiple, rename = "derive")]
     derives: Vec<String>,
     schema: Option<SchemaMode>,
-    status: Option<String>,
+    status: Option<Path>,
     #[darling(multiple, rename = "category")]
     categories: Vec<String>,
     #[darling(multiple, rename = "shortname")]
@@ -808,28 +808,28 @@ struct StatusInformation {
 /// returns: A `StatusInformation` struct
 fn process_status(
     root_ident: &Ident,
-    status: &Option<String>,
+    status: &Option<Path>,
     visibility: &Visibility,
     kube_core: &Path,
 ) -> StatusInformation {
-    if let Some(status_name) = &status {
-        let ident = format_ident!("{}", status_name);
+    if let Some(status_path) = &status {
+        let pth = quote! { #status_path };
         StatusInformation {
             field: quote! {
                 #[serde(skip_serializing_if = "Option::is_none")]
-                #visibility status: Option<#ident>,
+                #visibility status: Option<#pth>,
             },
             default: quote! { status: None, },
             impl_hasstatus: quote! {
                 impl #kube_core::object::HasStatus for #root_ident {
 
-                    type Status = #ident;
+                    type Status = #pth;
 
-                    fn status(&self) -> Option<&#ident> {
+                    fn status(&self) -> Option<&#pth> {
                         self.status.as_ref()
                     }
 
-                    fn status_mut(&mut self) -> &mut Option<#ident> {
+                    fn status_mut(&mut self) -> &mut Option<#pth> {
                         &mut self.status
                     }
                 }


### PR DESCRIPTION
fix for https://github.com/kube-rs/kube/discussions/1703

allows module gated imports to be referenced such as;

```rust
pub mod mystatus {
    use super::*;
    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
    pub struct FooStatus { ... }
}
```
by using `#[kube(status = "mystatus::FooStatus")]` on a spec struct.