### PR TITLE
allow empty body in const context

### DIFF
--- a/kube-client/src/client/body.rs
+++ b/kube-client/src/client/body.rs
@@ -31,12 +31,12 @@ enum Kind {
 }
 
 impl Body {
-    fn new(kind: Kind) -> Self {
+    const fn new(kind: Kind) -> Self {
         Body { kind }
     }
 
     /// Create an empty body
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self::new(Kind::Once(None))
     }
 


### PR DESCRIPTION
Allows to construct empty body in the const context.