### PR TITLE
Feat: Indexer

### DIFF
--- a/kube-runtime/src/indexer.rs
+++ b/kube-runtime/src/indexer.rs
@@ -1,0 +1,50 @@
+use async_stream::stream;
+use futures::{Stream, StreamExt};
+use std::{hash::Hash, sync::Arc};
+
+use crate::{reflector::Lookup, watcher};
+
+pub trait Index<K> {
+    fn apply(&self, obj: K);
+    fn delete(&self, obj: &K);
+    fn rehydrate(&self, objs: Vec<K>);
+}
+
+pub fn indexer<K, I: Index<K>, W>(index: Arc<I>, stream: W) -> impl Stream<Item = W::Item>
+where
+    K: Lookup + Clone,
+    K::DynamicType: Eq + Hash + Clone,
+    W: Stream<Item = watcher::Result<watcher::Event<K>>>,
+{
+    let mut stream = Box::pin(stream);
+    stream! {
+        let mut buffer = Vec::new();
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(ev) => {
+                    match &ev {
+                        watcher::Event::Apply(obj) => {
+                            index.apply(obj.clone());
+                        }
+                        watcher::Event::Delete(obj) => {
+                            index.delete(&obj);
+                        }
+                        watcher::Event::Init => {
+                            buffer = Vec::new();
+                        }
+                        watcher::Event::InitApply(obj) => {
+                            buffer.push(obj.clone());
+                        }
+                        watcher::Event::InitDone => {
+                            index.rehydrate(buffer);
+                            buffer = Vec::new();
+                        }
+                    };
+
+                    yield Ok(ev);
+                },
+                Err(ev) => yield Err(ev)
+            }
+        }
+    }
+}

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -24,6 +24,7 @@ pub mod controller;
 pub mod events;
 
 pub mod finalizer;
+pub mod indexer;
 pub mod reflector;
 pub mod scheduler;
 pub mod utils;
@@ -32,6 +33,7 @@ pub mod watcher;
 
 pub use controller::{Config, Controller, applier};
 pub use finalizer::finalizer;
+pub use indexer::{Index, indexer};
 pub use reflector::reflector;
 pub use scheduler::scheduler;
 pub use utils::WatchStreamExt;

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -1,4 +1,5 @@
 use crate::{
+    Index,
     utils::{
         event_decode::EventDecode,
         event_modify::EventModify,
@@ -16,6 +17,7 @@ use crate::{
 
 use crate::watcher::DefaultBackoff;
 use futures::{Stream, TryStream};
+use std::sync::Arc;
 
 /// Extension trait for streams returned by [`watcher`](watcher()) or [`reflector`](crate::reflector::reflector)
 pub trait WatchStreamExt: Stream {
@@ -273,6 +275,15 @@ pub trait WatchStreamExt: Stream {
         K::DynamicType: Eq + std::hash::Hash + Clone,
     {
         crate::reflector(writer, self)
+    }
+
+    fn index<K, I: Index<K>>(self, index: Arc<I>) -> impl Stream<Item = Self::Item>
+    where
+        Self: Stream<Item = watcher::Result<watcher::Event<K>>> + Sized,
+        K: Resource + Clone + 'static,
+        K::DynamicType: Eq + std::hash::Hash + Clone,
+    {
+        crate::indexer(index, self)
     }
 }
 


### PR DESCRIPTION
## Motivation

kube-rs does not have native way to create user defined cache/index that is shared between multiple resource types.
This index implementation is inspired by kubert's index implementation (https://github.com/olix0r/kubert/blob/main/kubert/src/index.rs, https://github.com/linkerd/linkerd2/blob/main/policy-controller/k8s/index/src/inbound/index.rs) but implemented in more kube-rs native style.

Most useful perk of indexer is ability to cache forward relations that can later be used in controllers `watches` fn to add relations that do not exist in target resource spec/status (i.e. service selector -> pod)

## Solution

This is initial draft implementation, any suggestions to this design are appreciated.

Implement trait to represent apply / delete / rehydrate (reload)  api, and watcher stream extension to trigger those api calls. 
