### PR TITLE
fix(derive): Emit schemars crate attribute

### DIFF
--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -469,6 +469,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
     let docstr =
         doc.unwrap_or_else(|| format!(" Auto-generated derived type for {ident} via `CustomResource`"));
     let quoted_serde = Literal::string(&serde.to_token_stream().to_string());
+    let quoted_schemars = Literal::string(&schemars.to_token_stream().to_string());
     let root_obj = quote! {
         #[doc = #docstr]
         #[automatically_derived]
@@ -476,6 +477,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         #[derive(#(#derive_paths),*)]
         #[serde(rename_all = "camelCase")]
         #[serde(crate = #quoted_serde)]
+        #[schemars(crate = #quoted_schemars)]
         #struct_rules
         #visibility struct #rootident {
             #schemars_skip


### PR DESCRIPTION
## Motivation

The `JsonSchema` derive macro will use an incorrect import of `schemars` which does not match the customized import via `#[kube(crates(schemars = ...))]`. In my case, this was undiscovered until now, because previously, `schemars` was available at the top-level through a dependency declaration in `Cargo.toml`.

## Solution

This PR simply adds the `#[schemars(crate = ...)]` attribute to the generated CRD struct.
