### PR TITLE
Remove unused use<'_> from log_stream()

### DIFF
--- a/kube-client/src/api/subresource.rs
+++ b/kube-client/src/api/subresource.rs
@@ -428,7 +428,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn log_stream(&self, name: &str, lp: &LogParams) -> Result<impl AsyncBufRead + use<'_, K>> {
+    pub async fn log_stream(&self, name: &str, lp: &LogParams) -> Result<impl AsyncBufRead + use<K>> {
         let mut req = self.request.logs(name, lp).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("log_stream");
         self.client.request_stream(req).await


### PR DESCRIPTION
I noticed an additional '_ lifetime being captured in v2.0.0. Going through the Git history, I suspect this was an unintentional change as part of the Rust 2024 migration.