### PR TITLE
fix: feature-flag CREATE_NO_WINDOW to not break stderr inheritance

### DIFF
--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -619,8 +619,16 @@ fn auth_exec(auth: &ExecConfig) -> Result<ExecCredential, Error> {
 
     #[cfg(target_os = "windows")]
     {
-        const CREATE_NO_WINDOW: u32 = 0x08000000;
-        cmd.creation_flags(CREATE_NO_WINDOW);
+        // Opt-in via env var; see https://github.com/kube-rs/kube/issues/1901 for why
+        // this is gated (CREATE_NO_WINDOW breaks stderr inheritance for interactive exec
+        // plugins like kubelogin.exe).
+        if std::env::var("KUBE_RS_UNSTABLE_CREATE_NO_WINDOW")
+            .map(|s| s == "1")
+            .unwrap_or(false)
+        {
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
     }
 
     let out = cmd.output().map_err(Error::AuthExecStart)?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

Please refer to #1901 for a thorough description of the issue.

To summarize, setting the `CREATE_NO_WINDOW` flag in process creation for Windows makes it so that the stderr inheritance breaks (writes ~only happen when the process ends).

In a scenario with interactive login, device code verification messages would get passed to stderr, but with the current code, they would not be shown until the process would end, making 2FA impossible to fulfill.

## Solution

I merely introduced the consensus we came to in the issue (inline envvar check). If there are changes required, I'll do them.

I chose to omit tests, etc, because the Windows tests situation already seems to be rather messy, and testing this is kind of annoying (though doable.)