### PR TITLE
Temporarily pin muslrust image for e2e tests due to unsupported openssl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
               --mount type=bind,source=${{ github.workspace }},target=/volume \
               --mount type=bind,source=$HOME/.cargo/registry,target=/root/.cargo/registry \
               --mount type=bind,source=$HOME/.cargo/git,target=/root/.cargo/git \
-              clux/muslrust:stable \
+              clux/muslrust:1.86.0-stable \
               cargo build -p e2e --release --bin=job --features=latest,${{matrix.tls}} -v
           cp target/x86_64-unknown-linux-musl/release/job e2e/
 

--- a/justfile
+++ b/justfile
@@ -90,7 +90,7 @@ e2e-job-musl features:
   docker run \
     -v cargo-cache:/root/.cargo/registry \
     -v "$PWD:/volume" -w /volume \
-    --rm -it clux/muslrust:stable cargo build --release --features={{features}} -p e2e
+    --rm -it clux/muslrust:1.86.0-stable cargo build --release --features={{features}} -p e2e
   cp target/x86_64-unknown-linux-musl/release/job e2e/job
   chmod +x e2e/job
 


### PR DESCRIPTION
_some_ very professional person has reasonably [removed support for openssl](https://github.com/clux/muslrust/pull/154) in muslrust due to it being EOL and without good replacements.

---

I'll come up with a better e2e build for this later, but makig ci green for now by pinning to the last muslrust stable that had openssl.