### PR TITLE
remove prelude Future import

### DIFF
--- a/kube-client/src/api/portforward.rs
+++ b/kube-client/src/api/portforward.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, future::Future};
+use std::collections::HashMap;
 
 use bytes::{Buf, Bytes};
 use futures::{

--- a/kube-client/src/api/remote_command.rs
+++ b/kube-client/src/api/remote_command.rs
@@ -1,5 +1,3 @@
-use std::future::Future;
-
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
 
 use futures::{

--- a/kube-runtime/src/controller/future_hash_map.rs
+++ b/kube-runtime/src/controller/future_hash_map.rs
@@ -1,4 +1,4 @@
-use futures::{Future, FutureExt, Stream};
+use futures::{FutureExt, Stream};
 use std::{
     collections::HashMap,
     hash::Hash,

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -24,7 +24,6 @@ use pin_project::pin_project;
 use serde::de::DeserializeOwned;
 use std::{
     fmt::{Debug, Display},
-    future::Future,
     hash::Hash,
     sync::Arc,
     task::{ready, Poll},

--- a/kube-runtime/src/controller/runner.rs
+++ b/kube-runtime/src/controller/runner.rs
@@ -4,7 +4,7 @@ use futures::{FutureExt, Stream, StreamExt};
 use pin_project::pin_project;
 use std::{
     convert::Infallible,
-    future::{self, Future},
+    future,
     hash::Hash,
     pin::Pin,
     task::{Context, Poll},
@@ -164,7 +164,7 @@ mod tests {
     };
     use futures::{
         channel::{mpsc, oneshot},
-        future, poll, stream, Future, SinkExt, StreamExt, TryStreamExt,
+        future, poll, stream, SinkExt, StreamExt, TryStreamExt,
     };
     use std::{
         cell::RefCell,

--- a/kube-runtime/src/utils/delayed_init.rs
+++ b/kube-runtime/src/utils/delayed_init.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, sync::Mutex, task::Poll};
 
-use futures::{channel, Future, FutureExt};
+use futures::{channel, FutureExt};
 use thiserror::Error;
 use tracing::trace;
 

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -25,7 +25,7 @@ pub use EventDecode as EventFlatten;
 
 use futures::{
     stream::{self, Peekable},
-    Future, FutureExt, Stream, StreamExt, TryStream, TryStreamExt,
+    FutureExt, Stream, StreamExt, TryStream, TryStreamExt,
 };
 use pin_project::pin_project;
 use std::{

--- a/kube-runtime/src/utils/stream_backoff.rs
+++ b/kube-runtime/src/utils/stream_backoff.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, pin::Pin, task::Poll};
+use std::{pin::Pin, task::Poll};
 
 use futures::{Stream, TryStream};
 use pin_project::pin_project;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

The Future trait is added to the prelude at Rust 2024.

## Solution

Removes the import sentences of the Future trait.