### PR TITLE
Add schemars pin in readme to avoid confusing users

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ schemars = { version = "0.8" }
 k8s-openapi = { version = "0.25", features = ["latest", "schemars"] }
 ```
 
-See [features](https://kube.rs/features/) for a quick overview of default-enabled / opt-in functionality. You can remove `schemars` and the `schemars` feature if you do not need the `kube/derive` feature.
+See [features](https://kube.rs/features/) for a quick overview of default-enabled / opt-in functionality. You can remove `schemars` parts if you do not need the `kube/derive` feature.
 
 ## Upgrading
 


### PR DESCRIPTION
for #1811

also added a delineation in the linked [kubernetes-versions](https://kube.rs/kubernetes-version/) page via https://github.com/kube-rs/website/commit/e523e95aeb0ad9273b795206b3d9219d9ad4e801