### PR TITLE
Fix AttachedProcess task leak on drop and join() deadlock

### DIFF
--- a/kube-client/src/api/remote_command.rs
+++ b/kube-client/src/api/remote_command.rs
@@ -112,7 +112,15 @@ pub struct AttachedProcess {
     stderr_reader: Option<DuplexStream>,
     status_rx: Option<StatusReceiver>,
     terminal_resize_tx: Option<TerminalSizeSender>,
-    task: tokio::task::JoinHandle<Result<(), Error>>,
+    task: Option<tokio::task::JoinHandle<Result<(), Error>>>,
+}
+
+impl Drop for AttachedProcess {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
 }
 
 impl AttachedProcess {
@@ -153,7 +161,7 @@ impl AttachedProcess {
             has_stdin: ap.stdin,
             has_stdout: ap.stdout,
             has_stderr: ap.stderr,
-            task,
+            task: Some(task),
             stdin_writer: Some(stdin_writer),
             stdout_reader,
             stderr_reader,
@@ -224,12 +232,26 @@ impl AttachedProcess {
     /// Abort the background task, causing remote command to fail.
     #[inline]
     pub fn abort(&self) {
-        self.task.abort();
+        if let Some(task) = &self.task {
+            task.abort();
+        }
     }
 
     /// Waits for the remote command task to complete.
-    pub async fn join(self) -> Result<(), Error> {
-        self.task.await.unwrap_or_else(|e| Err(Error::Spawn(e)))
+    pub async fn join(mut self) -> Result<(), Error> {
+        // Drop all streams before awaiting the task to prevent deadlocks.
+        // If stdout/stderr readers have not been drained, the background task
+        // blocks writing to the full DuplexStream buffer while join() blocks
+        // waiting for the task.
+        self.stdin_writer = None;
+        self.stdout_reader = None;
+        self.stderr_reader = None;
+        self.status_rx = None;
+        self.terminal_resize_tx = None;
+        match self.task.take() {
+            Some(task) => task.await.unwrap_or_else(|e| Err(Error::Spawn(e))),
+            None => Ok(()),
+        }
     }
 
     /// Take a future that resolves with any status object or when the sender is dropped.


### PR DESCRIPTION
## Motivation

`AttachedProcess` has two related lifecycle issues:

**1. Task leak on drop (WebSocket connection kept alive indefinitely)**

Dropping an `AttachedProcess` without calling `join()` or `abort()` detaches the background task spawned at construction. Unlike a passive leak, the detached task actively sends WebSocket ping frames every 60 seconds (`remote_command.rs:293-294`), keeping the connection alive until the server terminates it. This is in contrast to `CancelableJoinHandle` in `kube-runtime` which correctly aborts on drop.

**2. Deadlock in `join()` when stdout/stderr not drained**

`join()` awaits the background task directly without first dropping the `DuplexStream` halves (`stdout_reader`, `stderr_reader`, etc.). If stdout or stderr is enabled but the caller has not taken and fully drained the reader via `.stdout()` / `.stderr()`, the background task blocks when the DuplexStream buffer fills (1024 bytes by default at `remote_command.rs:95`), while `join()` blocks waiting for the task:

```
Background task: write to stdout_writer -> blocks (buffer full, reader not consumed)
           ^                                                                    |
           |                                                                    v
    join(): awaits task  <-  waiting for task  <-  task stuck on write  ---------+
```

Compare with `Portforwarder::join()` (`portforward.rs:148-158`) which correctly clears all streams before awaiting:

```rust
pub async fn join(self) -> Result<(), Error> {
    let Self { mut ports, mut errors, task } = self;
    // Start by terminating any streams that have not yet been taken
    // since they would otherwise keep the connection open indefinitely
    ports.clear();
    errors.clear();
    task.await.unwrap_or_else(|e| Err(Error::Spawn(e)))
}
```

Both issues were introduced in #861 (2022-03-31).

## Solution

- **Add `Drop` impl** that aborts the background task, preventing task and WebSocket connection leaks when an `AttachedProcess` is dropped without explicit cleanup.
- **Fix `join()`** to clear all `DuplexStream` halves and channels before awaiting the task, matching the `Portforwarder::join()` pattern.
- The `task` field is changed to `Option<JoinHandle>` so that `join()` can take ownership of the handle while still allowing `Drop` to abort it when `join()` is not called.