### PR TITLE
Add suffix to generated struct by `CELSchema`

### DIFF
--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -98,6 +98,9 @@ pub struct FooSpec {
 
     #[cel_validate(rule = Rule::new("self == oldSelf").message("is immutable"))]
     foo_sub_spec: Option<FooSubSpec>,
+
+    #[serde(default = "FooSpec::default_value")]
+    associated_default: bool,
 }
 
 #[derive(CELSchema, Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
@@ -106,6 +109,12 @@ pub struct FooSubSpec {
     field: String,
 
     other: Option<String>,
+}
+
+impl FooSpec {
+    fn default_value() -> bool {
+        true
+    }
 }
 
 // https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy
@@ -171,6 +180,7 @@ async fn main() -> Result<()> {
         set_listable: Default::default(),
         cel_validated: Default::default(),
         foo_sub_spec: Default::default(),
+        associated_default: Default::default(),
     });
 
     // Set up dynamic resource to test using raw values.
@@ -206,6 +216,7 @@ async fn main() -> Result<()> {
     assert_eq!(serde_json::to_string(&val["spec"]["defaultListable"])?, "[2]");
     assert_eq!(serde_json::to_string(&val["spec"]["setListable"])?, "[2]");
     assert_eq!(serde_json::to_string(&val["spec"]["celValidated"])?, "\"legal\"");
+    assert_eq!(serde_json::to_string(&val["spec"]["associatedDefault"])?, "true");
 
     // Missing required field (non-nullable without default) is an error
     let data = DynamicObject::new("qux", &api_resource).data(serde_json::json!({

--- a/kube-derive/src/cel_schema.rs
+++ b/kube-derive/src/cel_schema.rs
@@ -71,7 +71,7 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
     };
 
     // Collect global structure validation rules
-    let struct_name = IdentString::new(ident.clone()).map(|ident| format!("{ident}Validation"));
+    let struct_name = IdentString::new(ident.clone()).map(|ident| format!("{ident}Validated"));
     let struct_rules: Vec<TokenStream> = rules.iter().map(|r| quote! {#r,}).collect();
 
     // Modify generated struct name to avoid Struct::method conflicts in attributes
@@ -203,7 +203,7 @@ mod tests {
                     false
                 }
                 fn schema_name() -> String {
-                    "FooSpec".to_string() + "_kube_validation".into()
+                    "FooSpecValidated".to_string()
                 }
                 fn json_schema(
                     gen: &mut ::schemars::gen::SchemaGenerator,
@@ -211,11 +211,11 @@ mod tests {
                     #[derive(::serde::Serialize, ::schemars::JsonSchema)]
                     #[automatically_derived]
                     #[allow(missing_docs)]
-                    struct FooSpec {
+                    struct FooSpecValidated {
                         foo: String,
                     }
                     use ::kube::core::{Rule, Message, Reason};
-                    let s = &mut FooSpec::json_schema(gen);
+                    let s = &mut FooSpecValidated::json_schema(gen);
                     ::kube::core::validate(s, &["true".into()]).unwrap();
                     {
                         #[derive(::serde::Serialize, ::schemars::JsonSchema)]

--- a/kube-derive/src/cel_schema.rs
+++ b/kube-derive/src/cel_schema.rs
@@ -1,4 +1,4 @@
-use darling::{FromDeriveInput, FromField, FromMeta};
+use darling::{util::IdentString, FromDeriveInput, FromField, FromMeta};
 use proc_macro2::TokenStream;
 use syn::{parse_quote, Attribute, DeriveInput, Expr, Ident, Path};
 
@@ -71,8 +71,11 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
     };
 
     // Collect global structure validation rules
-    let struct_name = ident.to_string();
+    let struct_name = IdentString::new(ident.clone()).map(|ident| format!("{ident}Validation"));
     let struct_rules: Vec<TokenStream> = rules.iter().map(|r| quote! {#r,}).collect();
+
+    // Modify generated struct name to avoid Struct::method conflicts in attributes
+    ast.ident = struct_name.as_ident().clone();
 
     // Remove all unknown attributes from the original structure copy
     // Has to happen on the original definition at all times, as we don't have #[derive] stanzes.
@@ -123,6 +126,9 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
         }
     }
 
+    let schema_name = struct_name.as_str();
+    let generated_struct_name = struct_name.as_ident();
+
     quote! {
         impl #schemars::JsonSchema for #ident {
             fn is_referenceable() -> bool {
@@ -130,7 +136,7 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
             }
 
             fn schema_name() -> String {
-                #struct_name.to_string() + "_kube_validation".into()
+                #schema_name.to_string()
             }
 
             fn json_schema(gen: &mut #schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
@@ -140,7 +146,7 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
                 #ast
 
                 use #kube_core::{Rule, Message, Reason};
-                let s = &mut #ident::json_schema(gen);
+                let s = &mut #generated_struct_name::json_schema(gen);
                 #kube_core::validate(s, &[#(#struct_rules)*]).unwrap();
                 #(#property_modifications)*
                 s.clone()

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -68,6 +68,9 @@ struct FooSpec {
     untagged_enum_person: UntaggedEnumPerson,
 
     set: HashSet<String>,
+
+    #[serde(default = "FooSpec::default_value")]
+    associated_default: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -83,6 +86,12 @@ fn default_value() -> String {
 
 fn default_nullable() -> Option<String> {
     Some("default_nullable".into())
+}
+
+impl FooSpec {
+    fn default_value() -> bool {
+        true
+    }
 }
 
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
@@ -168,7 +177,8 @@ fn test_serialized_matches_expected() {
                 age: 42,
                 gender: Gender::Male,
             }),
-            set: HashSet::from(["foo".to_owned()])
+            set: HashSet::from(["foo".to_owned()]),
+            associated_default: false,
         }))
         .unwrap(),
         serde_json::json!({
@@ -200,7 +210,8 @@ fn test_serialized_matches_expected() {
                     "age": 42,
                     "gender": "Male"
                 },
-                "set": ["foo"]
+                "set": ["foo"],
+                "associatedDefault": false,
             }
         })
     )
@@ -371,6 +382,10 @@ fn test_crd_schema_matches_expected() {
                                                     "type": "string"
                                                 },
                                             },
+                                            "associatedDefault": {
+                                                "type": "boolean",
+                                                "default": true,
+                                            },
                                         },
                                         "required": [
                                             "complexEnum",
@@ -409,7 +424,7 @@ fn test_crd_schema_matches_expected() {
                                 "x-kubernetes-validations": [{
                                     "rule": "self.metadata.name == 'singleton'",
                                 }],
-                                "title": "Foo_kube_validation",
+                                "title": "FooValidated",
                                 "type": "object"
                             }
                         },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Fixes issue with using associated methods for serde default in a `CELSchema` macro.

Fixes #1746 

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Provide a suffix to the generated structure to avoid conflicts with outer block struct name, causing implementation overrides.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
