### PR TITLE
feat(deps): enable `hyper-util/tracing` feature flag

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -49,7 +49,7 @@ json-patch.workspace = true
 tower = { workspace = true, features = ["limit"] }
 tower-http = { workspace = true, features = ["trace", "decompression-gzip"] }
 hyper = { workspace = true, features = ["client", "http1"] }
-hyper-util = { workspace = true, features = ["client-legacy", "http1", "tokio"] }
+hyper-util = { workspace = true, features = ["client-legacy", "http1", "tokio", "tracing"] }
 thiserror.workspace = true
 backon.workspace = true
 clap = { version = "4.0", default-features = false, features = ["std", "cargo", "derive"] }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -65,7 +65,7 @@ jsonpath-rust = { workspace = true, optional = true }
 tokio-util = { workspace = true, features = ["io", "codec"], optional = true }
 hyper = { workspace = true, features = ["client", "http1"], optional = true }
 hyper-http-proxy = { version = "1", default-features = false, optional = true }
-hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "tokio"], optional = true }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "tokio", "tracing"], optional = true }
 hyper-rustls = { workspace = true, features = ["http1", "logging", "native-tokio", "tls12"], optional = true }
 hyper-socks2 = { workspace = true, optional = true }
 tokio-tungstenite = { workspace = true, optional = true }


### PR DESCRIPTION
the latest release of `hyper-util` includes hyperium/hyper-util#166, which changes the behavior of the `TokioExecutor` when the `tracing` feature flag has been enabled.

when this flag is enabled, the `TokioExecutor` will now propagate the current tracing span to spawned tasks.

this commit adds this new `hyper-util` feature to the dependency used by the `kube-client` crate.

* https://github.com/hyperium/hyper-util/pull/166