### PR TITLE
Simplify async doc examples v1

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -603,9 +603,9 @@ impl Config {
 /// }
 ///
 /// /// something to drive the controller
-/// 
+///
 /// async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
-/// #   let client: Client = todo!(); 
+/// #   let client: Client = todo!();
 ///     let context = Arc::new(()); // bad empty context - put client in here
 ///     let cmgs = Api::<ConfigMapGenerator>::all(client.clone());
 ///     let cms = Api::<ConfigMap>::all(client.clone());


### PR DESCRIPTION
## What Problem are you trying to Solve ?

This is solving issue (#912)

Previously we were using two patterns for the docs, one  leads to the full async-setup visible in every example [Api Docs](https://docs.rs/kube/latest/kube/struct.Api.html) and the other leads to business-action only [EventRecorder docs](https://docs.rs/kube/latest/kube/runtime/events/struct.Recorder.html)

We wanted to use the second pattern **Business-action** only. we need to comment out hidden imports, comment out the async wrappers. Deindent it.

Made changes in the following file `kube-runtime>src>controller>mod.rs`


**What are the changes that has been Implemented ?**

- Removed the Tokio runtime entrypoint
- used `async fn wrapper` 
- Hide client initialization,  used `todo!()` 
- rapped `runtime only lines` in hidden section

Every change is similar to the one done in `watcher.rs` file

There are more places inside `mod.rs` file where changes needs to be made.

I have implemented change at one place Line `602-624` and all the test cases passed properly

### Code  Changes made 

<img width="811" height="442" alt="mod rs" src="https://github.com/user-attachments/assets/b2cc8c51-f7f8-41c4-853b-4d084e4e46ee" />


### Passed Test cases

<img width="967" height="170" alt="all-tests" src="https://github.com/user-attachments/assets/caa38826-93c4-4bf4-9494-45aa428329da" />


I am still making more changes

@clux Sir