### PR TITLE
Fix interactive auth mode to allow prompt messages

### DIFF
--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -588,6 +588,7 @@ fn auth_exec(auth: &ExecConfig) -> Result<ExecCredential, Error> {
     let interactive = auth.interactive_mode != Some(ExecInteractiveMode::Never);
     if interactive {
         cmd.stdin(std::process::Stdio::inherit());
+        cmd.stderr(std::process::Stdio::inherit());
     } else {
         cmd.stdin(std::process::Stdio::piped());
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

During interactive auth with a cluster, `stderr` is ignored - some tools (like [kubelogin](https://github.com/Azure/kubelogin)) use stderr to print a prompt to the user, like a URL to visit. It's possible that this is related also to https://github.com/kube-rs/kube/issues/1632.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

During interactive auth with a cluster, inherit `stderr` as well as `stdout`.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
