### PR TITLE
Allow schemars validate attribute in `CELSchema`

### DIFF
--- a/kube-derive/src/cel_schema.rs
+++ b/kube-derive/src/cel_schema.rs
@@ -79,7 +79,7 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
 
     // Remove all unknown attributes from the original structure copy
     // Has to happen on the original definition at all times, as we don't have #[derive] stanzes.
-    let attribute_whitelist = ["serde", "schemars", "doc"];
+    let attribute_whitelist = ["serde", "schemars", "doc", "validate"];
     ast.attrs = remove_attributes(&ast.attrs, &attribute_whitelist);
 
     let struct_data = match ast.data {

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -393,7 +393,7 @@ pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::Tok
 /// assert!(serde_json::to_string(&Struct::crd()).unwrap().contains(r#""default":"value""#));
 /// assert!(serde_json::to_string(&Struct::crd()).unwrap().contains(r#""rule":"self.matadata.name == 'singleton'""#));
 /// ```
-#[proc_macro_derive(CELSchema, attributes(cel_validate, schemars))]
+#[proc_macro_derive(CELSchema, attributes(cel_validate, schemars, validate))]
 pub fn derive_schema_validation(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     cel_schema::derive_validated_schema(input.into()).into()
 }

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -67,6 +67,9 @@ struct FooSpec {
     /// This is a untagged enum with a description
     untagged_enum_person: UntaggedEnumPerson,
 
+    #[validate(length(min = 1))]
+    my_list: Vec<String>,
+
     set: HashSet<String>,
 
     #[serde(default = "FooSpec::default_value")]
@@ -177,8 +180,9 @@ fn test_serialized_matches_expected() {
                 age: 42,
                 gender: Gender::Male,
             }),
-            set: HashSet::from(["foo".to_owned()]),
             associated_default: false,
+            my_list: vec!["".into()],
+            set: HashSet::from(["foo".to_owned()])
         }))
         .unwrap(),
         serde_json::json!({
@@ -210,8 +214,9 @@ fn test_serialized_matches_expected() {
                     "age": 42,
                     "gender": "Male"
                 },
-                "set": ["foo"],
                 "associatedDefault": false,
+                "myList": [""],
+                "set": ["foo"]
             }
         })
     )
@@ -376,6 +381,13 @@ fn test_crd_schema_matches_expected() {
                                                 ],
                                                 "description": "This is a untagged enum with a description"
                                             },
+                                            "myList": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "minItems": 1,
+                                            },
                                             "set": {
                                                 "type": "array",
                                                 "items": {
@@ -389,6 +401,7 @@ fn test_crd_schema_matches_expected() {
                                         },
                                         "required": [
                                             "complexEnum",
+                                            "myList",
                                             "nonNullable",
                                             "set",
                                             "timestamp",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Schemars uses `schemars` and `validate` [interchangeably](https://graham.cool/schemars/v0/deriving/attributes/#supported-validator-attributes), which adds a requirement to accommodate existing users opted-in for `validate` attribute usage.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Whitelist `validate` attribute, as it is a part of `schemars` derive handling.

Fixes #1745
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
