### PR TITLE
use tower_http::ServiceExt

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -67,7 +67,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "http1",
 hyper-rustls = { workspace = true, features = ["http1", "logging", "native-tokio", "tls12"], optional = true }
 tokio-tungstenite = { workspace = true, optional = true }
 tower = { workspace = true, features = ["buffer", "filter", "util", "retry"], optional = true }
-tower-http = { workspace = true, features = ["auth", "map-response-body", "trace"], optional = true }
+tower-http = { workspace = true, features = ["auth", "map-response-body", "trace", "util"], optional = true }
 hyper-timeout = { workspace = true, optional = true }
 tame-oauth = { workspace = true, features = ["gcp"], optional = true }
 secrecy = { workspace = true }


### PR DESCRIPTION
## Motivation

`tower_http::ServiceExt` could be used to simplify service converting.

## Solution

Changes to use `tower_http::ServiceExt`.
