### PR TITLE
chore: Remove dependency on home crate, use std instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ either = "1.6.1"
 form_urlencoded = "1.2.0"
 futures = { version = "0.3.17", default-features = false }
 hashbrown = "0.16.0"
-home = "0.5.4"
 hostname = "0.4"
 http = "1.1.0"
 http-body = "1.0.1"

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -26,7 +26,7 @@ gzip = ["client", "tower-http/decompression-gzip"]
 client = ["config", "__non_core", "hyper", "hyper-util", "http-body", "http-body-util", "tower", "tower-http", "hyper-timeout", "chrono", "jsonpath-rust", "bytes", "futures", "tokio", "tokio-util", "either"]
 jsonpatch = ["kube-core/jsonpatch"]
 admission = ["kube-core/admission"]
-config = ["__non_core", "pem", "home"]
+config = ["__non_core", "pem"]
 socks5 = ["hyper-util/client-proxy"]
 http-proxy = ["hyper-util/client-proxy"]
 unstable-client = []
@@ -45,7 +45,6 @@ workspace = true
 [dependencies]
 base64 = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
-home = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml = { workspace = true, optional = true }

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -660,7 +660,15 @@ fn ensure_trailing_newline(mut data: Vec<u8>) -> Vec<u8> {
 
 /// Returns kubeconfig path from `$HOME/.kube/config`.
 fn default_kube_path() -> Option<PathBuf> {
-    home::home_dir().map(|h| h.join(".kube").join("config"))
+    // Before Rust 1.85.0, `home_dir` would return wrong results on Windows, usage of the crate
+    // `home` was encouraged (and is what kube-rs did).
+    // Rust 1.85.0 fixed the problem (https://doc.rust-lang.org/1.85.0/std/env/fn.home_dir.html),
+    // Rust 1.87.0 removed the function deprecation.
+    // As the MSRV was bumped to 1.85.0 we are safe to use the fixed std function.
+    // Note: We intentionally use `allow` over `expect` to support compilation on Rust >= 1.87.0
+    // Note: This can be removed once the MSRV is bumped to >= 1.87.0
+    #[allow(deprecated)]
+    std::env::home_dir().map(|h| h.join(".kube").join("config"))
 }
 
 mod base64serde {


### PR DESCRIPTION
## Motivation

We have CI problems related to the `home` crate (https://github.com/kube-rs/kube/pull/1839), so I looked up what that crate is doing.

## Solution

In it's description it states that Rust 1.85.0 fixed the Windows HOME problems and users are encouraged to use `std` instead.

So I did exactly that, as kube's MSRV is 1.85.0.
