### PR TITLE
simplify the async doc examples

### DIFF
--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -701,26 +701,26 @@ where
 /// The events are intended to provide a safe input interface for a state store like a [`reflector`].
 /// Direct users may want to use [`WatchStreamExt`] for higher-level constructs.
 ///
-/// ```no_run
+/// ```
 /// use kube::{
 ///   api::{Api, ResourceExt}, Client,
 ///   runtime::{watcher, WatchStreamExt}
 /// };
 /// use k8s_openapi::api::core::v1::Pod;
 /// use futures::TryStreamExt;
-/// #[tokio::main]
-/// async fn main() -> Result<(), watcher::Error> {
-///     let client = Client::try_default().await.unwrap();
-///     let pods: Api<Pod> = Api::namespaced(client, "apps");
 ///
-///     watcher(pods, watcher::Config::default()).applied_objects()
-///         .try_for_each(|p| async move {
-///          println!("Applied: {}", p.name_any());
-///             Ok(())
-///         })
-///         .await?;
-///     Ok(())
-/// }
+/// # async fn wrapper() -> Result<(), watcher::Error> {
+/// #   let client: Client = todo!();
+/// let pods: Api<Pod> = Api::namespaced(client, "apps");
+///
+/// watcher(pods, watcher::Config::default()).applied_objects()
+///     .try_for_each(|p| async move {
+///         println!("Applied: {}", p.name_any());
+///        Ok(())
+///     })
+///     .await?;
+/// # Ok(())
+/// # }
 /// ```
 /// [`WatchStreamExt`]: super::WatchStreamExt
 /// [`reflector`]: super::reflector::reflector
@@ -765,26 +765,26 @@ pub fn watcher<K: Resource + Clone + DeserializeOwned + Debug + Send + 'static>(
 /// The events are intended to provide a safe input interface for a state store like a [`reflector`].
 /// Direct users may want to use [`WatchStreamExt`] for higher-level constructs.
 ///
-/// ```no_run
+/// ```
 /// use kube::{
 ///   api::{Api, ResourceExt}, Client,
 ///   runtime::{watcher, metadata_watcher, WatchStreamExt}
 /// };
 /// use k8s_openapi::api::core::v1::Pod;
 /// use futures::TryStreamExt;
-/// #[tokio::main]
-/// async fn main() -> Result<(), watcher::Error> {
-///     let client = Client::try_default().await.unwrap();
-///     let pods: Api<Pod> = Api::namespaced(client, "apps");
 ///
-///     metadata_watcher(pods, watcher::Config::default()).applied_objects()
+/// # async fn wrapper() -> Result<(), watcher::Error> {
+/// #   let client: Client = todo!();
+/// let pods: Api<Pod> = Api::namespaced(client, "apps");
+///
+/// metadata_watcher(pods, watcher::Config::default()).applied_objects()
 ///         .try_for_each(|p| async move {
 ///          println!("Applied: {}", p.name_any());
 ///             Ok(())
 ///         })
 ///         .await?;
-///     Ok(())
-/// }
+/// #   Ok(())
+/// # }
 /// ```
 /// [`WatchStreamExt`]: super::WatchStreamExt
 /// [`reflector`]: super::reflector::reflector


### PR DESCRIPTION
## What Problem are you trying to Solve ?

This is solving issue (#912)

Previously we were using two patterns for the docs, one  leads to the full async-setup visible in every example [Api Docs](https://docs.rs/kube/latest/kube/struct.Api.html) and the other leads to business-action only [EventRecorder docs](https://docs.rs/kube/latest/kube/runtime/events/struct.Recorder.html)

We wanted to use the second pattern **Business-action** only. we need to comment out hidden imports, comment out the async wrappers. Deindent it.


I have first started with `kube-runtime>src>watcher.rs`

There are two places in `watcher.rs` code file where full async setup is visible, I converted it into the second pattern.

Removed `#[tokio::main]` so that it shows the API usage only


Instance 1

<img width="750" height="497" alt="instance1" src="https://github.com/user-attachments/assets/2664db06-424e-4372-beb3-8f695d46f32b" />

Instance 2

<img width="833" height="492" alt="instance2" src="https://github.com/user-attachments/assets/b7fa3040-4775-4cbf-955c-9a1979880a8f" />


I ran the tests and everything passed successfully .

<img width="878" height="177" alt="tests" src="https://github.com/user-attachments/assets/a7193fee-84d6-48a2-ad3f-aa5f2aa5e0b7" />


@clux  Sir i have raised the new pull-request and retested everything with `cargo test --doc -p kube-runtime` and all tests were passed

The first pull-request was #1893 