### PR TITLE
Replace std::sync::Mutex with parking_lot::Mutex in DelayedInit and SplitCase

### DIFF
--- a/kube-runtime/src/utils/delayed_init.rs
+++ b/kube-runtime/src/utils/delayed_init.rs
@@ -1,4 +1,6 @@
-use std::{fmt::Debug, sync::Mutex, task::Poll};
+use std::{fmt::Debug, task::Poll};
+
+use parking_lot::Mutex;
 
 use futures::{FutureExt, channel};
 use thiserror::Error;
@@ -72,7 +74,7 @@ where
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        let mut state = self.0.state.lock().unwrap();
+        let mut state = self.0.state.lock();
         trace!("got lock lock");
         match &mut *state {
             ReceiverState::Waiting(rx) => {

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -31,9 +31,11 @@ use pin_project::pin_project;
 use std::{
     fmt::Debug,
     pin::{Pin, pin},
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::Poll,
 };
+
+use parking_lot::Mutex;
 use stream::IntoStream;
 use tokio::{runtime::Handle, task::JoinHandle};
 
@@ -72,7 +74,7 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         let this = self.project();
-        let inner = this.inner.lock().unwrap();
+        let inner = this.inner.lock();
         let mut inner = Pin::new(inner);
         let inner_peek = pin!(inner.as_mut().peek());
         match inner_peek.poll(cx) {


### PR DESCRIPTION
## Motivation

`DelayedInit::get()` (`kube-runtime/src/utils/delayed_init.rs`) and `SplitCase::poll_next()` (`kube-runtime/src/utils/mod.rs`) both use `std::sync::Mutex` with `.lock().unwrap()`. If any task panics while holding either mutex, the mutex becomes poisoned and all subsequent `.lock().unwrap()` calls will panic, crashing the entire controller.

- `DelayedInit` is used by the controller readiness gate (`delay_tasks_until`), so a poisoned mutex crashes all subsequent readiness checks.
- `SplitCase` powers `trystream_try_via`, the core stream-splitting mechanism of the `applier()`, so a poisoned mutex crashes every subsequent poll of the controller loop.

## Solution

Switch both from `std::sync::Mutex` to `parking_lot::Mutex`, which does not poison. `parking_lot` is already a dependency of `kube-runtime` (used in `reflector/store.rs`), so this adds no new dependencies.

This is the same class of fix as #1977 (RwLock poisoning in `ReloadingVerifier`).

Closes #1982