### PR TITLE
Use Duration::abs_diff in approx_eq test helper

### DIFF
--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -978,8 +978,7 @@ mod tests {
     }
 
     fn approx_eq(a: Duration, b: Duration) -> bool {
-        let diff = if a > b { a - b } else { b - a };
-        diff < Duration::from_micros(100)
+        a.abs_diff(b) < Duration::from_micros(100)
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

The approx_eq helper function in kube-runtime/src/watcher.rs uses a manual pattern to calculate the absolute difference between two Duration values:

```rust
let diff = if a > b { a - b } else { b - a };
```

Duration::abs_diff is stable and provides a cleaner, more idiomatic way to achieve this.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

Replace the manual absolute difference calculation with Duration::abs_diff:

```rust
fn approx_eq(a: Duration, b: Duration) -> bool {
    a.abs_diff(b) < Duration::from_micros(100)                                 
}       
```