### PR TITLE
Bump k8s-openapi to 0.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ hyper-timeout = "0.5.1"
 hyper-util = "0.1.16"
 json-patch = "4"
 jsonpath-rust = "0.7.3"
-k8s-openapi = { git = "https://github.com/Arnavion/k8s-openapi.git", rev = "e9a9eaf", default-features = false }
+k8s-openapi = { version = "0.26.0", default-features = false }
 openssl = "0.10.36"
 parking_lot = "0.12.0"
 pem = "3.0.1"

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Select a version of `kube` along matching versions of [k8s-openapi](https://gith
 
 ```toml
 [dependencies]
-kube = { version = "1", features = ["runtime", "derive"] }
-schemars = { version = "0.8" }
-k8s-openapi = { version = "0.25", features = ["latest", "schemars"] }
+kube = { version = "2", features = ["runtime", "derive"] }
+schemars = { version = "1" }
+k8s-openapi = { version = "0.26", features = ["latest", "schemars"] }
 ```
 
 See [features](https://kube.rs/features/) for a quick overview of default-enabled / opt-in functionality. You can remove `schemars` parts if you do not need the `kube/derive` feature.
@@ -158,13 +158,13 @@ Uses [rustls](https://github.com/rustls/rustls) with `ring` provider (default) o
 To switch [rustls providers](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html), turn off `default-features` and enable the `aws-lc-rs` feature:
 
 ```toml
-kube = { version = "1.1.0", default-features = false, features = ["client", "rustls-tls", "aws-lc-rs"] }
+kube = { version = "2.0.0", default-features = false, features = ["client", "rustls-tls", "aws-lc-rs"] }
 ```
 
 To switch to `openssl`, turn off `default-features`, and enable the `openssl-tls` feature:
 
 ```toml
-kube = { version = "1.1.0", default-features = false, features = ["client", "openssl-tls"] }
+kube = { version = "2.0.0", default-features = false, features = ["client", "openssl-tls"] }
 ```
 
 This will pull in `openssl` and `hyper-openssl`. If `default-features` is left enabled, you will pull in two TLS stacks, and the default will remain as `rustls`.


### PR DESCRIPTION
Kubernetes 1.36 via [k8s-openapi 0.26](https://github.com/Arnavion/k8s-openapi/blob/v0.26.0/CHANGELOG.md#k8s-openapi). Keeping MK8SV as is.

Bumping relevant readme places. This means we can release 2.0