### PR TITLE
Bump `k8s-openapi` to `0.25.0`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.81.0-bullseye
+FROM docker.io/rust:1.82.0-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       matrix:
         # Run these tests against older clusters as well
         k8s:
-        - "v1.28" # MK8SV
+        - "v1.30" # MK8SV
         - "latest"
     steps:
       - uses: actions/checkout@v4
@@ -196,7 +196,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: "v1.28" # MK8SV
+          version: "v1.30" # MK8SV
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
           tool: cargo-tarpaulin@0.28.0
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: "v1.28" # MK8SV
+          version: "v1.30" # MK8SV
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ hyper-timeout = "0.5.1"
 hyper-util = "0.1.11"
 json-patch = "4"
 jsonpath-rust = "0.7.3"
-k8s-openapi = { version = "0.24.0", default-features = false }
+k8s-openapi = { version = "0.25.0", default-features = false }
 openssl = "0.10.36"
 parking_lot = "0.12.0"
 pem = "3.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.81.0"
+rust-version = "1.82.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kube-rs
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
-[![Rust 1.81](https://img.shields.io/badge/MSRV-1.81-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.81.0)
+[![Rust 1.82](https://img.shields.io/badge/MSRV-1.82-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.82.0)
 [![Tested against Kubernetes v1.30 and above](https://img.shields.io/badge/MK8SV-v1.30-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
 [![Rust 1.81](https://img.shields.io/badge/MSRV-1.81-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.81.0)
-[![Tested against Kubernetes v1.28 and above](https://img.shields.io/badge/MK8SV-v1.28-326ce5.svg)](https://kube.rs/kubernetes-version)
+[![Tested against Kubernetes v1.30 and above](https://img.shields.io/badge/MK8SV-v1.30-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)
 

--- a/deny.toml
+++ b/deny.toml
@@ -36,7 +36,7 @@ allow = [
 exceptions = [
     # Pulled in via hyper-rustls when using the webpki-roots feature,
     # which is off by default.
-    { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" },
+    { allow = ["CDLA-Permissive-2.0", "MPL-2.0"], crate = "webpki-roots" },
 ]
 
 [sources]
@@ -58,6 +58,10 @@ name = "base64"
 
 [[bans.skip-tree]]
 name = "windows-sys"
+
+[[bans.skip-tree]]
+# currently multiple versions while it's 1.0 is being rolled out
+name = "webpki-roots"
 
 # currently multiple version of thiserror in flight due to its major bump
 [[bans.skip]]

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -662,15 +662,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
     };
 
     // Known constraints that are hard to enforce elsewhere
-    let compile_constraints = if !selectable.is_empty() {
-        quote! {
-            #k8s_openapi::k8s_if_le_1_29! {
-                compile_error!("selectable fields require Kubernetes >= 1.30");
-            }
-        }
-    } else {
-        quote! {}
-    };
+    let compile_constraints = quote! {}; // all modern features rolled out atm.
 
     let jsondata = quote! {
         #schemagen

--- a/kube-runtime/src/wait.rs
+++ b/kube-runtime/src/wait.rs
@@ -181,9 +181,8 @@ pub mod conditions {
     #[must_use]
     pub fn is_deleted<K: Resource>(uid: &str) -> impl Condition<K> + '_ {
         move |obj: Option<&K>| {
-            obj.map_or(
-                // Object is not found, success!
-                true,
+            // NB: Object not found implies success.
+            obj.is_none_or(
                 // Object is found, but a changed uid would mean that it was deleted and recreated
                 |obj| obj.meta().uid.as_deref() != Some(uid),
             )


### PR DESCRIPTION
Change via [k8s-openapi CHANGELOG](https://github.com/Arnavion/k8s-openapi/blob/master/CHANGELOG.md#v0250-2025-05-11).

### Kubernetes Minimum
Less supported versions from `k8s-openapi` this time so it kind of screws with our [version-policy](https://kube.rs/kubernetes-version/) a bit, as we cannot test what is not in k8s-openapi. Effectively we now only have 3 Kubernetes versions between latest and MK8SV.

### MSRV
Bumps MSRV one version to 1.82.0 based on lowest found in the msrv check.
<details><summary>log output</summary>
<p>

```
error: rustc 1.81.0 is not supported by the following packages:
  icu_collections@2.0.0 requires rustc 1.82
  icu_locale_core@2.0.0 requires rustc 1.82
  icu_normalizer@2.0.0 requires rustc 1.82
  icu_normalizer_data@2.0.0 requires rustc 1.82
  icu_normalizer_data@2.0.0 requires rustc 1.82
  icu_normalizer_data@2.0.0 requires rustc 1.82
  icu_properties@2.0.0 requires rustc 1.82
  icu_properties_data@2.0.0 requires rustc 1.82
  icu_properties_data@2.0.0 requires rustc 1.82
  icu_properties_data@2.0.0 requires rustc 1.82
  icu_provider@2.0.0 requires rustc 1.82
  idna_adapter@1.2.1 requires rustc 1.82
  litemap@0.8.0 requires rustc 1.82
  zerotrie@0.2.2 requires rustc 1.82
  zerovec@0.11.2 requires rustc 1.82
```

via [failing msrv job](https://github.com/kube-rs/kube/actions/runs/14968862945/job/42044967368)

</p>
</details>


### Deny
Excludes a temporary duplicate webpki-roots (at 1.0 and 0.26) and allows it's new license (it's an optional dep anyway).
Via [deny job failure](https://github.com/kube-rs/kube/actions/runs/14969180585/job/42045966630).

### Clippy
Nice lint from wait.rs to use [`Option::is_none_or`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none_or):
<details><summary>clippy output</summary>
<p>

```
 Error: error: this `map_or` can be simplified
   --> kube-runtime/src/wait.rs:184:13
    |
184 | /             obj.map_or(
185 | |                 // Object is not found, success!
186 | |                 true,
...   |
189 | |             )
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
note: the lint level is defined here
   --> kube-runtime/src/lib.rs:11:9
    |
11  | #![deny(clippy::all)]
    |         ^^^^^^^^^^^
    = note: `#[deny(clippy::unnecessary_map_or)]` implied by `#[deny(clippy::all)]`
help: use is_none_or instead
    |
184 ~             obj.is_none_or(
185 |                 // Object is not found, success!
186 ~                 |obj| obj.meta().uid.as_deref() != Some(uid),
    |
```

</p>
</details>


---

Plan is still to proceed with [1.0](https://github.com/kube-rs/kube/issues/1688) after. Not heard anyone else have big concerns about it.