### PR TITLE
update to runtime-macros 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ pin-project = "1.0.4"
 proc-macro2 = "1.0.29"
 quote = "1.0.10"
 rand = "0.9.0"
+runtime-macros = "1.1.1"
 rustls = { version = "0.23.16", default-features = false }
 schemars = "1.0.0"
 secrecy = "0.10.2"

--- a/deny.toml
+++ b/deny.toml
@@ -43,7 +43,6 @@ exceptions = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/tyrone-wu/runtime-macros.git"]
 
 
 [bans]

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -34,5 +34,5 @@ schemars = { workspace = true, features = ["chrono04"] }
 chrono.workspace = true
 trybuild.workspace = true
 assert-json-diff.workspace = true
-runtime-macros = { git = "https://github.com/tyrone-wu/runtime-macros.git", rev = "e31f4de52e078d41aba4792a7ea30139606c1362" }
+runtime-macros.workspace = true
 prettyplease.workspace = true


### PR DESCRIPTION
## Motivation

`runtime-macros` `1.1.1` could be used as it updated to `syn` 2.

## Solution

Updates to `runtime-macros` `1.1.1`.