### PR TITLE
allow releasing 1.0 in the future

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -81,7 +81,7 @@ k8s-openapi= { workspace = true, features = [] }
 
 [dev-dependencies]
 hyper = { workspace = true, features = ["server"] }
-kube = { path = "../kube", features = ["derive", "client", "ws"], version = "<1.0.0, >=0.61.0" }
+kube = { path = "../kube", features = ["derive", "client", "ws"], version = "<2.0.0, >=0.98.0" }
 tempfile.workspace = true
 futures = { workspace = true, features = ["async-await"] }
 tokio = { workspace = true, features = ["full"] }

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -40,5 +40,5 @@ serde-value.workspace = true
 [dev-dependencies]
 k8s-openapi = { workspace = true, features = ["latest"] }
 assert-json-diff.workspace = true
-kube = { path = "../kube", version = "<1.0.0, >=0.53.0" }
+kube = { path = "../kube", version = "<2.0.0, >=0.98.0" }
 serde_yaml.workspace = true

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -28,7 +28,7 @@ proc-macro = true
 [dev-dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_yaml.workspace = true
-kube = { path = "../kube", version = "<1.0.0, >=0.61.0", features = ["derive", "client"] }
+kube = { path = "../kube", version = "<2.0.0, >=0.98.0", features = ["derive", "client"] }
 k8s-openapi = { workspace = true, features = ["latest"] }
 schemars = { workspace = true, features = ["chrono"] }
 chrono.workspace = true

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -51,7 +51,7 @@ async-stream.workspace = true
 hostname.workspace = true
 
 [dev-dependencies]
-kube = { path = "../kube", features = ["derive", "client", "runtime"], version = "<1.0.0, >=0.60.0" }
+kube = { path = "../kube", features = ["derive", "client", "runtime"], version = "<2.0.0, >=0.98.0" }
 serde_json.workspace = true
 serde_yaml.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }


### PR DESCRIPTION
prevents a bound check error on a 1.0 release.

for https://github.com/kube-rs/kube/issues/1688
