### PR TITLE
Fix oidc with openssl

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -73,7 +73,7 @@ hyper-timeout = { workspace = true, optional = true }
 tame-oauth = { workspace = true, features = ["gcp"], optional = true }
 secrecy = { workspace = true }
 tracing = { workspace = true, features = ["log"], optional = true }
-hyper-openssl = { workspace = true, features = ["client-legacy"], optional = true }
+hyper-openssl = { workspace = true, features = ["client-legacy", "tokio"], optional = true }
 form_urlencoded = { workspace = true, optional = true }
 k8s-openapi= { workspace = true, features = [] }
 

--- a/kube-client/src/client/auth/oidc.rs
+++ b/kube-client/src/client/auth/oidc.rs
@@ -267,7 +267,7 @@ compile_error!(
 #[cfg(feature = "rustls-tls")]
 type HttpsConnector = hyper_rustls::HttpsConnector<HttpConnector>;
 #[cfg(all(not(feature = "rustls-tls"), feature = "openssl-tls"))]
-type HttpsConnector = hyper_openssl::HttpsConnector<HttpConnector>;
+type HttpsConnector = hyper_openssl::client::legacy::HttpsConnector<HttpConnector>;
 
 /// Struct for refreshing the ID token with the refresh token.
 #[derive(Debug)]
@@ -334,7 +334,7 @@ impl Refresher {
             .enable_http1()
             .build();
         #[cfg(all(not(feature = "rustls-tls"), feature = "openssl-tls"))]
-        let https = hyper_openssl::HttpsConnector::new()?;
+        let https = hyper_openssl::client::legacy::HttpsConnector::new()?;
 
         let https_client = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(https);
 


### PR DESCRIPTION
## Motivation

This PR fixes the initialisation of the with oidc and openssl [see issue](https://github.com/kube-rs/kube/issues/1806)

## Solution

changing hyper_openssl::HttpsConnector to the new hyper_openssl::client::legacy::HttpsConnector and adding tokio feature to hyper-openssl as it's needed by the HttpsConnector 
