### PR TITLE
docs: Adjust #[kube(scale(...)] doc example

### DIFF
--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -137,9 +137,9 @@ mod resource;
 ///
 /// ```ignore
 /// #[kube(scale(
-///     specReplicasPath = ".spec.replicas",
-///     statusReplicaPath = ".status.replicas",
-///     labelSelectorPath = ".spec.labelSelector"
+///     spec_replicas_path = ".spec.replicas",
+///     status_replica_path = ".status.replicas",
+///     label_selector_path = ".spec.labelSelector"
 /// ))]
 /// ```
 ///


### PR DESCRIPTION
Fixes #1729

The typed scale argument of the derive macro uses snake_case fields instead of camelCase ones. This commit updates the doc example to use the correct casing.
