### PR TITLE
Update admission example and pin to a local crd

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -51,14 +51,21 @@ cargo run --example event_watcher -- --for=Pod/prometheus-promstack-kube-prometh
 ```
 
 ## kube admission controller example
-Admission controllers are a bit of a special beast. They don't actually need `kube_client` (unless you need to verify something with the api-server) or `kube_runtime` (unless you also build a complementing reconciler) because, by themselves, they simply get changes sent to them over `https`. You will need a webserver, certificates, and either your controller deployed behind a `Service`, or as we do here: running locally with a private ip that your `k3d` cluster can reach.
+Admission controllers are web servers, where the apiserver talks to you. You don't necessarily require a `kube::Client` (unless you additionally need to cross-reference with information not present in the apiserver admissionrequest).
+
+You will need certificates, and a web server app deployed behind a `Service`, or as we do here: running locally with a private ip that your `k3d` cluster can reach;
 
 ```sh
 export ADMISSION_PRIVATE_IP=192.168.1.163
 ./admission_setup.sh
-cargo run --example admission_controller &
+kubectl apply -f admission_crd.yaml
+cargo run --example admission_controller
+
+# separate shell:
 kubectl apply -f admission_ok.yaml # should succeed and add a label
+# -> admittest.kube.rs/ok created
 kubectl apply -f admission_reject.yaml # should fail
+# -> Error from server: error when creating "admission_reject.yaml": admission webhook "foo-admission.default.svc" denied the request: Resource contained 'illegal' label
 ```
 
 ## kube-derive focused examples
@@ -74,7 +81,7 @@ cargo run --example cert_check # showcases partial typing with Resource derive
 
 The `no_schema` one opts out from the default `schema` feature from `kube-derive` (and thus the need for you to derive/impl `JsonSchema`).
 
-**However**: without the `schema` feature, it's left **up to you to fill in a valid openapi v3 schema**, as schemas are **required** for [v1::CustomResourceDefinitions](https://docs.rs/k8s-openapi/0.10.0/k8s_openapi/apiextensions_apiserver/pkg/apis/apiextensions/v1/struct.CustomResourceDefinition.html), and the generated crd will be rejected by the apiserver if it's missing. As the last example shows, you can do this directly without `schemars`.
+**However**: without the `schema` feature, it's left **up to you to fill in a valid openapi v3 schema**, as schemas are **required** for [v1::CustomResourceDefinitions](https://docs.rs/k8s-openapi/latest/k8s_openapi/apiextensions_apiserver/pkg/apis/apiextensions/v1/struct.CustomResourceDefinition.html), and the generated crd will be rejected by the apiserver if it's missing. As the last example shows, you can do this directly without `schemars`.
 
 Note that these examples also contain tests for CI, and are invoked with the same parameters, but using `cargo test` rather than `cargo run`.
 

--- a/examples/admission_controller.rs
+++ b/examples/admission_controller.rs
@@ -47,13 +47,14 @@ async fn mutate_handler(body: AdmissionReview<DynamicObject>) -> Result<impl Rep
     // req.Object always exists for us, but could be None if extending to DELETE events
     if let Some(obj) = req.object {
         let name = obj.name_any(); // apiserver may not have generated a name yet
+        let kind = obj.types.clone().unwrap_or_default().kind;
         res = match mutate(res.clone(), &obj) {
             Ok(res) => {
-                info!("accepted: {:?} on Foo {}", req.operation, name);
+                info!("accepted: {:?} on {kind}/{name}", req.operation);
                 res
             }
             Err(err) => {
-                warn!("denied: {:?} on {} ({})", req.operation, name, err);
+                warn!("denied: {:?} on {kind}/{name} ({})", req.operation, err);
                 res.deny(err.to_string())
             }
         };

--- a/examples/admission_controller.yaml.tpl
+++ b/examples/admission_controller.yaml.tpl
@@ -1,5 +1,5 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: admission-controller-demo
@@ -19,10 +19,10 @@ webhooks:
       #  path: "/mutate"
     rules:
       - operations: ["CREATE", "UPDATE"]
-        apiGroups: ["clux.dev"]
+        apiGroups: ["kube.rs"]
         apiVersions: ["v1"]
-        resources: ["foos"]
+        resources: ["admittests"]
     failurePolicy: Fail
-    admissionReviewVersions: ["v1", "v1beta1"]
+    admissionReviewVersions: ["v1"]
     sideEffects: None
     timeoutSeconds: 5

--- a/examples/admission_crd.yaml
+++ b/examples/admission_crd.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: admittests.kube.rs
+spec:
+  group: kube.rs
+  names:
+    categories: []
+    kind: AdmitTest
+    plural: admittests
+    shortNames: []
+    singular: admittest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns: []
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for AdmitSpec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              info:
+                nullable: true
+                type: string
+              name:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: AdmitTest
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/examples/admission_ok.yaml
+++ b/examples/admission_ok.yaml
@@ -1,5 +1,5 @@
-apiVersion: clux.dev/v1
-kind: Foo
+apiVersion: kube.rs/v1
+kind: AdmitTest
 metadata:
   name: ok
 spec:

--- a/examples/admission_reject.yaml
+++ b/examples/admission_reject.yaml
@@ -1,5 +1,5 @@
-apiVersion: clux.dev/v1
-kind: Foo
+apiVersion: kube.rs/v1
+kind: AdmitTest
 metadata:
   name: reject
   labels:


### PR DESCRIPTION
Currently it was implicitly relying on Foo,
but Foo is different depending on when/where you got it from.

Easier to just make a new CRD for it and make it the only thing we use it for.

Should fix https://github.com/kube-rs/kube/issues/1781