### PR TITLE
feat(client): include request URI context in ApiError (#949)

### DIFF
--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -77,8 +77,8 @@ async fn main() -> Result<()> {
             info!("Created {} ({:?})", o.name_any(), o.status.unwrap());
             debug!("Created CRD: {:?}", o.spec);
         }
-        Err(kube::Error::Api(ae)) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
-        Err(e) => return Err(e.into()),                        // any other case is probably bad
+        Err(kube::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
+        Err(e) => return Err(e.into()), // any other case is probably bad
     }
     // Wait for the api to catch up
     sleep(Duration::from_secs(1)).await;
@@ -205,7 +205,7 @@ async fn main() -> Result<()> {
     assert!(fx.spec.validate().is_err());
     // check rejection from apiserver (validation rules embedded in JsonSchema)
     match foos.create(&pp, &fx).await {
-        Err(kube::Error::Api(ae)) => {
+        Err(kube::Error::Api { source: ae, uri: _ }) => {
             assert_eq!(ae.code, 422);
             assert!(
                 ae.message

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -235,7 +235,7 @@ async fn main() -> Result<()> {
     let res = dynapi.create(&PostParams::default(), &data).await;
     assert!(res.is_err());
     match res.err() {
-        Some(kube::Error::Api(err)) => {
+        Some(kube::Error::Api { source: err, uri: _ }) => {
             assert_eq!(err.code, 422);
             assert_eq!(err.reason, "Invalid");
             assert!(err.is_failure());
@@ -276,7 +276,7 @@ async fn main() -> Result<()> {
     let cel_res = foos.patch("baz", &ssapply, &Patch::Apply(cel_patch)).await;
     assert!(cel_res.is_err());
     match cel_res.err() {
-        Some(kube::Error::Api(err)) => {
+        Some(kube::Error::Api { source: err, uri: _ }) => {
             assert_eq!(err.code, 422);
             assert_eq!(err.reason, "Invalid");
             assert!(err.is_failure());
@@ -298,7 +298,7 @@ async fn main() -> Result<()> {
     let cel_res = foos.patch("baz", &ssapply, &Patch::Apply(cel_patch)).await;
     assert!(cel_res.is_err());
     match cel_res.err() {
-        Some(kube::Error::Api(err)) => {
+        Some(kube::Error::Api { source: err, uri: _ }) => {
             assert_eq!(err.code, 422);
             assert_eq!(err.reason, "Invalid");
             assert!(err.is_failure());
@@ -321,7 +321,7 @@ async fn main() -> Result<()> {
     let cel_res = foos.patch("baz", &ssapply, &Patch::Apply(cel_patch)).await;
     assert!(cel_res.is_err());
     match cel_res.err() {
-        Some(kube::Error::Api(err)) => {
+        Some(kube::Error::Api { source: err, uri: _ }) => {
             assert_eq!(err.code, 422);
             assert_eq!(err.reason, "Invalid");
             assert!(err.is_failure());
@@ -344,7 +344,7 @@ async fn main() -> Result<()> {
     let cel_res = foos.patch("baz", &ssapply, &Patch::Apply(cel_patch)).await;
     assert!(cel_res.is_err());
     match cel_res.err() {
-        Some(kube::Error::Api(err)) => {
+        Some(kube::Error::Api { source: err, uri: _ }) => {
             assert_eq!(err.code, 422);
             assert_eq!(err.reason, "Invalid");
             assert!(err.is_failure());
@@ -380,7 +380,7 @@ async fn main() -> Result<()> {
     let cel_res = foos.patch("baz", &ssapply, &Patch::Apply(cel_patch)).await;
     assert!(cel_res.is_err());
     match cel_res.err() {
-        Some(kube::Error::Api(err)) => {
+        Some(kube::Error::Api { source: err, uri: _ }) => {
             assert_eq!(err.code, 422);
             assert_eq!(err.reason, "Invalid");
             assert!(err.is_failure());

--- a/examples/pod_api.rs
+++ b/examples/pod_api.rs
@@ -37,8 +37,8 @@ async fn main() -> anyhow::Result<()> {
             assert_eq!(p.name_any(), name);
             info!("Created {}", name);
         }
-        Err(kube::Error::Api(ae)) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
-        Err(e) => return Err(e.into()),                        // any other case is probably bad
+        Err(kube::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
+        Err(e) => return Err(e.into()), // any other case is probably bad
     }
 
     // Watch it phase for a few seconds

--- a/examples/pod_log_kubelet_debug.rs
+++ b/examples/pod_log_kubelet_debug.rs
@@ -38,8 +38,8 @@ async fn main() -> anyhow::Result<()> {
 
     match pods.create(&Default::default(), &p).await {
         Ok(o) => assert_eq!(p.name_unchecked(), o.name_unchecked()),
-        Err(kube::Error::Api(ae)) => assert_eq!(ae.code, 409), // if we failed to clean-up
-        Err(e) => return Err(e.into()),                        // any other case if a failure
+        Err(kube::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if we failed to clean-up
+        Err(e) => return Err(e.into()), // any other case if a failure
     }
 
     // wait for container to finish

--- a/examples/secret_syncer.rs
+++ b/examples/secret_syncer.rs
@@ -65,7 +65,10 @@ async fn cleanup(cm: Arc<ConfigMap>, secrets: &kube::Api<Secret>) -> Result<Acti
         .map(|_| ())
         .or_else(|err| match err {
             // Object is already deleted
-            kube::Error::Api(status) if status.is_not_found() => Ok(()),
+            kube::Error::Api {
+                source: ref status,
+                uri: _,
+            } if status.is_not_found() => Ok(()),
             err => Err(err),
         })
         .map_err(Error::DeleteSecret)?;

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -141,7 +141,7 @@ where
     pub async fn get_opt(&self, name: &str) -> Result<Option<K>> {
         match self.get(name).await {
             Ok(obj) => Ok(Some(obj)),
-            Err(Error::Api(status)) if status.is_not_found() => Ok(None),
+            Err(Error::Api {source: status, uri: _}) if status.is_not_found() => Ok(None),
             Err(err) => Err(err),
         }
     }
@@ -196,7 +196,7 @@ where
     ) -> Result<Option<PartialObjectMeta<K>>> {
         match self.get_metadata_with(name, gp).await {
             Ok(meta) => Ok(Some(meta)),
-            Err(Error::Api(status)) if status.is_not_found() => Ok(None),
+            Err(Error::Api {source: status, uri: _}) if status.is_not_found() => Ok(None),
             Err(err) => Err(err),
         }
     }

--- a/kube-client/src/api/entry.rs
+++ b/kube-client/src/api/entry.rs
@@ -402,7 +402,7 @@ mod tests {
             ..ConfigMap::default()
         });
         assert!(
-            matches!(dbg!(entry2.commit(&PostParams::default()).await), Err(CommitError::Save(Error::Api(status))) if status.is_already_exists())
+            matches!(dbg!(entry2.commit(&PostParams::default()).await), Err(CommitError::Save(Error::Api { source: status, uri: _ })) if status.is_already_exists())
         );
 
         // Cleanup
@@ -473,7 +473,7 @@ mod tests {
             .get_or_insert_with(BTreeMap::default)
             .insert("key".to_string(), "value3".to_string());
         assert!(
-            matches!(entry2.commit(&PostParams::default()).await, Err(CommitError::Save(Error::Api(status))) if status.is_conflict())
+            matches!(entry2.commit(&PostParams::default()).await, Err(CommitError::Save(Error::Api { source: status, uri: _ })) if status.is_conflict())
         );
 
         // Cleanup

--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -215,8 +215,9 @@ impl Client {
     /// This method can be used to get raw access to the API which may be used to, for example,
     /// create a proxy server or application-level gateway between localhost and the API server.
     pub async fn send(&self, request: Request<Body>) -> Result<Response<Body>> {
+        let req_uri = request.uri().clone();
         let mut svc = self.inner.clone();
-        let res = svc
+        let mut res = svc
             .ready()
             .await
             .map_err(Error::Service)?
@@ -231,6 +232,7 @@ impl Client {
                     // Error from another middleware
                     .unwrap_or_else(Error::Service)
             })?;
+        res.extensions_mut().insert(req_uri);
         Ok(res)
     }
 
@@ -344,6 +346,7 @@ impl Client {
     where
         T: Clone + DeserializeOwned,
     {
+        let req_uri = request.uri().clone();
         let res = self.send(request.map(Body::from)).await?;
         // trace!("Streaming from {} -> {}", res.url(), res.status().as_str());
         tracing::trace!("headers: {:?}", res.headers());
@@ -360,44 +363,50 @@ impl Client {
             LinesCodec::new(),
         );
 
-        Ok(frames.filter_map(|res| async {
-            match res {
-                Ok(line) => match serde_json::from_str::<WatchEvent<T>>(&line) {
-                    Ok(event) => Some(Ok(event)),
-                    Err(e) => {
-                        // Ignore EOF error that can happen for incomplete line from `decode_eof`.
-                        if e.is_eof() {
-                            return None;
+        Ok(frames.filter_map(move |res| {
+            let req_uri = req_uri.clone();
+            async move {
+                match res {
+                    Ok(line) => match serde_json::from_str::<WatchEvent<T>>(&line) {
+                        Ok(event) => Some(Ok(event)),
+                        Err(e) => {
+                            // Ignore EOF error that can happen for incomplete line from `decode_eof`.
+                            if e.is_eof() {
+                                return None;
+                            }
+
+                            // Got general error response
+                            if let Ok(status) = serde_json::from_str::<Status>(&line) {
+                                return Some(Err(Error::Api {
+                                    source: status.boxed(),
+                                    uri: req_uri
+                                }));
+                            }
+                            // Parsing error
+                            Some(Err(Error::SerdeError(e)))
                         }
+                    },
 
-                        // Got general error response
-                        if let Ok(status) = serde_json::from_str::<Status>(&line) {
-                            return Some(Err(Error::Api(status.boxed())));
+                    Err(LinesCodecError::Io(e)) => match e.kind() {
+                        // Client timeout
+                        std::io::ErrorKind::TimedOut => {
+                            tracing::warn!("timeout in poll: {}", e); // our client timeout
+                            None
                         }
-                        // Parsing error
-                        Some(Err(Error::SerdeError(e)))
-                    }
-                },
+                        // Unexpected EOF from chunked decoder.
+                        // Tends to happen after 300+s of watching.
+                        std::io::ErrorKind::UnexpectedEof => {
+                            tracing::warn!("eof in poll: {}", e);
+                            None
+                        }
+                        _ => Some(Err(Error::ReadEvents(e))),
+                    },
 
-                Err(LinesCodecError::Io(e)) => match e.kind() {
-                    // Client timeout
-                    std::io::ErrorKind::TimedOut => {
-                        tracing::warn!("timeout in poll: {}", e); // our client timeout
-                        None
+                    // Reached the maximum line length without finding a newline.
+                    // This should never happen because we're using the default `usize::MAX`.
+                    Err(LinesCodecError::MaxLineLengthExceeded) => {
+                        Some(Err(Error::LinesCodecMaxLineLengthExceeded))
                     }
-                    // Unexpected EOF from chunked decoder.
-                    // Tends to happen after 300+s of watching.
-                    std::io::ErrorKind::UnexpectedEof => {
-                        tracing::warn!("eof in poll: {}", e);
-                        None
-                    }
-                    _ => Some(Err(Error::ReadEvents(e))),
-                },
-
-                // Reached the maximum line length without finding a newline.
-                // This should never happen because we're using the default `usize::MAX`.
-                Err(LinesCodecError::MaxLineLengthExceeded) => {
-                    Some(Err(Error::LinesCodecMaxLineLengthExceeded))
                 }
             }
         }))
@@ -543,6 +552,7 @@ impl Client {
 async fn handle_api_errors(res: Response<Body>) -> Result<Response<Body>> {
     let status = res.status();
     if status.is_client_error() || status.is_server_error() {
+        let req_uri = res.extensions().get::<http::Uri>().cloned().unwrap_or_default();
         // trace!("Status = {:?} for {}", status, res.url());
         let body_bytes = res.into_body().collect().await?.to_bytes();
         let text = String::from_utf8(body_bytes.to_vec()).map_err(Error::FromUtf8)?;
@@ -550,12 +560,18 @@ async fn handle_api_errors(res: Response<Body>) -> Result<Response<Body>> {
         // trace!("Parsing error: {}", text);
         if let Ok(status) = serde_json::from_str::<Status>(&text) {
             tracing::debug!("Unsuccessful: {status:?}");
-            Err(Error::Api(status.boxed()))
+            Err(Error::Api {
+                source: status.boxed(),
+                uri: req_uri
+            })
         } else {
             tracing::warn!("Unsuccessful data error parse: {text}");
             let status = Status::failure(&text, "Failed to parse error data").with_code(status.as_u16());
             tracing::debug!("Unsuccessful: {status:?} (reconstruct)");
-            Err(Error::Api(status.boxed()))
+            Err(Error::Api {
+                source: status.boxed(),
+                uri: req_uri
+            })
         }
     } else {
         Ok(res)

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -15,8 +15,14 @@ pub enum Error {
     /// It's also used in `WatchEvent` from watch calls.
     ///
     /// It's quite common to get a `410 Gone` when the `resourceVersion` is too old.
-    #[error("ApiError: {0} ({0:?})")]
-    Api(#[source] Box<Status>),
+    #[error("ApiError: {source} ({source:?}) at {uri}")]
+    Api {
+        /// The underlying Kubernetes status object
+        #[source]
+        source: Box<Status>,
+        /// The request URI that triggered this error
+        uri: http::Uri,
+    },
 
     /// Hyper error
     #[cfg(feature = "client")]

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -322,7 +322,7 @@ mod test {
         match pods.create(&pp, &p).await {
             Ok(o) => assert_eq!(p.name_unchecked(), o.name_unchecked()),
             Err(crate::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if we failed to clean-up
-            Err(e) => return Err(e.into()),                         // any other case if a failure
+            Err(e) => return Err(e.into()), // any other case if a failure
         }
 
         // Manual watch-api for it to become ready
@@ -403,7 +403,7 @@ mod test {
         match pods.create(&Default::default(), &p).await {
             Ok(o) => assert_eq!(p.name_unchecked(), o.name_unchecked()),
             Err(crate::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if we failed to clean-up
-            Err(e) => return Err(e.into()),                         // any other case if a failure
+            Err(e) => return Err(e.into()), // any other case if a failure
         }
 
         // Manual watch-api for it to become ready
@@ -556,7 +556,7 @@ mod test {
         match pods.create(&Default::default(), &p).await {
             Ok(o) => assert_eq!(p.name_unchecked(), o.name_unchecked()),
             Err(crate::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if we failed to clean-up
-            Err(e) => return Err(e.into()),                         // any other case if a failure
+            Err(e) => return Err(e.into()), // any other case if a failure
         }
 
         // Manual watch-api for it to become ready
@@ -642,7 +642,7 @@ mod test {
         match pods.create(&Default::default(), &p).await {
             Ok(o) => assert_eq!(p.name_unchecked(), o.name_unchecked()),
             Err(crate::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if we failed to clean-up
-            Err(e) => return Err(e.into()),                         // any other case if a failure
+            Err(e) => return Err(e.into()), // any other case if a failure
         }
 
         // Test we can get a pod as a PartialObjectMeta and convert to
@@ -933,8 +933,8 @@ mod test {
 
         match pods.create(&Default::default(), &p).await {
             Ok(o) => assert_eq!(p.name_unchecked(), o.name_unchecked()),
-            Err(crate::Error::Api(ae)) => assert_eq!(ae.code, 409), // if we failed to clean-up
-            Err(e) => return Err(e.into()),                         // any other case if a failure
+            Err(crate::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if we failed to clean-up
+            Err(e) => return Err(e.into()), // any other case if a failure
         }
 
         // Manual watch-api for it to become ready

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -321,7 +321,7 @@ mod test {
         let pp = PostParams::default();
         match pods.create(&pp, &p).await {
             Ok(o) => assert_eq!(p.name_unchecked(), o.name_unchecked()),
-            Err(crate::Error::Api(ae)) => assert_eq!(ae.code, 409), // if we failed to clean-up
+            Err(crate::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if we failed to clean-up
             Err(e) => return Err(e.into()),                         // any other case if a failure
         }
 
@@ -402,7 +402,7 @@ mod test {
 
         match pods.create(&Default::default(), &p).await {
             Ok(o) => assert_eq!(p.name_unchecked(), o.name_unchecked()),
-            Err(crate::Error::Api(ae)) => assert_eq!(ae.code, 409), // if we failed to clean-up
+            Err(crate::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if we failed to clean-up
             Err(e) => return Err(e.into()),                         // any other case if a failure
         }
 
@@ -555,7 +555,7 @@ mod test {
 
         match pods.create(&Default::default(), &p).await {
             Ok(o) => assert_eq!(p.name_unchecked(), o.name_unchecked()),
-            Err(crate::Error::Api(ae)) => assert_eq!(ae.code, 409), // if we failed to clean-up
+            Err(crate::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if we failed to clean-up
             Err(e) => return Err(e.into()),                         // any other case if a failure
         }
 
@@ -641,7 +641,7 @@ mod test {
 
         match pods.create(&Default::default(), &p).await {
             Ok(o) => assert_eq!(p.name_unchecked(), o.name_unchecked()),
-            Err(crate::Error::Api(ae)) => assert_eq!(ae.code, 409), // if we failed to clean-up
+            Err(crate::Error::Api { source: ae, uri: _ }) => assert_eq!(ae.code, 409), // if we failed to clean-up
             Err(e) => return Err(e.into()),                         // any other case if a failure
         }
 

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -529,7 +529,8 @@ where
                 match api.watch(&wc.to_watch_params(WatchPhase::Initial), "0").await {
                     Ok(stream) => (None, State::InitialWatch { stream }),
                     Err(err) => {
-                        if std::matches!(err, ClientErr::Api(ref status) if status.is_forbidden()) {
+                        if std::matches!(err, ClientErr::Api { source: ref status, uri: _ } if status.is_forbidden())
+                        {
                             warn!("watch initlist error with 403: {err:?}");
                         } else {
                             debug!("watch initlist error: {err:?}");
@@ -576,7 +577,8 @@ where
                     })
                 }
                 Err(err) => {
-                    if std::matches!(err, ClientErr::Api(ref status) if status.is_forbidden()) {
+                    if std::matches!(err, ClientErr::Api { source: ref status, uri: _ } if status.is_forbidden())
+                    {
                         warn!("watch list error with 403: {err:?}");
                     } else {
                         debug!("watch list error: {err:?}");
@@ -622,7 +624,8 @@ where
                     (Some(Err(Error::WatchError(err.boxed()))), new_state)
                 }
                 Some(Err(err)) => {
-                    if std::matches!(err, ClientErr::Api(ref status) if status.is_forbidden()) {
+                    if std::matches!(err, ClientErr::Api { source: ref status, uri: _ } if status.is_forbidden())
+                    {
                         warn!("watcher error 403: {err:?}");
                     } else {
                         debug!("watcher error: {err:?}");
@@ -642,7 +645,8 @@ where
                     stream,
                 }),
                 Err(err) => {
-                    if std::matches!(err, ClientErr::Api(ref status) if status.is_forbidden()) {
+                    if std::matches!(err, ClientErr::Api { source: ref status, uri: _ } if status.is_forbidden())
+                    {
                         warn!("watch initlist error with 403: {err:?}");
                     } else {
                         debug!("watch initlist error: {err:?}");
@@ -701,7 +705,8 @@ where
                 (Some(Err(Error::WatchError(err.boxed()))), new_state)
             }
             Some(Err(err)) => {
-                if std::matches!(err, ClientErr::Api(ref status) if status.is_forbidden()) {
+                if std::matches!(err, ClientErr::Api { source: ref status, uri: _ } if status.is_forbidden())
+                {
                     warn!("watcher error 403: {err:?}");
                 } else {
                     debug!("watcher error: {err:?}");


### PR DESCRIPTION
## Motivation

When handling API errors (such as 404 Not Found, 409 Conflict, etc.) returned by the Kubernetes API server, the current `Error::Api` variant only wraps the raw `Status` object. This makes debugging highly problematic in large-scale infrastructure environments because the error context does not indicate **which specific URI/endpoint failed**.

For instance, when a service mesh or external client receives an unhelpful API error, troubleshooting requires cross-referencing external logs since the exact request path is completely lost. This PR resolves #949 by injecting the missing request URI directly into the `Error::Api` variant.

## Solution

To bypass the architectural constraint where the `Response` object independently lacks request context metadata, we implemented a sidecar metadata pocket mechanism utilizing HTTP response extensions:

1. **`Error::Api` Variant Refactoring (`kube-client/src/error.rs`)**
   - Transformed the `Api` variant from a tuple struct to a struct variant: `Api { source: Box<Status>, uri: http::Uri }`.
   - Updated the error macro formatting to explicitly print the failed URI path along with the API status.

2. **Context Injection in Client Pipeline (`kube-client/src/client/mod.rs`)**
   - In `Client::send`, cloned the original `request.uri()` before the request ownership is moved.
   - Inserted the cloned URI into the response metadata using `response.extensions_mut().insert(req_uri)`.
   - In `handle_api_errors`, extracted the `http::Uri` type back from the extensions map and successfully packed it into the new `Error::Api` struct layout.

3. **Watch API Stream Support & Test Realignment**
   - Fixed the asynchronous stream closure in `request_events` by applying the `move` keyword to propagate `req_uri` across async boundaries cleanly.
   - Fixed all pattern matchings and assertion breaks across unit/doc-tests (`lib.rs`, `entry.rs`, `core_methods.rs`).
   - Verified that all 50+ unit tests and 50+ doc-tests pass flawlessly (`test result: ok`).