### PR TITLE
Update API version of AdmissionResponse created via invalid call

### DIFF
--- a/kube-core/src/admission.rs
+++ b/kube-core/src/admission.rs
@@ -33,8 +33,6 @@ pub struct ConvertAdmissionReviewError;
 pub const META_KIND: &str = "AdmissionReview";
 /// The `api_version` field in [`TypeMeta`] on the v1 version.
 pub const META_API_VERSION_V1: &str = "admission.k8s.io/v1";
-/// The `api_version` field in [`TypeMeta`] on the v1beta1 version.
-pub const META_API_VERSION_V1BETA1: &str = "admission.k8s.io/v1beta1";
 
 /// The top level struct used for Serializing and Deserializing AdmissionReview
 /// requests and responses.
@@ -301,7 +299,7 @@ impl AdmissionResponse {
             // supported and we won't be using any of the new fields.
             types: TypeMeta {
                 kind: META_KIND.to_owned(),
-                api_version: META_API_VERSION_V1BETA1.to_owned(),
+                api_version: META_API_VERSION_V1.to_owned(),
             },
             uid: Default::default(),
             allowed: false,


### PR DESCRIPTION
The API version is hardcoded to v1beta1, which is obsoleted since K8S v1.22. Giving v1.22 is not supported by kube-rs. Simply update the version is alright.

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Fix #1904 

## Solution

The API versions v1 and v1beta1 are defined in two consts. Update the only place that uses them from v1beta1 to v1, and remove the v1beta1 const. Building passed indicates that there is no other place using v1beta1 const.
