### PR TITLE
add pub fn namespace(&self) -> Option<&str> to Api

### DIFF
--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -62,6 +62,11 @@ pub struct Api<K> {
 ///
 /// This generally means resources created via [`DynamicObject`](crate::api::DynamicObject).
 impl<K: Resource> Api<K> {
+    /// Return a reference to the namespace of this [`Api`] instance, if any
+    pub fn namespace(&self) -> Option<&str> {
+        self.namespace.as_deref()
+    }
+
     /// Cluster level resources, or resources viewed across all namespaces
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.


### PR DESCRIPTION
Signed-off-by: Tom Grushka <tom@dra11y.com>

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

There is currently no way to access the `namespace: Option<String>` private field of the `Api` instance. In case the `Api` is passed around code, as a developer of a `kube-rs` operator / controller, I want to be able to verify the namespace scope of the `Api` instance.

Further details in Feature Request: #1787 


## Solution

Provide immutable access to the `namespace: Option<String>` private field as a `Deref`.

Further details in Feature Request: #1787 
