### PR TITLE
simplify cluster_url parse

### DIFF
--- a/examples/pod_log_kubelet_debug.rs
+++ b/examples/pod_log_kubelet_debug.rs
@@ -3,7 +3,6 @@ use k8s_openapi::api::core::v1::Pod;
 use tracing::*;
 
 use futures::AsyncBufReadExt;
-use hyper::Uri;
 use kube::{
     Client, Config,
     api::{Api, DeleteParams, ResourceExt},
@@ -62,7 +61,7 @@ async fn kubelet_log() -> anyhow::Result<()> {
     // and assumes 10250 is a reachable kubelet port (k3d default)
     let mut config = Config::infer().await?;
     config.accept_invalid_certs = true;
-    config.cluster_url = "https://localhost:10250".to_string().parse::<Uri>().unwrap();
+    config.cluster_url = "https://localhost:10250".parse().unwrap();
     let client: Client = config.try_into()?;
 
     // Get logs directly from the node, bypassing the kube-apiserver

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -135,7 +135,6 @@ mod test {
         client::ConfigExt,
     };
     use futures::{AsyncBufRead, AsyncBufReadExt, StreamExt, TryStreamExt};
-    use hyper::Uri;
     use k8s_openapi::api::core::v1::{EphemeralContainer, Pod, PodSpec};
     use kube_core::{
         params::{DeleteParams, Patch, PatchParams, PostParams, WatchParams},
@@ -954,7 +953,7 @@ mod test {
 
         let mut config = Config::infer().await?;
         config.accept_invalid_certs = true;
-        config.cluster_url = "https://localhost:10250".to_string().parse::<Uri>().unwrap();
+        config.cluster_url = "https://localhost:10250".parse().unwrap();
         let kubelet_client: Client = config.try_into()?;
 
         // Verify exec works and we can get the output


### PR DESCRIPTION
## Motivation

The `cluster_url` parsing could be simplified.

## Solution

Parsing the url directly.