### PR TITLE
Distinguish between initial and resumed watch phases for streaming lists

### DIFF
--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -947,3 +947,31 @@ impl Backoff for DefaultBackoff {
         self.0.reset();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_watch_params_initial_phase_with_streaming_list_sets_send_initial_events() {
+        let config = Config::default().streaming_lists();
+        let params = config.to_watch_params(WatchPhase::Initial);
+        assert!(params.send_initial_events);
+    }
+
+    #[test]
+    fn to_watch_params_resumed_phase_with_streaming_list_does_not_set_send_initial_events() {
+        let config = Config::default().streaming_lists();
+        let params = config.to_watch_params(WatchPhase::Resumed);
+        assert!(!params.send_initial_events);
+    }
+
+    #[test]
+    fn to_watch_params_listwatch_mode_does_not_set_send_initial_events() {
+        let config = Config::default(); // ListWatch mode
+        let params_initial = config.to_watch_params(WatchPhase::Initial);
+        let params_resumed = config.to_watch_params(WatchPhase::Resumed);
+        assert!(!params_initial.send_initial_events);
+        assert!(!params_resumed.send_initial_events);
+    }
+}


### PR DESCRIPTION
## Motivation

Fixes #1844

When using `streaming_lists()` mode, users observe duplicate events every ~290 seconds. This happens because watch connections timeout after 290s (Kubernetes API limitation), and when reconnecting, the watcher incorrectly sets `sendInitialEvents=true`, causing the API server to resend all objects.

The root cause is that `to_watch_params()` always sets `send_initial_events=true` for StreamingList mode, regardless of whether it's an initial watch or a reconnection.

## Solution

Introduce a `WatchPhase` enum to distinguish between initial and resumed watches:

```rust
enum WatchPhase {
    Initial,  // from State::Empty - requests initial events
    Resumed,  // from State::InitListed - no initial events
}
```

- WatchPhase::Initial: Used when starting a fresh streaming list watch, sets sendInitialEvents=true
- WatchPhase::Resumed: Used when reconnecting after timeout, sets sendInitialEvents=false

This aligns with how client-go handles streaming lists - it uses watchList() for initial sync and watch() for reconnections, never requesting initial events on reconnection.
