### PR TITLE
ring/aws-lc-rs docs and feature tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,18 @@ See the [controller guide](https://kube.rs/controllers/intro/) for how to write 
 
 ## TLS
 
-By default [rustls](https://github.com/rustls/rustls) is used for TLS, but `openssl` is supported. To switch, turn off `default-features`, and enable the `openssl-tls` feature:
+Uses [rustls](https://github.com/rustls/rustls) with `ring` provider (default) or `aws-lc-rs` provider (optional).
+
+To switch [rustls providers](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html), turn off `default-features` and enable the `aws-lc-rs` feature:
 
 ```toml
-[dependencies]
+kube = { version = "0.98.0", default-features = false, features = ["client", "rustls-tls", "aws-lc-rs"] }
+```
+
+To switch to `openssl`, turn off `default-features`, and enable the `openssl-tls` feature:
+
+```toml
 kube = { version = "0.98.0", default-features = false, features = ["client", "openssl-tls"] }
-k8s-openapi = { version = "0.24.0", features = ["latest"] }
 ```
 
 This will pull in `openssl` and `hyper-openssl`. If `default-features` is left enabled, you will pull in two TLS stacks, and the default will remain as `rustls`.

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -81,7 +81,7 @@ k8s-openapi= { workspace = true, features = [] }
 
 [dev-dependencies]
 hyper = { workspace = true, features = ["server"] }
-kube = { path = "../kube", features = ["derive", "client", "ws", "ring"], version = "<1.0.0, >=0.61.0" }
+kube = { path = "../kube", features = ["derive", "client", "ws"], version = "<1.0.0, >=0.61.0" }
 tempfile.workspace = true
 futures = { workspace = true, features = ["async-await"] }
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
the dev dep of kube to a feature that does not yet exist prevents a release atm

dry-run output:

```
   Packaging kube-client v0.98.0 (/Users/eirik.albrigtsen/kube/kube/kube-client)
    Updating crates.io index
error: failed to prepare local package for uploading

Caused by:
  failed to select a version for `kube`.
      ... required by package `kube-client v0.98.0 (/Users/eirik.albrigtsen/kube/kube/kube-client)`
  versions that meet the requirements `<1.0.0, >=0.61.0` are: 0.98.0, 0.97.0, 0.96.0, 0.95.0, 0.94.2, 0.94.1, 0.94.0, 0.93.1, 0.93.0, 0.92.1, 0.92.0, 0.91.0, 0.90.0, 0.89.0, 0.88.1, 0.88.0, 0.87.2, 0.87.1, 0.85.0, 0.84.0, 0.83.0, 0.82.2, 0.82.1, 0.82.0, 0.81.0, 0.80.0, 0.79.0, 0.78.0, 0.77.0, 0.76.0, 0.75.0, 0.74.0, 0.73.1, 0.73.0, 0.72.0, 0.71.0, 0.70.0, 0.69.1, 0.69.0, 0.68.0, 0.67.0, 0.66.0, 0.65.0, 0.64.0, 0.63.2, 0.63.1, 0.63.0, 0.62.0, 0.61.0

  the package `kube-client` depends on `kube`, with features: `ring` but `kube` does not have these features.
```

if we can bypass the dev dep feature, then this should work, running through ci to verify tests (which is ultimately what the dev dep is for).