### PR TITLE
Add a metadata field to Status

### DIFF
--- a/kube-core/src/admission.rs
+++ b/kube-core/src/admission.rs
@@ -234,7 +234,7 @@ pub enum Operation {
 ///     .into_review();
 ///
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AdmissionResponse {

--- a/kube-core/src/conversion/types.rs
+++ b/kube-core/src/conversion/types.rs
@@ -171,6 +171,7 @@ impl From<ConversionRequest> for ConversionResponse {
                 status: None,
                 code: 0,
                 message: String::new(),
+                metadata: None,
                 reason: String::new(),
                 details: None,
             },


### PR DESCRIPTION
This is a fresh attempt at https://github.com/kube-rs/kube/pull/1809

The motivation is summarized in https://github.com/kube-rs/kube/issues/1890

Reviewer notes:
- I opted to grab the `ListMeta` field directly from k8s-openapi. This...kind of feels weird, since the kube_core::Status is now _extremely_ similar to the k8s-openapi `Status`. Should these just be the same struct?
- `ListMeta` does not impl `Eq`, so I removed it from `Status`. As such, this PR is a breaking change in at least 2 ways (it adds a new field, and it removes an impl).

I can manually impl `Eq` (which is safe right now, but may become unsafe in the future). I can also use a separate struct that is wire-compatible with the k8s-openapi struct (I'd probably only define the continue token initially). Preferences?