### PR TITLE
Add an optional text area for yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,6 +46,14 @@ body:
         k8s-openapi = { version = "0.13.0", features = ["v1_21"], default-features = false }
         ```
 
+  - type: textarea
+    attributes:
+      label: YAML
+      description: |
+        Do you have kubeconfig snippet or resource YAML that would be relevant?
+    validations:
+      required: false
+
   - type: dropdown
     attributes:
       label: Affected crates


### PR DESCRIPTION
occasionally we have bugs related to kubeconfigs and kubernetes resources

maybe this can be a helpful reminder to people.

suggested in https://github.com/kube-rs/kube/issues/1814#issuecomment-3228288580