### PR TITLE
Handle RwLock write poisoning in ReloadingVerifier

### DIFF
--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -153,7 +153,7 @@ pub mod rustls_tls {
                     return guard.0.clone();
                 }
             }
-            let mut guard = self.inner.write().unwrap();
+            let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
             if guard.1.elapsed() < Self::RELOAD_INTERVAL {
                 return guard.0.clone();
             }


### PR DESCRIPTION
## Motivation

PR #1976 fixed the read lock in `ReloadingVerifier::current()` to gracefully handle poisoning via `unwrap_or_else(|e| e.into_inner())`, but the write lock on the next line was left as a bare `.unwrap()`.

If any thread panics while holding the `RwLock`, subsequent CA bundle reload attempts will cascade-panic on the write path instead of recovering with the stale data, which is the intended behavior (as shown by the read lock fix and the `tracing::warn` fallback on reload failure).

**Failure scenario:** The `current()` method is called from the `ServerCertVerifier` trait implementation, which runs on every TLS handshake. If any prior handshake panics while reloading the CA bundle, all subsequent TLS connections panic instead of gracefully using the cached verifier.

This was introduced in #1962 and the read side was fixed in #1976 (merged 2026-05-04). The write side was missed.

## Solution

Apply the same `unwrap_or_else(|e| e.into_inner())` pattern already used by the read lock five lines above.