### PR TITLE
client: include response body in ProtocolSwitch error

### DIFF
--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -258,7 +258,9 @@ impl Client {
         upgrade::StreamProtocol::add_to_headers(&mut parts.headers)?;
 
         let res = self.send(Request::from_parts(parts, Body::from(body))).await?;
-        let protocol = upgrade::verify_response(&res, &key).map_err(Error::UpgradeConnection)?;
+        let (protocol, res) = upgrade::verify_response(res, &key)
+            .await
+            .map_err(Error::UpgradeConnection)?;
         match hyper::upgrade::on(res).await {
             Ok(upgraded) => Ok(Connection {
                 stream: WebSocketStream::from_raw_socket(

--- a/kube-client/src/client/upgrade.rs
+++ b/kube-client/src/client/upgrade.rs
@@ -90,8 +90,14 @@ pub enum UpgradeConnectionError {
     /// connection.
     ///
     /// [`SWITCHING_PROTOCOLS`]: http::status::StatusCode::SWITCHING_PROTOCOLS
-    #[error("failed to switch protocol: {0}")]
-    ProtocolSwitch(http::status::StatusCode),
+    #[error("failed to switch protocol: {status}: {body}")]
+    ProtocolSwitch {
+        /// HTTP status code returned by the API server.
+        status: http::status::StatusCode,
+        /// Response body, typically a JSON-encoded `metav1.Status` with
+        /// message, reason, and details explaining the failure.
+        body: String,
+    },
 
     /// `Upgrade` header was not set to `websocket` (case insensitive)
     #[error("upgrade header was not set to websocket")]
@@ -116,9 +122,19 @@ pub enum UpgradeConnectionError {
 
 // Verify upgrade response according to RFC6455.
 // Based on `tungstenite` and added subprotocol verification.
-pub fn verify_response(res: &Response<Body>, key: &str) -> Result<StreamProtocol, UpgradeConnectionError> {
+pub async fn verify_response(
+    res: Response<Body>,
+    key: &str,
+) -> Result<(StreamProtocol, Response<Body>), UpgradeConnectionError> {
     if res.status() != StatusCode::SWITCHING_PROTOCOLS {
-        return Err(UpgradeConnectionError::ProtocolSwitch(res.status()));
+        let status = res.status();
+        let body = res
+            .into_body()
+            .collect_bytes()
+            .await
+            .map(|b| String::from_utf8_lossy(&b).into_owned())
+            .unwrap_or_default();
+        return Err(UpgradeConnectionError::ProtocolSwitch { status, body });
     }
 
     let headers = res.headers();
@@ -150,10 +166,10 @@ pub fn verify_response(res: &Response<Body>, key: &str) -> Result<StreamProtocol
     }
 
     // Make sure that the server returned an expected subprotocol.
-    let protocol = match StreamProtocol::get_from_response(res) {
+    let protocol = match StreamProtocol::get_from_response(&res) {
         Some(p) => p,
         None => return Err(UpgradeConnectionError::SecWebSocketProtocolMismatch),
     };
 
-    Ok(protocol)
+    Ok((protocol, res))
 }


### PR DESCRIPTION
## What this PR does

Fixes #1405.

When exec, portforward, or attach fails because the Kubernetes API server returns a non-101 response (e.g. 403 Forbidden, 404 Pod Not Found), the HTTP response body, which contains a full `metav1.Status` JSON with message, reason, and details, was discarded. Users saw only:

> `failed to switch protocol: 403 Forbidden`

...instead of the actual error:

> `pods "my-pod" is forbidden: User "system:serviceaccount:default:my-sa" cannot create resource "pods/exec"`

**Changes:**
- Changed `ProtocolSwitch(StatusCode)` to `ProtocolSwitch { status, body }` struct variant
- Made `verify_response` async to read the response body on failure
- Updated the error Display format to include the body text
- Updated the call site in `mod.rs`

Closes #1405

## AI Disclosure

Developed with AI assistance (Grok by xAI) in a human-in-the-loop workflow. All code reviewed and verified by the human author.

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>