### PR TITLE
Support additional `x-kubernetes-*` schema extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ base64 = "0.22.1"
 bytes = "1.1.0"
 chrono = { version = "0.4.34", default-features = false }
 darling = "0.20.3"
+derive_more = "2.0.1"
 educe = { version = "0.6.0", default-features = false }
 either = "1.6.1"
 form_urlencoded = "1.2.0"

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -7,7 +7,7 @@ use kube::{
         WatchEvent, WatchParams,
     },
     runtime::wait::{await_condition, conditions},
-    KubeSchema, Client, CustomResource, CustomResourceExt,
+    Client, CustomResource, CustomResourceExt, KubeSchema,
 };
 use serde::{Deserialize, Serialize};
 

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -7,7 +7,7 @@ use kube::{
         WatchEvent, WatchParams,
     },
     runtime::wait::{await_condition, conditions},
-    CELSchema, Client, CustomResource, CustomResourceExt,
+    KubeSchema, Client, CustomResource, CustomResourceExt,
 };
 use serde::{Deserialize, Serialize};
 
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 // - https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting
 // - https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting-and-nullable
 
-#[derive(CustomResource, CELSchema, Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
+#[derive(CustomResource, KubeSchema, Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
 #[kube(
     group = "clux.dev",
     version = "v1",
@@ -103,7 +103,7 @@ pub struct FooSpec {
     associated_default: bool,
 }
 
-#[derive(CELSchema, Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
+#[derive(KubeSchema, Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
 pub struct FooSubSpec {
     #[cel_validate(rule = "self != 'not legal'".into())]
     field: String,

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -26,10 +26,10 @@ use serde::{Deserialize, Serialize};
     namespaced,
     derive = "PartialEq",
     derive = "Default",
-    rule = Rule::new("self.metadata.name != 'forbidden'"),
+    validation = Rule::new("self.metadata.name != 'forbidden'"),
 )]
 #[serde(rename_all = "camelCase")]
-#[x_kube(rule = Rule::new("self.nonNullable == oldSelf.nonNullable"))]
+#[x_kube(validation = Rule::new("self.nonNullable == oldSelf.nonNullable"))]
 pub struct FooSpec {
     // Non-nullable without default is required.
     //
@@ -91,12 +91,12 @@ pub struct FooSpec {
     // Field with CEL validation
     #[serde(default = "default_legal")]
     #[x_kube(
-        rule = Rule::new("self != 'illegal'").message(Message::Expression("'string cannot be illegal'".into())).reason(Reason::FieldValueForbidden),
-        rule = Rule::new("self != 'not legal'").reason(Reason::FieldValueInvalid),
+        validation = Rule::new("self != 'illegal'").message(Message::Expression("'string cannot be illegal'".into())).reason(Reason::FieldValueForbidden),
+        validation = Rule::new("self != 'not legal'").reason(Reason::FieldValueInvalid),
     )]
     cel_validated: Option<String>,
 
-    #[x_kube(rule = Rule::new("self == oldSelf").message("is immutable"))]
+    #[x_kube(validation = Rule::new("self == oldSelf").message("is immutable"))]
     foo_sub_spec: Option<FooSubSpec>,
 
     #[serde(default = "FooSpec::default_value")]
@@ -105,7 +105,7 @@ pub struct FooSpec {
 
 #[derive(KubeSchema, Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
 pub struct FooSubSpec {
-    #[x_kube(rule = "self != 'not legal'".into())]
+    #[x_kube(validation = "self != 'not legal'".into())]
     field: String,
 
     other: Option<String>,

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
     rule = Rule::new("self.metadata.name != 'forbidden'"),
 )]
 #[serde(rename_all = "camelCase")]
-#[cel_validate(rule = Rule::new("self.nonNullable == oldSelf.nonNullable"))]
+#[x_kube(rule = Rule::new("self.nonNullable == oldSelf.nonNullable"))]
 pub struct FooSpec {
     // Non-nullable without default is required.
     //
@@ -90,13 +90,13 @@ pub struct FooSpec {
 
     // Field with CEL validation
     #[serde(default = "default_legal")]
-    #[cel_validate(
+    #[x_kube(
         rule = Rule::new("self != 'illegal'").message(Message::Expression("'string cannot be illegal'".into())).reason(Reason::FieldValueForbidden),
         rule = Rule::new("self != 'not legal'").reason(Reason::FieldValueInvalid),
     )]
     cel_validated: Option<String>,
 
-    #[cel_validate(rule = Rule::new("self == oldSelf").message("is immutable"))]
+    #[x_kube(rule = Rule::new("self == oldSelf").message("is immutable"))]
     foo_sub_spec: Option<FooSubSpec>,
 
     #[serde(default = "FooSpec::default_value")]
@@ -105,7 +105,7 @@ pub struct FooSpec {
 
 #[derive(KubeSchema, Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
 pub struct FooSubSpec {
-    #[cel_validate(rule = "self != 'not legal'".into())]
+    #[x_kube(rule = "self != 'not legal'".into())]
     field: String,
 
     other: Option<String>,

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -36,6 +36,7 @@ chrono = { workspace = true, features = ["now"] }
 schemars = { workspace = true, optional = true }
 k8s-openapi.workspace = true
 serde-value.workspace = true
+derive_more = { workspace = true, features = ["from"] }
 
 [dev-dependencies]
 k8s-openapi = { workspace = true, features = ["latest"] }

--- a/kube-core/src/cel.rs
+++ b/kube-core/src/cel.rs
@@ -336,7 +336,7 @@ impl MergeStrategy {
             data.insert("x-kubernetes-list-type".into(), "map".into());
             data.insert("x-kubernetes-list-map-keys".into(), serde_json::to_value(&keys)?);
 
-            return Ok(data)
+            return Ok(data);
         }
 
         let value = serde_json::to_value(self)?;

--- a/kube-core/src/cel.rs
+++ b/kube-core/src/cel.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::BTreeMap, str::FromStr};
 
+use derive_more::From;
 #[cfg(feature = "schema")] use schemars::schema::Schema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -315,7 +316,7 @@ pub enum StructMerge {
 }
 
 /// MergeStrategy represents set of options for a server-side merge strategy applied to a field.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(From, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum MergeStrategy {
     /// ListType represents x-kubernetes merge strategy for list.
     #[serde(rename = "x-kubernetes-list-type")]
@@ -326,25 +327,6 @@ pub enum MergeStrategy {
     /// StructType represents x-kubernetes merge strategy for struct.
     #[serde(rename = "x-kubernetes-struct-type")]
     StructType(StructMerge),
-}
-
-
-impl From<ListMerge> for MergeStrategy {
-    fn from(value: ListMerge) -> Self {
-        Self::ListType(value)
-    }
-}
-
-impl From<MapMerge> for MergeStrategy {
-    fn from(value: MapMerge) -> Self {
-        Self::MapType(value)
-    }
-}
-
-impl From<StructMerge> for MergeStrategy {
-    fn from(value: StructMerge) -> Self {
-        Self::StructType(value)
-    }
 }
 
 impl MergeStrategy {
@@ -358,7 +340,7 @@ impl MergeStrategy {
         }
 
         let value = serde_json::to_value(self)?;
-        Ok(serde_json::from_value(value)?)
+        serde_json::from_value(value)
     }
 }
 

--- a/kube-core/src/cel.rs
+++ b/kube-core/src/cel.rs
@@ -316,6 +316,8 @@ pub enum StructMerge {
 }
 
 /// MergeStrategy represents set of options for a server-side merge strategy applied to a field.
+///
+/// See upstream documentation of values at https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy
 #[derive(From, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum MergeStrategy {
     /// ListType represents x-kubernetes merge strategy for list.

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -26,10 +26,10 @@ pub mod crd;
 pub use crd::CustomResourceExt;
 
 pub mod cel;
-pub use cel::{Message, Reason, Rule, ListMerge, MapMerge, StructMerge};
+pub use cel::{ListMerge, MapMerge, Message, Reason, Rule, StructMerge};
 
 #[cfg(feature = "schema")]
-pub use cel::{merge_properties, validate, validate_property, merge_strategy, merge_strategy_property};
+pub use cel::{merge_properties, merge_strategy, merge_strategy_property, validate, validate_property};
 
 pub mod gvk;
 pub use gvk::{GroupVersion, GroupVersionKind, GroupVersionResource};

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -26,10 +26,10 @@ pub mod crd;
 pub use crd::CustomResourceExt;
 
 pub mod cel;
-pub use cel::{Message, Reason, Rule};
+pub use cel::{Message, Reason, Rule, ListMerge, MapMerge, StructMerge};
 
 #[cfg(feature = "schema")]
-pub use cel::{merge_properties, validate, validate_property};
+pub use cel::{merge_properties, validate, validate_property, merge_strategy, merge_strategy_property};
 
 pub mod gvk;
 pub use gvk::{GroupVersion, GroupVersionKind, GroupVersionResource};

--- a/kube-derive/src/cel_schema.rs
+++ b/kube-derive/src/cel_schema.rs
@@ -10,10 +10,9 @@ struct Rule {
 }
 
 #[derive(FromField)]
-#[darling(attributes(merge))]
+#[darling(attributes(merge_strategy))]
 struct MergeStrategy {
-    #[darling(rename = "kind")]
-    merge_kind: Option<Expr>,
+    kind: Option<Expr>,
 }
 
 #[derive(FromDeriveInput)]
@@ -104,8 +103,8 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
                 Err(err) => return err.write_errors(),
             };
 
-            let MergeStrategy { merge_kind } = match MergeStrategy::from_field(field) {
-                Ok(merge_kind) => merge_kind,
+            let MergeStrategy { kind: merge_kind } = match MergeStrategy::from_field(field) {
+                Ok(kind) => kind,
                 Err(err) => return err.write_errors(),
             };
 
@@ -208,7 +207,7 @@ mod tests {
             #[cel_validate(rule = "true".into())]
             struct FooSpec {
                 #[cel_validate(rule = "true".into())]
-                #[merge(kind = ListMerge::Atomic)]
+                #[merge_strategy(kind = ListMerge::Atomic)]
                 foo: Vec<String>
             }
         };

--- a/kube-derive/src/cel_schema.rs
+++ b/kube-derive/src/cel_schema.rs
@@ -117,8 +117,10 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
             }
 
             let rules: Vec<TokenStream> = rules.iter().map(|r| quote! {#r,}).collect();
-            let rules = (!rules.is_empty()).then_some(quote! {#kube_core::validate_property(merge, 0, &[#(#rules)*]).unwrap();});
-            let merge_strategy = merge_kind.map(|strategy| quote! {#kube_core::merge_strategy_property(merge, 0, #strategy).unwrap();});
+            let rules = (!rules.is_empty())
+                .then_some(quote! {#kube_core::validate_property(merge, 0, &[#(#rules)*]).unwrap();});
+            let merge_strategy = merge_kind
+                .map(|strategy| quote! {#kube_core::merge_strategy_property(merge, 0, #strategy).unwrap();});
 
             // We need to prepend derive macros, as they were consumed by this macro processing, being a derive by itself.
             property_modifications.push(quote! {

--- a/kube-derive/src/cel_schema.rs
+++ b/kube-derive/src/cel_schema.rs
@@ -17,7 +17,7 @@ struct MergeStrategy {
 
 #[derive(FromDeriveInput)]
 #[darling(attributes(cel_validate), supports(struct_named))]
-struct CELSchema {
+struct KubeSchema {
     #[darling(default)]
     crates: Crates,
     ident: Ident,
@@ -63,7 +63,7 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
         Ok(di) => di,
     };
 
-    let CELSchema {
+    let KubeSchema {
         crates: Crates {
             kube_core,
             schemars,
@@ -71,7 +71,7 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
         },
         ident,
         rules,
-    } = match CELSchema::from_derive_input(&ast) {
+    } = match KubeSchema::from_derive_input(&ast) {
         Err(err) => return err.write_errors(),
         Ok(attrs) => attrs,
     };
@@ -181,7 +181,7 @@ fn remove_attributes(attrs: &[Attribute], witelist: &[&str]) -> Vec<Attribute> {
 #[test]
 fn test_derive_validated() {
     let input = quote! {
-        #[derive(CustomResource, CELSchema, Serialize, Deserialize, Debug, PartialEq, Clone)]
+        #[derive(CustomResource, KubeSchema, Serialize, Deserialize, Debug, PartialEq, Clone)]
         #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
         #[cel_validate(rule = "self != ''".into())]
         struct FooSpec {
@@ -190,7 +190,7 @@ fn test_derive_validated() {
         }
     };
     let input = syn::parse2(input).unwrap();
-    let v = CELSchema::from_derive_input(&input).unwrap();
+    let v = KubeSchema::from_derive_input(&input).unwrap();
     assert_eq!(v.rules.len(), 1);
 }
 
@@ -203,7 +203,7 @@ mod tests {
     #[test]
     fn test_derive_validated_full() {
         let input = quote! {
-            #[derive(CELSchema)]
+            #[derive(KubeSchema)]
             #[cel_validate(rule = "true".into())]
             struct FooSpec {
                 #[cel_validate(rule = "true".into())]

--- a/kube-derive/src/cel_schema.rs
+++ b/kube-derive/src/cel_schema.rs
@@ -93,7 +93,11 @@ pub(crate) fn derive_validated_schema(input: TokenStream) -> TokenStream {
     let mut property_modifications = vec![];
     if let syn::Fields::Named(fields) = &mut struct_data.fields {
         for field in &mut fields.named {
-            let XKube { rules, merge_strategy, .. } = match XKube::from_field(field) {
+            let XKube {
+                rules,
+                merge_strategy,
+                ..
+            } = match XKube::from_field(field) {
                 Ok(rule) => rule,
                 Err(err) => return err.write_errors(),
             };

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -46,8 +46,8 @@ struct KubeAttrs {
     annotations: Vec<KVTuple>,
     #[darling(multiple, rename = "label")]
     labels: Vec<KVTuple>,
-    #[darling(multiple, rename = "rule")]
-    rules: Vec<Expr>,
+    #[darling(multiple, rename = "validation")]
+    validations: Vec<Expr>,
 
     /// Sets the `storage` property to `true` or `false`.
     ///
@@ -358,7 +358,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         printcolums,
         selectable,
         scale,
-        rules,
+        validations,
         storage,
         served,
         deprecated,
@@ -441,14 +441,14 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
     // these are validated by the API server implicitly. Also, we can't generate the
     // schema for `metadata` (`ObjectMeta`) because it doesn't implement `JsonSchema`.
     let schemars_skip = schema_mode.derive().then_some(quote! { #[schemars(skip)] });
-    if schema_mode.derive() && !rules.is_empty() {
+    if schema_mode.derive() && !validations.is_empty() {
         derive_paths.push(syn::parse_quote! { #kube::KubeSchema });
     } else if schema_mode.derive() {
         derive_paths.push(syn::parse_quote! { #schemars::JsonSchema });
     }
 
     let struct_rules: Option<Vec<TokenStream>> =
-        (!rules.is_empty()).then(|| rules.iter().map(|r| quote! {rule = #r,}).collect());
+        (!validations.is_empty()).then(|| validations.iter().map(|r| quote! {validation = #r,}).collect());
     let struct_rules = struct_rules.map(|r| quote! { #[x_kube(#(#r)*)]});
 
     let meta_annotations = if !annotations.is_empty() {

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -442,7 +442,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
     // schema for `metadata` (`ObjectMeta`) because it doesn't implement `JsonSchema`.
     let schemars_skip = schema_mode.derive().then_some(quote! { #[schemars(skip)] });
     if schema_mode.derive() && !rules.is_empty() {
-        derive_paths.push(syn::parse_quote! { #kube::CELSchema });
+        derive_paths.push(syn::parse_quote! { #kube::KubeSchema });
     } else if schema_mode.derive() {
         derive_paths.push(syn::parse_quote! { #schemars::JsonSchema });
     }

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -449,7 +449,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
 
     let struct_rules: Option<Vec<TokenStream>> =
         (!rules.is_empty()).then(|| rules.iter().map(|r| quote! {rule = #r,}).collect());
-    let struct_rules = struct_rules.map(|r| quote! { #[cel_validate(#(#r)*)]});
+    let struct_rules = struct_rules.map(|r| quote! { #[x_kube(#(#r)*)]});
 
     let meta_annotations = if !annotations.is_empty() {
         quote! { Some(std::collections::BTreeMap::from([#((#annotations.0.to_string(), #annotations.1.to_string()),)*])) }

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -393,7 +393,7 @@ pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::Tok
 /// assert!(serde_json::to_string(&Struct::crd()).unwrap().contains(r#""default":"value""#));
 /// assert!(serde_json::to_string(&Struct::crd()).unwrap().contains(r#""rule":"self.matadata.name == 'singleton'""#));
 /// ```
-#[proc_macro_derive(CELSchema, attributes(cel_validate, schemars, validate))]
+#[proc_macro_derive(CELSchema, attributes(cel_validate, schemars, validate, merge))]
 pub fn derive_schema_validation(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     cel_schema::derive_validated_schema(input.into()).into()
 }

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -393,7 +393,7 @@ pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::Tok
 /// assert!(serde_json::to_string(&Struct::crd()).unwrap().contains(r#""default":"value""#));
 /// assert!(serde_json::to_string(&Struct::crd()).unwrap().contains(r#""rule":"self.matadata.name == 'singleton'""#));
 /// ```
-#[proc_macro_derive(CELSchema, attributes(cel_validate, schemars, validate, merge))]
+#[proc_macro_derive(CELSchema, attributes(cel_validate, schemars, validate, merge_strategy))]
 pub fn derive_schema_validation(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     cel_schema::derive_validated_schema(input.into()).into()
 }

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -188,7 +188,7 @@ mod resource;
 /// #[kube(deprecated = "Replaced by other CRD")]
 /// ```
 ///
-/// ## `#[kube(rule = Rule::new("self == oldSelf").message("field is immutable"))]`
+/// ## `#[kube(validation = Rule::new("self == oldSelf").message("field is immutable"))]`
 /// Inject a top level CEL validation rule for the top level generated struct.
 /// This attribute is for resources deriving [`KubeSchema`] instead of [`schemars::JsonSchema`].
 ///
@@ -373,12 +373,12 @@ pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::Tok
 ///     group = "kube.rs",
 ///     version = "v1",
 ///     kind = "Struct",
-///     rule = Rule::new("self.matadata.name == 'singleton'"),
+///     validation = Rule::new("self.matadata.name == 'singleton'"),
 /// )]
-/// #[x_kube(rule = Rule::new("self == oldSelf"))]
+/// #[x_kube(validation = Rule::new("self == oldSelf"))]
 /// struct MyStruct {
 ///     #[serde(default = "default")]
-///     #[x_kube(rule = Rule::new("self != ''").message("failure message"))]
+///     #[x_kube(validation = Rule::new("self != ''").message("failure message"))]
 ///     field: String,
 /// }
 ///

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -190,7 +190,7 @@ mod resource;
 ///
 /// ## `#[kube(rule = Rule::new("self == oldSelf").message("field is immutable"))]`
 /// Inject a top level CEL validation rule for the top level generated struct.
-/// This attribute is for resources deriving [`CELSchema`] instead of [`schemars::JsonSchema`].
+/// This attribute is for resources deriving [`KubeSchema`] instead of [`schemars::JsonSchema`].
 ///
 /// ## Example with all properties
 ///
@@ -362,13 +362,13 @@ pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::Tok
 /// Generates a JsonSchema implementation a set of CEL validation rules applied on the CRD.
 ///
 /// ```rust
-/// use kube::CELSchema;
+/// use kube::KubeSchema;
 /// use kube::CustomResource;
 /// use serde::Deserialize;
 /// use serde::Serialize;
 /// use kube::core::crd::CustomResourceExt;
 ///
-/// #[derive(CustomResource, CELSchema, Serialize, Deserialize, Clone, Debug)]
+/// #[derive(CustomResource, KubeSchema, Serialize, Deserialize, Clone, Debug)]
 /// #[kube(
 ///     group = "kube.rs",
 ///     version = "v1",
@@ -393,7 +393,7 @@ pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::Tok
 /// assert!(serde_json::to_string(&Struct::crd()).unwrap().contains(r#""default":"value""#));
 /// assert!(serde_json::to_string(&Struct::crd()).unwrap().contains(r#""rule":"self.matadata.name == 'singleton'""#));
 /// ```
-#[proc_macro_derive(CELSchema, attributes(cel_validate, schemars, validate, merge_strategy))]
+#[proc_macro_derive(KubeSchema, attributes(cel_validate, schemars, validate, merge_strategy))]
 pub fn derive_schema_validation(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     cel_schema::derive_validated_schema(input.into()).into()
 }

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -375,10 +375,10 @@ pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::Tok
 ///     kind = "Struct",
 ///     rule = Rule::new("self.matadata.name == 'singleton'"),
 /// )]
-/// #[cel_validate(rule = Rule::new("self == oldSelf"))]
+/// #[x_kube(rule = Rule::new("self == oldSelf"))]
 /// struct MyStruct {
 ///     #[serde(default = "default")]
-///     #[cel_validate(rule = Rule::new("self != ''").message("failure message"))]
+///     #[x_kube(rule = Rule::new("self != ''").message("failure message"))]
 ///     field: String,
 /// }
 ///
@@ -393,7 +393,7 @@ pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::Tok
 /// assert!(serde_json::to_string(&Struct::crd()).unwrap().contains(r#""default":"value""#));
 /// assert!(serde_json::to_string(&Struct::crd()).unwrap().contains(r#""rule":"self.matadata.name == 'singleton'""#));
 /// ```
-#[proc_macro_derive(KubeSchema, attributes(cel_validate, schemars, validate, merge_strategy))]
+#[proc_macro_derive(KubeSchema, attributes(x_kube, schemars, validate))]
 pub fn derive_schema_validation(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     cel_schema::derive_validated_schema(input.into()).into()
 }

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -30,7 +30,7 @@ use std::collections::{HashMap, HashSet};
     annotation("clux.dev/firewall", "enabled"),
     label("clux.dev", "cluxingv1"),
     label("clux.dev/persistence", "disabled"),
-    rule = Rule::new("self.metadata.name == 'singleton'"),
+    validation = Rule::new("self.metadata.name == 'singleton'"),
     status = "Status",
     scale(
         spec_replicas_path = ".spec.replicas",
@@ -38,7 +38,7 @@ use std::collections::{HashMap, HashSet};
         label_selector_path = ".status.labelSelector"
     ),
 )]
-#[x_kube(rule = Rule::new("has(self.nonNullable)"))]
+#[x_kube(validation = Rule::new("has(self.nonNullable)"))]
 #[serde(rename_all = "camelCase")]
 struct FooSpec {
     non_nullable: String,
@@ -61,7 +61,7 @@ struct FooSpec {
     timestamp: DateTime<Utc>,
 
     /// This is a complex enum with a description
-    #[x_kube(rule = Rule::new("!has(self.variantOne) || self.variantOne.int > 22"))]
+    #[x_kube(validation = Rule::new("!has(self.variantOne) || self.variantOne.int > 22"))]
     complex_enum: ComplexEnum,
 
     /// This is a untagged enum with a description

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -3,14 +3,14 @@
 
 use assert_json_diff::assert_json_eq;
 use chrono::{DateTime, Utc};
-use kube::CELSchema;
+use kube::KubeSchema;
 use kube_derive::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 // See `crd_derive_schema` example for how the schema generated from this struct affects defaulting and validation.
-#[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone, CELSchema)]
+#[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone, KubeSchema)]
 #[kube(
     group = "clux.dev",
     version = "v1",

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -170,27 +170,24 @@ fn test_shortnames() {
 #[test]
 fn test_serialized_matches_expected() {
     assert_json_eq!(
-        serde_json::to_value(Foo::new(
-            "bar",
-            FooSpec {
-                non_nullable: "asdf".to_string(),
-                non_nullable_with_default: "asdf".to_string(),
-                nullable_skipped: None,
-                nullable: None,
-                nullable_skipped_with_default: None,
-                nullable_with_default: None,
-                timestamp: DateTime::from_timestamp(0, 0).unwrap(),
-                complex_enum: ComplexEnum::VariantOne { int: 23 },
-                untagged_enum_person: UntaggedEnumPerson::GenderAndAge(GenderAndAge {
-                    age: 42,
-                    gender: Gender::Male,
-                }),
-                associated_default: false,
-                my_list: vec!["".into()],
-                set: HashSet::from(["foo".to_owned()]),
-                x_kubernetes_set: vec![],
-            }
-        ))
+        serde_json::to_value(Foo::new("bar", FooSpec {
+            non_nullable: "asdf".to_string(),
+            non_nullable_with_default: "asdf".to_string(),
+            nullable_skipped: None,
+            nullable: None,
+            nullable_skipped_with_default: None,
+            nullable_with_default: None,
+            timestamp: DateTime::from_timestamp(0, 0).unwrap(),
+            complex_enum: ComplexEnum::VariantOne { int: 23 },
+            untagged_enum_person: UntaggedEnumPerson::GenderAndAge(GenderAndAge {
+                age: 42,
+                gender: Gender::Male,
+            }),
+            associated_default: false,
+            my_list: vec!["".into()],
+            set: HashSet::from(["foo".to_owned()]),
+            x_kubernetes_set: vec![],
+        }))
         .unwrap(),
         serde_json::json!({
             "apiVersion": "clux.dev/v1",

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -38,7 +38,7 @@ use std::collections::{HashMap, HashSet};
         label_selector_path = ".status.labelSelector"
     ),
 )]
-#[cel_validate(rule = Rule::new("has(self.nonNullable)"))]
+#[x_kube(rule = Rule::new("has(self.nonNullable)"))]
 #[serde(rename_all = "camelCase")]
 struct FooSpec {
     non_nullable: String,
@@ -61,7 +61,7 @@ struct FooSpec {
     timestamp: DateTime<Utc>,
 
     /// This is a complex enum with a description
-    #[cel_validate(rule = Rule::new("!has(self.variantOne) || self.variantOne.int > 22"))]
+    #[x_kube(rule = Rule::new("!has(self.variantOne) || self.variantOne.int > 22"))]
     complex_enum: ComplexEnum,
 
     /// This is a untagged enum with a description
@@ -75,7 +75,7 @@ struct FooSpec {
     #[serde(default = "FooSpec::default_value")]
     associated_default: bool,
 
-    #[merge_strategy(kind = ListMerge::Set)]
+    #[x_kube(merge_strategy = ListMerge::Set)]
     x_kubernetes_set: Vec<String>,
 }
 

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -75,7 +75,7 @@ struct FooSpec {
     #[serde(default = "FooSpec::default_value")]
     associated_default: bool,
 
-    #[merge(kind = ListMerge::Set)]
+    #[merge_strategy(kind = ListMerge::Set)]
     x_kubernetes_set: Vec<String>,
 }
 

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -170,7 +170,7 @@ pub use kube_derive::Resource;
 
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
-pub use kube_derive::CELSchema;
+pub use kube_derive::KubeSchema;
 
 #[cfg(feature = "runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "runtime")))]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Extend the set of supported property modifications with `x-kubernetes` rules related to SSA merge strategy:

- `x-kubernetes-list-type`
- `x-kubernetes-list-map-keys`
- `x-kubernetes-map-type`

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

The current implementation replaces `CELSchema` with `KubeSchema`, renames `cel_validate` to `x_kube`, and adds a new `x_kube(merge_strategy = …)` attribute to specify the merge strategy for the annotated field.

Changes:
- `CELSchema` is replaced with `KubeSchema`.
- `cel_validate(rule = …)` attribute is renamed to `x_kube(validation = …)`.
- `x_kube(merge_strategy = …)` attribute is added to specify merge strategy.

This change should cover https://github.com/kube-rs/kube/issues/1744

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
