### PR TITLE
fix: add use<> to kubelet_node_logs for rust edition 2024

### DIFF
--- a/kube-client/src/client/kubelet_debug.rs
+++ b/kube-client/src/client/kubelet_debug.rs
@@ -1,9 +1,9 @@
 use crate::{
-    Client, Error, Result,
     api::{AttachParams, AttachedProcess, LogParams, Portforwarder},
     client::AsyncBufRead,
+    Client, Error, Result,
 };
-use kube_core::{Request, kubelet_debug::KubeletDebugParams};
+use kube_core::{kubelet_debug::KubeletDebugParams, Request};
 use std::fmt::Debug;
 
 /// Methods to access debug endpoints directly on `kubelet`


### PR DESCRIPTION
## Motivation

`kubelet_node_logs` is overcapturing lifetimes after the changes in Rust edition 2024

## Solution

Add `+ use<>` to not capture what's not needed