### PR TITLE
Permit older version of API for v2 discovery for k8s < 1.30 (down to 1.27)

### DIFF
--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -14,7 +14,7 @@ use http_body_util::BodyExt;
 #[cfg(feature = "ws")] use hyper_util::rt::TokioIo;
 use jiff::Timestamp;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as k8s_meta_v1;
-use kube_core::response::Status;
+use kube_core::{discovery::v2::ACCEPT_AGGREGATED_DISCOVERY_V2, response::Status};
 use serde::de::DeserializeOwned;
 use serde_json::{self, Value};
 #[cfg(feature = "ws")]
@@ -477,10 +477,6 @@ impl Client {
         .await
     }
 }
-
-/// Content negotiation Accept header for Aggregated Discovery API v2
-const ACCEPT_AGGREGATED_DISCOVERY_V2: &str =
-    "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList";
 
 /// Aggregated Discovery API methods
 ///

--- a/kube-core/src/discovery/v2.rs
+++ b/kube-core/src/discovery/v2.rs
@@ -8,6 +8,10 @@
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ListMeta, ObjectMeta};
 use serde::{Deserialize, Serialize};
 
+/// Content negotiation Accept header for Aggregated Discovery API v2
+pub const ACCEPT_AGGREGATED_DISCOVERY_V2: &str = "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList,application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json";
+
+
 /// APIGroupDiscoveryList is a resource containing a list of APIGroupDiscovery.
 /// This is one of the types that can be returned from the /api and /apis endpoint
 /// and contains an aggregated list of API resources (built-ins, Custom Resource Definitions, resources from aggregated servers)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

Typical k8s feature gate graduation policy in `beta` usually means that the feature is enabled by default in all cluster installation from the first version where the feature graduated to `beta`. Since for aggregated discovery it was ~ k8s 1.27 (according to [removed features](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/#feature-gates-that-are-removed) - `AggregatedDiscoveryEndpoint `), `kube` client code should generally just work with aggregated discovery on these cluster versions already

Unfortunately, it seems that the first version where current aggregated call actually succeeds is after k8s `1.27`. It is easily reproducible by creating a kind cluster and issuing a `curl` call with the `Accept` header defined in `ACCEPT_AGGREGATED_DISCOVERY_V2`:

```sh
kind create cluster --image kindest/node:v1.27.16
# Fails
curl -XGET -H "Accept: application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList" 'https://127.0.0.1:<port>/apis' -k -H "Authorization: Bearer ${token}"
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "only the following media types are accepted: application/json, application/yaml, application/vnd.kubernetes.protobuf",
  "reason": "NotAcceptable",
  "code": 406
}

# Works
curl -XGET -H "Accept: application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList,application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json" 'https://127.0.0.1:<port>/apis' -k -H "Authorization: Bearer ${token}" | head -10 # Works
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0{
  "kind": "APIGroupDiscoveryList",
  "apiVersion": "apidiscovery.k8s.io/v2beta1",
  "metadata": {},
  "items": [
    {
      "metadata": {
        "name": "apiregistration.k8s.io",
        "creationTimestamp": null
      }
...
```

The reason is explained in https://github.com/kubernetes/kubernetes/issues/129001#issuecomment-2514460363, or it applies in opposite direction to the current header state, requesting version `v2` only. 

## Solution

Update header to accept `v2beta1` api version also. According to the [comment](https://github.com/kubernetes/kubernetes/issues/129001#issuecomment-2518335834), the only diff in `CRD` is api version, so current `APIGroupDiscoveryList` structures will accept different version without issues.

Also exposed the constant and moved it into API, as this is the only place where the definitions exist, and would allow to benefit from it for raw client query users.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
