### PR TITLE
Update hyper-util for enabled feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ hyper-openssl = "0.10.2"
 hyper-rustls = { version = "0.27.1", default-features = false }
 hyper-socks2 = { version = "0.9.0", default-features = false }
 hyper-timeout = "0.5.1"
-hyper-util = "0.1.9"
+hyper-util = "0.1.11"
 json-patch = "4"
 jsonpath-rust = "0.7.3"
 k8s-openapi = { version = "0.24.0", default-features = false }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

PR #1734 enabled the new `tracing` feature of the `hyper-util` crate, which was added in `0.1.11`. This repo is pinned to `0.1.9` which leads to this error when pointing my local build at it.

![image](https://github.com/user-attachments/assets/5af911c2-38e4-4c83-879b-73b56d780779)

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

Upgrade the crate version.
