### PR TITLE
Add common wait conditions for Deployments, LoadBalancer Services, and Ingress

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -54,6 +54,7 @@ hostname.workspace = true
 [dev-dependencies]
 kube = { path = "../kube", features = ["derive", "client", "runtime"], version = "<1.0.0, >=0.60.0" }
 serde_json.workspace = true
+serde_yaml.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
 rand.workspace = true
 schemars.workspace = true

--- a/kube-runtime/src/wait.rs
+++ b/kube-runtime/src/wait.rs
@@ -339,6 +339,685 @@ pub mod conditions {
             self.0.matches_object(obj) || self.1.matches_object(obj)
         }
     }
+
+    mod tests {
+        #[test]
+        /// pass when CRD is established
+        fn crd_established_ok() {
+            use super::{is_crd_established, Condition};
+
+            let crd = r#"
+                apiVersion: apiextensions.k8s.io/v1
+                kind: CustomResourceDefinition
+                metadata:
+                  name: testthings.kube.rs
+                spec:
+                  group: kube.rs
+                  names:
+                    categories: []
+                    kind: TestThing
+                    plural: testthings
+                    shortNames: []
+                    singular: testthing
+                  scope: Namespaced
+                  versions:
+                    - additionalPrinterColumns: []
+                      name: v1
+                      schema:
+                        openAPIV3Schema:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      served: true
+                      storage: true
+                status:
+                  acceptedNames:
+                    kind: TestThing
+                    listKind: TestThingList
+                    plural: testthings
+                    singular: testthing
+                  conditions:
+                    - lastTransitionTime: "2025-03-06T03:10:03Z"
+                      message: no conflicts found
+                      reason: NoConflicts
+                      status: "True"
+                      type: NamesAccepted
+                    - lastTransitionTime: "2025-03-06T03:10:03Z"
+                      message: the initial names have been accepted
+                      reason: InitialNamesAccepted
+                      status: "True"
+                      type: Established
+                storedVersions:
+                  - v1
+            "#;
+
+            let c = serde_yaml::from_str(crd).unwrap();
+            assert!(is_crd_established().matches_object(Some(&c)))
+        }
+
+        #[test]
+        /// fail when CRD is not yet ready
+        fn crd_established_fail() {
+            use super::{is_crd_established, Condition};
+
+            let crd = r#"
+                apiVersion: apiextensions.k8s.io/v1
+                kind: CustomResourceDefinition
+                metadata:
+                  name: testthings.kube.rs
+                spec:
+                  group: kube.rs
+                  names:
+                    categories: []
+                    kind: TestThing
+                    plural: testthings
+                    shortNames: []
+                    singular: testthing
+                  scope: Namespaced
+                  versions:
+                    - additionalPrinterColumns: []
+                      name: v1
+                      schema:
+                        openAPIV3Schema:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      served: true
+                      storage: true
+                status:
+                  acceptedNames:
+                    kind: TestThing
+                    listKind: TestThingList
+                    plural: testthings
+                    singular: testthing
+                  conditions:
+                    - lastTransitionTime: "2025-03-06T03:10:03Z"
+                      message: no conflicts found
+                      reason: NoConflicts
+                      status: "True"
+                      type: NamesAccepted
+                    - lastTransitionTime: "2025-03-06T03:10:03Z"
+                      message: the initial names have been accepted
+                      reason: InitialNamesAccepted
+                      status: "False"
+                      type: Established
+                storedVersions:
+                  - v1
+            "#;
+
+            let c = serde_yaml::from_str(crd).unwrap();
+            assert!(!is_crd_established().matches_object(Some(&c)))
+        }
+
+        #[test]
+        /// fail when CRD does not exist
+        fn crd_established_missing() {
+            use super::{is_crd_established, Condition};
+
+            assert!(!is_crd_established().matches_object(None))
+        }
+
+        #[test]
+        /// pass when pod is running
+        fn pod_running_ok() {
+            use super::{is_pod_running, Condition};
+
+            let pod = r#"
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  namespace: default
+                  name: testpod
+                spec:
+                  containers:
+                    - name: testcontainer
+                      image: alpine
+                      command: [ sleep ]
+                      args: [ "100000" ]
+                status:
+                  conditions:
+                    - lastProbeTime: null
+                      lastTransitionTime: "2025-03-06T03:53:07Z"
+                      status: "True"
+                      type: PodReadyToStartContainers
+                    - lastProbeTime: null
+                      lastTransitionTime: "2025-03-06T03:52:58Z"
+                      status: "True"
+                      type: Initialized
+                    - lastProbeTime: null
+                      lastTransitionTime: "2025-03-06T03:53:24Z"
+                      status: "True"
+                      type: Ready
+                    - lastProbeTime: null
+                      lastTransitionTime: "2025-03-06T03:53:24Z"
+                      status: "True"
+                      type: ContainersReady
+                    - lastProbeTime: null
+                      lastTransitionTime: "2025-03-06T03:52:58Z"
+                      status: "True"
+                      type: PodScheduled
+                  containerStatuses:
+                    - containerID: containerd://598323380ae59d60c1ab98f9091c94659137a976d52136a8083775d47fea5875
+                      image: docker.io/library/alpine:latest
+                      imageID: docker.io/library/alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
+                      lastState: {}
+                      name: testcontainer
+                      ready: true
+                      restartCount: 0
+                      started: true
+                      state:
+                        running:
+                          startedAt: "2025-03-06T03:59:20Z"
+                  phase: Running
+                  qosClass: Burstable
+            "#;
+
+            let p = serde_yaml::from_str(pod).unwrap();
+            assert!(is_pod_running().matches_object(Some(&p)))
+        }
+
+        #[test]
+        /// fail if pod is unschedulable
+        fn pod_running_unschedulable() {
+            use super::{is_pod_running, Condition};
+
+            let pod = r#"
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  namespace: default
+                  name: testpod
+                spec:
+                  containers:
+                    - name: testcontainer
+                      image: alpine
+                      command: [ sleep ]
+                      args: [ "100000" ]
+                status:
+                  conditions:
+                    - lastProbeTime: null
+                      lastTransitionTime: "2025-03-06T03:52:25Z"
+                      message: '0/1 nodes are available: 1 node(s) were unschedulable. preemption: 0/1
+                      nodes are available: 1 Preemption is not helpful for scheduling.'
+                      reason: Unschedulable
+                      status: "False"
+                      type: PodScheduled
+                  phase: Pending
+                  qosClass: Burstable
+            "#;
+
+            let p = serde_yaml::from_str(pod).unwrap();
+            assert!(!is_pod_running().matches_object(Some(&p)))
+        }
+
+        #[test]
+        /// fail if pod does not exist
+        fn pod_running_missing() {
+            use super::{is_pod_running, Condition};
+
+            assert!(!is_pod_running().matches_object(None))
+        }
+
+        #[test]
+        /// pass if job completed
+        fn job_completed_ok() {
+            use super::{is_job_completed, Condition};
+
+            let job = r#"
+                apiVersion: batch/v1
+                kind: Job
+                metadata:
+                  name: pi
+                  namespace: default
+                spec:
+                  template:
+                    spec:
+                      containers:
+                      - name: pi
+                        command:
+                        - perl
+                        - -Mbignum=bpi
+                        - -wle
+                        - print bpi(2000)
+                        image: perl:5.34.0
+                        imagePullPolicy: IfNotPresent
+                status:
+                  completionTime: "2025-03-06T05:27:56Z"
+                  conditions:
+                  - lastProbeTime: "2025-03-06T05:27:56Z"
+                    lastTransitionTime: "2025-03-06T05:27:56Z"
+                    message: Reached expected number of succeeded pods
+                    reason: CompletionsReached
+                    status: "True"
+                    type: SuccessCriteriaMet
+                  - lastProbeTime: "2025-03-06T05:27:56Z"
+                    lastTransitionTime: "2025-03-06T05:27:56Z"
+                    message: Reached expected number of succeeded pods
+                    reason: CompletionsReached
+                    status: "True"
+                    type: Complete
+                  ready: 0
+                  startTime: "2025-03-06T05:27:27Z"
+                  succeeded: 1
+                  terminating: 0
+                  uncountedTerminatedPods: {}
+            "#;
+
+            let j = serde_yaml::from_str(job).unwrap();
+            assert!(is_job_completed().matches_object(Some(&j)))
+        }
+
+        #[test]
+        /// fail if job is still in progress
+        fn job_completed_running() {
+            use super::{is_job_completed, Condition};
+
+            let job = r#"
+                apiVersion: batch/v1
+                kind: Job
+                metadata:
+                  name: pi
+                  namespace: default
+                spec:
+                  backoffLimit: 4
+                  completionMode: NonIndexed
+                  completions: 1
+                  manualSelector: false
+                  parallelism: 1
+                  template:
+                    spec:
+                      containers:
+                      - name: pi
+                        command:
+                        - perl
+                        - -Mbignum=bpi
+                        - -wle
+                        - print bpi(2000)
+                        image: perl:5.34.0
+                        imagePullPolicy: IfNotPresent
+                status:
+                  active: 1
+                  ready: 0
+                  startTime: "2025-03-06T05:27:27Z"
+                  terminating: 0
+                  uncountedTerminatedPods: {}
+            "#;
+
+            let j = serde_yaml::from_str(job).unwrap();
+            assert!(!is_job_completed().matches_object(Some(&j)))
+        }
+
+        #[test]
+        /// fail if job does not exist
+        fn job_completed_missing() {
+            use super::{is_job_completed, Condition};
+
+            assert!(!is_job_completed().matches_object(None))
+        }
+
+        #[test]
+        /// pass when deployment has been fully rolled out
+        fn deployment_completed_ok() {
+            use super::{is_deployment_completed, Condition};
+
+            let depl = r#"
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: testapp
+                  namespace: default
+                spec:
+                  progressDeadlineSeconds: 600
+                  replicas: 3
+                  revisionHistoryLimit: 10
+                  selector:
+                    matchLabels:
+                      app: test
+                  strategy:
+                    rollingUpdate:
+                      maxSurge: 25%
+                      maxUnavailable: 25%
+                    type: RollingUpdate
+                  template:
+                    metadata:
+                      creationTimestamp: null
+                      labels:
+                        app: test
+                    spec:
+                      containers:
+                      - image: postgres
+                        imagePullPolicy: Always
+                        name: postgres
+                        ports:
+                        - containerPort: 5432
+                          protocol: TCP
+                        env:
+                        - name: POSTGRES_PASSWORD
+                          value: foobar
+                status:
+                  availableReplicas: 3
+                  conditions:
+                  - lastTransitionTime: "2025-03-06T06:06:57Z"
+                    lastUpdateTime: "2025-03-06T06:06:57Z"
+                    message: Deployment has minimum availability.
+                    reason: MinimumReplicasAvailable
+                    status: "True"
+                    type: Available
+                  - lastTransitionTime: "2025-03-06T06:03:20Z"
+                    lastUpdateTime: "2025-03-06T06:06:57Z"
+                    message: ReplicaSet "testapp-7fcd4b58c9" has successfully progressed.
+                    reason: NewReplicaSetAvailable
+                    status: "True"
+                    type: Progressing
+                  observedGeneration: 2
+                  readyReplicas: 3
+                  replicas: 3
+                  updatedReplicas: 3
+            "#;
+
+            let d = serde_yaml::from_str(depl).unwrap();
+            assert!(is_deployment_completed().matches_object(Some(&d)))
+        }
+
+        #[test]
+        /// fail if deployment update is still rolling out
+        fn deployment_completed_pending() {
+            use super::{is_deployment_completed, Condition};
+
+            let depl = r#"
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: testapp
+                  namespace: default
+                spec:
+                  progressDeadlineSeconds: 600
+                  replicas: 3
+                  revisionHistoryLimit: 10
+                  selector:
+                    matchLabels:
+                      app: test
+                  strategy:
+                    rollingUpdate:
+                      maxSurge: 25%
+                      maxUnavailable: 25%
+                    type: RollingUpdate
+                  template:
+                    metadata:
+                      creationTimestamp: null
+                      labels:
+                        app: test
+                    spec:
+                      containers:
+                      - image: postgres
+                        imagePullPolicy: Always
+                        name: postgres
+                        ports:
+                        - containerPort: 5432
+                          protocol: TCP
+                        env:
+                        - name: POSTGRES_PASSWORD
+                          value: foobar
+                status:
+                  conditions:
+                  - lastTransitionTime: "2025-03-06T06:03:20Z"
+                    lastUpdateTime: "2025-03-06T06:03:20Z"
+                    message: Deployment does not have minimum availability.
+                    reason: MinimumReplicasUnavailable
+                    status: "False"
+                    type: Available
+                  - lastTransitionTime: "2025-03-06T06:03:20Z"
+                    lastUpdateTime: "2025-03-06T06:03:20Z"
+                    message: ReplicaSet "testapp-77789cd7d4" is progressing.
+                    reason: ReplicaSetUpdated
+                    status: "True"
+                    type: Progressing
+                  observedGeneration: 1
+                  replicas: 3
+                  unavailableReplicas: 3
+                  updatedReplicas: 3
+            "#;
+
+            let d = serde_yaml::from_str(depl).unwrap();
+            assert!(!is_deployment_completed().matches_object(Some(&d)))
+        }
+
+        #[test]
+        /// fail if deployment does not exist
+        fn deployment_completed_missing() {
+            use super::{is_deployment_completed, Condition};
+
+            assert!(!is_deployment_completed().matches_object(None))
+        }
+
+        #[test]
+        /// pass if loadbalancer service has recieved a loadbalancer IP
+        fn service_lb_provisioned_ok_ip() {
+            use super::{is_service_loadbalancer_provisioned, Condition};
+
+            let service = r"
+                apiVersion: v1
+                kind: Service
+                metadata:
+                  name: test
+                spec:
+                  selector:
+                    app.kubernetes.io/name: test
+                  type: LoadBalancer
+                  ports:
+                    - protocol: TCP
+                      port: 80
+                      targetPort: 9376
+                  clusterIP: 10.0.171.239
+                status:
+                  loadBalancer:
+                    ingress:
+                      - ip: 192.0.2.127
+            ";
+
+            let s = serde_yaml::from_str(service).unwrap();
+            assert!(is_service_loadbalancer_provisioned().matches_object(Some(&s)))
+        }
+
+        #[test]
+        /// pass if loadbalancer service has recieved a loadbalancer hostname
+        fn service_lb_provisioned_ok_hostname() {
+            use super::{is_service_loadbalancer_provisioned, Condition};
+
+            let service = r"
+                apiVersion: v1
+                kind: Service
+                metadata:
+                  name: test
+                spec:
+                  selector:
+                    app.kubernetes.io/name: test
+                  type: LoadBalancer
+                  ports:
+                    - protocol: TCP
+                      port: 80
+                      targetPort: 9376
+                  clusterIP: 10.0.171.239
+                status:
+                  loadBalancer:
+                    ingress:
+                      - hostname: example.exposed.service
+            ";
+
+            let s = serde_yaml::from_str(service).unwrap();
+            assert!(is_service_loadbalancer_provisioned().matches_object(Some(&s)))
+        }
+
+        #[test]
+        /// fail if loadbalancer service is still waiting for a LB
+        fn service_lb_provisioned_pending() {
+            use super::{is_service_loadbalancer_provisioned, Condition};
+
+            let service = r"
+                apiVersion: v1
+                kind: Service
+                metadata:
+                  name: test
+                spec:
+                  selector:
+                    app.kubernetes.io/name: test
+                  type: LoadBalancer
+                  ports:
+                    - protocol: TCP
+                      port: 80
+                      targetPort: 9376
+                  clusterIP: 10.0.171.239
+                status:
+                  loadBalancer: {}
+            ";
+
+            let s = serde_yaml::from_str(service).unwrap();
+            assert!(!is_service_loadbalancer_provisioned().matches_object(Some(&s)))
+        }
+
+        #[test]
+        /// pass if service is not a loadbalancer
+        fn service_lb_provisioned_not_loadbalancer() {
+            use super::{is_service_loadbalancer_provisioned, Condition};
+
+            let service = r"
+                apiVersion: v1
+                kind: Service
+                metadata:
+                  name: test
+                spec:
+                  selector:
+                    app.kubernetes.io/name: test
+                  type: ClusterIP
+                  ports:
+                    - protocol: TCP
+                      port: 80
+                      targetPort: 9376
+                status:
+                  loadBalancer: {}
+            ";
+
+            let s = serde_yaml::from_str(service).unwrap();
+            assert!(is_service_loadbalancer_provisioned().matches_object(Some(&s)))
+        }
+
+        #[test]
+        /// fail if service does not exist
+        fn service_lb_provisioned_missing() {
+            use super::{is_service_loadbalancer_provisioned, Condition};
+
+            assert!(!is_service_loadbalancer_provisioned().matches_object(None))
+        }
+
+        #[test]
+        /// pass when ingress has recieved a loadbalancer IP
+        fn ingress_provisioned_ok_ip() {
+            use super::{is_ingress_provisioned, Condition};
+
+            let ingress = r#"
+                apiVersion: networking.k8s.io/v1
+                kind: Ingress
+                metadata:
+                  name: test
+                  namespace: default
+                  resourceVersion: "1401"
+                  uid: d653ee4d-0adb-40d9-b03c-7f84f35d4a67
+                spec:
+                  ingressClassName: nginx
+                  rules:
+                  - host: httpbin.local
+                    http:
+                      paths:
+                      - path: /
+                        backend:
+                          service:
+                            name: httpbin
+                            port:
+                              number: 80
+                status:
+                  loadBalancer:
+                    ingress:
+                      - ip: 10.89.7.3
+            "#;
+
+            let i = serde_yaml::from_str(ingress).unwrap();
+            assert!(is_ingress_provisioned().matches_object(Some(&i)))
+        }
+
+        #[test]
+        /// pass when ingress has recieved a loadbalancer hostname
+        fn ingress_provisioned_ok_hostname() {
+            use super::{is_ingress_provisioned, Condition};
+
+            let ingress = r#"
+                apiVersion: networking.k8s.io/v1
+                kind: Ingress
+                metadata:
+                  name: test
+                  namespace: default
+                  resourceVersion: "1401"
+                  uid: d653ee4d-0adb-40d9-b03c-7f84f35d4a67
+                spec:
+                  ingressClassName: nginx
+                  rules:
+                  - host: httpbin.local
+                    http:
+                      paths:
+                      - path: /
+                        backend:
+                          service:
+                            name: httpbin
+                            port:
+                              number: 80
+                status:
+                  loadBalancer:
+                    ingress:
+                      - hostname: example.exposed.service
+            "#;
+
+            let i = serde_yaml::from_str(ingress).unwrap();
+            assert!(is_ingress_provisioned().matches_object(Some(&i)))
+        }
+
+        #[test]
+        /// fail if ingress is still waiting for a LB
+        fn ingress_provisioned_pending() {
+            use super::{is_ingress_provisioned, Condition};
+
+            let ingress = r#"
+                apiVersion: networking.k8s.io/v1
+                kind: Ingress
+                metadata:
+                  name: test
+                  namespace: default
+                  resourceVersion: "1401"
+                  uid: d653ee4d-0adb-40d9-b03c-7f84f35d4a67
+                spec:
+                  ingressClassName: nginx
+                  rules:
+                  - host: httpbin.local
+                    http:
+                      paths:
+                      - path: /
+                        backend:
+                          service:
+                            name: httpbin
+                            port:
+                              number: 80
+                status:
+                  loadBalancer: {}
+            "#;
+
+            let i = serde_yaml::from_str(ingress).unwrap();
+            assert!(!is_ingress_provisioned().matches_object(Some(&i)))
+        }
+
+        #[test]
+        /// fail if ingress does not exist
+        fn ingress_provisioned_missing() {
+            use super::{is_ingress_provisioned, Condition};
+
+            assert!(!is_ingress_provisioned().matches_object(None))
+        }
+    }
 }
 
 /// Utilities for deleting objects


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

I've been using this library to create a custom tool to deploy applications, and have been using these conditions via `await_condition` to wait for those applications to become ready or report failures back to the users.

Since these are generally useful for waiting for these types of services to become available, I'm hoping to contribute these back upstream so that other client-esque applications have these ready to use.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

This adds a few new wait conditions to `kube-runtime::wait::conditions` for `Deployment`s, `LoadBalancer`-type `Service`s, and `Ingress`s to complete or become ready.

The `Deployment` check (`is_deployment_completed()`) matches [K8S's definition of completed deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment).

`LoadBalancer` and `Ingress` resources don't have an associated status condition for 'ready', but they are updated with the LoadBalancer details the backing cloud/etc load balancer has been fully provisioned and is ready. The new `is_ingress_provisioned()` / `is_service_loadbalancer_provisioned()` checks wait for that update to set `.status.loadBalancer.ingress.(ip|hostname)`. Non-loadbalancer services are ignored by always returning true i.e. immediately ready.

I did not add tests for these since the existing condition checks do not have any.



