### PR TITLE
Adds a `try_clone` method for `kube_client::client::Body` when it's `Kind::Once`

### DIFF
--- a/kube-client/src/client/body.rs
+++ b/kube-client/src/client/body.rs
@@ -53,6 +53,18 @@ impl Body {
     pub async fn collect_bytes(self) -> Result<Bytes, crate::Error> {
         Ok(self.collect().await?.to_bytes())
     }
+
+    /// Tries to clone a [`Body`].
+    ///
+    /// Returns the cloned `Body` when it's [`Kind::Once`].
+    pub fn try_clone(&self) -> Option<Self> {
+        match &self.kind {
+            Kind::Once(bytes) => Some(Self {
+                kind: Kind::Once(bytes.clone()),
+            }),
+            Kind::Wrap(..) => None,
+        }
+    }
 }
 
 impl From<Bytes> for Body {


### PR DESCRIPTION
The easy part of https://github.com/kube-rs/kube/issues/1857

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Makes it possible to implement a `tower::retry::Policy` for retrying kube operations.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Adds a method for cloning the `Body` when its kind is `Kind::Once`. The `Kind::Wrap` seems a bit more complex to implement the same thing for it (and I don't think it's needed, since the end goal here is to implement `tower::retry::Policy`).
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
