### PR TITLE
Bump `json-patch` to 4 use bundled `jsonptr` to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,9 @@ hyper-rustls = { version = "0.27.1", default-features = false }
 hyper-socks2 = { version = "0.9.0", default-features = false }
 hyper-timeout = "0.5.1"
 hyper-util = "0.1.9"
-json-patch = "3"
+json-patch = "4"
 jsonpath-rust = "0.7.3"
-jsonptr = "0.6"
+jsonptr = "0.7"
 k8s-openapi = { version = "0.24.0", default-features = false }
 openssl = "0.10.36"
 parking_lot = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ hyper-timeout = "0.5.1"
 hyper-util = "0.1.9"
 json-patch = "4"
 jsonpath-rust = "0.7.3"
-jsonptr = "0.7"
 k8s-openapi = { version = "0.24.0", default-features = false }
 openssl = "0.10.36"
 parking_lot = "0.12.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,7 +28,6 @@ garde = { version = "0.22.0", default-features = false, features = ["derive"] }
 anyhow.workspace = true
 futures = { workspace = true, features = ["async-await"] }
 jsonpath-rust.workspace = true
-jsonptr.workspace = true
 kube = { path = "../kube", version = "^0.98.0", default-features = false, features = ["admission"] }
 kube-derive = { path = "../kube-derive", version = "^0.98.0", default-features = false } # only needed to opt out of schema
 k8s-openapi.workspace = true

--- a/examples/admission_controller.rs
+++ b/examples/admission_controller.rs
@@ -1,4 +1,4 @@
-use jsonptr::PointerBuf;
+use json_patch::jsonptr::PointerBuf;
 use kube::core::{
     admission::{AdmissionRequest, AdmissionResponse, AdmissionReview},
     DynamicObject, Resource, ResourceExt,

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -42,4 +42,3 @@ k8s-openapi = { workspace = true, features = ["latest"] }
 assert-json-diff.workspace = true
 kube = { path = "../kube", version = "<1.0.0, >=0.53.0" }
 serde_yaml.workspace = true
-jsonptr.workspace = true

--- a/kube-core/src/admission.rs
+++ b/kube-core/src/admission.rs
@@ -222,8 +222,7 @@ pub enum Operation {
 ///     .deny("Some rejection reason.")
 ///     .into_review();
 ///
-/// use json_patch::{AddOperation, Patch, PatchOperation};
-/// use jsonptr::PointerBuf;
+/// use json_patch::{AddOperation, Patch, PatchOperation, jsonptr::PointerBuf};
 ///
 /// // A response adding a label to the resource.
 /// let _: AdmissionReview<_> = AdmissionResponse::from(&req)

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -40,7 +40,6 @@ tokio = { workspace = true, features = ["time"] }
 tokio-util = { workspace = true, features = ["time"] }
 tracing.workspace = true
 json-patch.workspace = true
-jsonptr.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 backon.workspace = true

--- a/kube-runtime/src/finalizer.rs
+++ b/kube-runtime/src/finalizer.rs
@@ -1,8 +1,7 @@
 //! Finalizer helper for [`Controller`](crate::Controller) reconcilers
 use crate::controller::Action;
 use futures::{TryFuture, TryFutureExt};
-use json_patch::jsonptr::PointerBuf;
-use json_patch::{AddOperation, PatchOperation, RemoveOperation, TestOperation};
+use json_patch::{jsonptr::PointerBuf, AddOperation, PatchOperation, RemoveOperation, TestOperation};
 use kube_client::{
     api::{Patch, PatchParams},
     Api, Resource, ResourceExt,

--- a/kube-runtime/src/finalizer.rs
+++ b/kube-runtime/src/finalizer.rs
@@ -1,8 +1,8 @@
 //! Finalizer helper for [`Controller`](crate::Controller) reconcilers
 use crate::controller::Action;
 use futures::{TryFuture, TryFutureExt};
+use json_patch::jsonptr::PointerBuf;
 use json_patch::{AddOperation, PatchOperation, RemoveOperation, TestOperation};
-use jsonptr::PointerBuf;
 use kube_client::{
     api::{Patch, PatchParams},
     Api, Resource, ResourceExt,


### PR DESCRIPTION
replaces #1701 and #1696.

These would originally need to be upgraded together.
But now `json-patch` [re-exports jsonptr now](https://docs.rs/json-patch/latest/json_patch/#reexports) so we can get rid of the direct dep (which is very rarely used).

Doing it this way means we don't have to take a pin on `jsonptr` and just use whatever json-patch is using, and hopefully we'll get less dependabot errors.