### PR TITLE
Use json_schema! instead of serde_json::from_value

### DIFF
--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -3,7 +3,7 @@ use kube::{
     core::object::{HasSpec, HasStatus},
     CustomResource, CustomResourceExt, Resource,
 };
-use schemars::JsonSchema;
+use schemars::{json_schema, JsonSchema};
 use serde::{Deserialize, Serialize};
 
 /// Our spec for Foo
@@ -63,7 +63,7 @@ fn main() {
 }
 
 fn conditions(_: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
-    serde_json::from_value(serde_json::json!({
+    json_schema!({
         "type": "array",
         "x-kubernetes-list-type": "map",
         "x-kubernetes-list-map-keys": ["type"],
@@ -85,8 +85,7 @@ fn conditions(_: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
                 "type"
             ],
         },
-    }))
-    .unwrap()
+    })
 }
 
 // some tests

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -9,6 +9,7 @@ use kube::{
     runtime::wait::{await_condition, conditions},
     Client, CustomResource, CustomResourceExt, KubeSchema,
 };
+use schemars::json_schema;
 use serde::{Deserialize, Serialize};
 
 // This example shows how the generated schema affects defaulting and validation.
@@ -121,7 +122,7 @@ impl FooSpec {
 
 // https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy
 fn set_listable_schema(_: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
-    serde_json::from_value(serde_json::json!({
+    json_schema!({
         "type": "array",
         "items": {
             "format": "u32",
@@ -129,8 +130,7 @@ fn set_listable_schema(_: &mut schemars::generate::SchemaGenerator) -> schemars:
             "type": "integer"
         },
         "x-kubernetes-list-type": "set"
-    }))
-    .unwrap()
+    })
 }
 
 fn default_value() -> String {

--- a/kube-client/src/api/util/mod.rs
+++ b/kube-client/src/api/util/mod.rs
@@ -79,10 +79,10 @@ mod test {
 
         let node_name = "fakenode";
         let fake_node = serde_json::from_value(json!({
-        "apiVersion": "v1",
-        "kind": "Node",
-        "metadata": {
-            "name": node_name,
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "name": node_name,
             },
         }))?;
 

--- a/kube-core/src/duration.rs
+++ b/kube-core/src/duration.rs
@@ -283,12 +283,10 @@ impl schemars::JsonSchema for Duration {
     }
 
     fn json_schema(_: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
-        use schemars::json_schema;
-
         // the format should *not* be "duration", because "duration" means
         // the duration is formatted in ISO 8601, as described here:
         // https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-02#section-7.3.1
-        json_schema!({
+        schemars::json_schema!({
             "type": "string",
         })
     }


### PR DESCRIPTION
## Motivation

schemars has a dedicated macro to construct schemas from JSON: https://docs.rs/schemars/latest/schemars/macro.json_schema.html, so we should use that

I tried to get the CI green but the failures seem unrelated. `cargo test --all` passes locally
