### PR TITLE
Add nullable to optional fields with x-kubernetes-int-or-string

### DIFF
--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro = true
 serde = { workspace = true, features = ["derive"] }
 serde_yaml.workspace = true
 kube = { path = "../kube", version = ">=1", features = ["derive", "client"] }
-k8s-openapi = { workspace = true, features = ["latest"] }
+k8s-openapi = { workspace = true, features = ["latest", "schemars"] }
 schemars = { workspace = true, features = ["chrono04","jiff02"] }
 jiff.workspace = true
 trybuild.workspace = true

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -676,6 +676,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
                 .with_transform(#schemars::transform::AddNullable::default())
                 .with_transform(#kube_core::schema::StructuralSchemaRewriter)
                 .with_transform(#kube_core::schema::OptionalEnum)
+                .with_transform(#kube_core::schema::OptionalIntOrString)
                 .into_generator();
             let schema = generate.into_root_schema_for::<Self>();
         }


### PR DESCRIPTION
## Motivation

Fixes #1869

When using `Option<IntOrString>` or `Option<Quantity>` (k8s-openapi 0.26.x) in CRD specs, the generated schema is missing `nullable: true`, causing server-side apply to fail with:

Invalid value: "null": spec.foo in body must be of type integer,string: "null"

The root cause is that schemars' `AddNullable` transform only adds `nullable: true` to schemas with a `type` property. However, `IntOrString` and `Quantity` schemas only have `x-kubernetes-int-or-string: true` without a `type`, so they're skipped.

## Solution

Add `OptionalIntOrString` transform that:
1. Iterates over object properties
2. For properties NOT in the `required` list that have `x-kubernetes-int-or-string: true`
3. Adds `nullable: true` if not already present

This mirrors how Go's controller-tools handles nullable for pointer types (`*IntOrString`).

**Before:**

```json
{ "x-kubernetes-int-or-string": true }
```

After:
```
{ "x-kubernetes-int-or-string": true, "nullable": true }
```