### PR TITLE
Fix typo in config mod.rs

### DIFF
--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -114,7 +114,7 @@ pub enum LoadDataError {
     NoBase64DataOrFile,
 }
 
-/// Configuration object for accessing a Kuernetes cluster
+/// Configuration object for accessing a Kubernetes cluster
 ///
 /// The configurable parameters for connecting like cluster URL, default namespace, root certificates, and timeouts.
 /// Normally created implicitly through [`Config::infer`] or [`Client::try_default`](crate::Client::try_default).


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

I sent a colleague a link to https://docs.rs/kube-client/2.0.1/kube_client/config/struct.Config.html#structfield.root_cert, and the link preview showed "Configuration object for accessing a **Kuernetes** cluster", which I couldn't stand 😭 

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

replaced Kuernetes with Kubernetes
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
