### PR TITLE
Clamp scheduling delay to 6 months

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -69,8 +69,6 @@ impl Action {
     /// even in the case of missed changes (which can happen).
     ///
     /// Watch events are not normally missed, so running this once per hour (`Default`) as a fallback is reasonable.
-    ///
-    /// The duration is clamped to a maximum of 6 months.
     #[must_use]
     pub fn requeue(duration: Duration) -> Self {
         Self {

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -69,6 +69,8 @@ impl Action {
     /// even in the case of missed changes (which can happen).
     ///
     /// Watch events are not normally missed, so running this once per hour (`Default`) as a fallback is reasonable.
+    ///
+    /// The duration is clamped to a maximum of 6 months.
     #[must_use]
     pub fn requeue(duration: Duration) -> Self {
         Self {
@@ -477,7 +479,7 @@ where
                 },
                 run_at: reconciler_finished_at
                     .checked_add(requeue_after)
-                    .unwrap_or_else(crate::scheduler::far_future),
+                    .unwrap_or_else(crate::scheduler::max_schedule_time),
             }),
             result: Some(result),
         }

--- a/kube-runtime/src/scheduler.rs
+++ b/kube-runtime/src/scheduler.rs
@@ -77,7 +77,9 @@ impl<T: Hash + Eq + Clone, R> SchedulerProj<'_, T, R> {
         let next_time = request
             .run_at
             .checked_add(*self.debounce)
-            .map_or_else(max_schedule_time, |time| time.min(max_schedule_time()));
+            .map_or_else(max_schedule_time, |time|
+                // Clamp `time` to avoid [`DelayQueue`] panic (see <https://github.com/kube-rs/kube/issues/1772>)
+                time.min(max_schedule_time()));
         match self.scheduled.raw_entry_mut().from_key(&request.message) {
             // If new request is supposed to be earlier than the current entry's scheduled
             // time (for eg: the new request is user triggered and the current entry is the

--- a/kube-runtime/src/scheduler.rs
+++ b/kube-runtime/src/scheduler.rs
@@ -283,7 +283,9 @@ pub fn debounced_scheduler<T: Eq + Hash + Clone, S: Stream<Item = ScheduleReques
     Scheduler::new(requests, debounce)
 }
 
-// Define a maximum scheduling delay of about 6 months to prevent `DelayQueue::insert_at` and `DelayQueue::reset_at` from panicking
+// [`DelayQueue`] panics when trying to schedule an event further than 2 years into the future.
+// (See <https://github.com/kube-rs/kube/issues/1772>.)
+// We limit all scheduled durations to 6 months to stay well clear of that limit.
 pub(crate) fn max_schedule_time() -> Instant {
     Instant::now() + Duration::from_secs(86400 * 30 * 6)
 }


### PR DESCRIPTION
## Motivation

Fixes https://github.com/kube-rs/kube/issues/1772 (long durations cause panics in [DelayQueue.html#method.insert_at](https://docs.rs/tokio-util/0.7.15/tokio_util/time/struct.DelayQueue.html#method.insert_at) and [DelayQueue.html#method.reset_at](https://docs.rs/tokio-util/0.7.15/tokio_util/time/struct.DelayQueue.html#method.reset_at)).

## Solution

Clamp the scheduling delay to a maximum of 6 months. This value is now also used as fallback if `checked_add` fails.
