### PR TITLE
Update rand dev-dependency from 0.9 to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ pem = "3.0.1"
 pin-project = "1.0.4"
 proc-macro2 = "1.0.29"
 quote = "1.0.10"
-rand = "0.9.0"
+rand = "0.10.0"
 runtime-macros = "1.1.1"
 rustls = { version = "0.23.16", default-features = false }
 schemars = "1.0.0"

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -141,7 +141,7 @@ mod tests {
     use futures::{StreamExt, TryStreamExt, stream};
     use k8s_openapi::{api::core::v1::ConfigMap, apimachinery::pkg::apis::meta::v1::ObjectMeta};
     use rand::{
-        Rng,
+        RngExt,
         distr::{Bernoulli, Uniform},
     };
     use std::collections::{BTreeMap, HashMap};


### PR DESCRIPTION
##  Motivation:

Dependabot PR #1935 proposed updating rand to 0.10, but it only bumped the version in Cargo.toml without addressing the breaking API change, causing CI failure.

## Solution:
                                         
- Update rand workspace dependency from 0.9.0 to 0.10.0
- Rename `rand::Rng` to `rand::RngExt` in test code (kube-runtime/src/reflector/mod.rs), following the https://rust-random.github.io/book/update-0.10.html

rand is only used as a dev-dependency in kube-runtime, so this has no impact on the public API.