### PR TITLE
runtime: implement `Store::state_with` and `Store::state_filtered`

### DIFF
--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -277,6 +277,16 @@ where
     }
 
     /// Return a filtered snapshot of the current values, retaining only objects whose labels match `selector`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use k8s_openapi::api::core::v1::ConfigMap;
+    /// # use kube_client::core::{Expression, Selector};
+    /// # let (reader, _writer) = kube_runtime::reflector::store::<ConfigMap>();
+    /// let selector: Selector = Expression::Equal("app".into(), "nginx".into()).into();
+    /// let result = reader.state_filtered(&selector);
+    /// ```
     #[must_use]
     pub fn state_filtered(&self, selector: &Selector) -> Vec<Arc<K>>
     where

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -8,6 +8,10 @@ use crate::{
 };
 use ahash::AHashMap;
 use educe::Educe;
+use kube_client::{
+    ResourceExt,
+    core::{Selector, SelectorExt},
+};
 use parking_lot::RwLock;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
 use thiserror::Error;
@@ -258,6 +262,29 @@ where
             .cloned()
     }
 
+    /// Return a filtered snapshot of the current values, retaining only objects matching `predicate`
+    #[must_use]
+    pub fn state_with<P>(&self, predicate: P) -> Vec<Arc<K>>
+    where
+        P: Fn(&K) -> bool,
+    {
+        self.store
+            .read()
+            .values()
+            .filter(|k| predicate(k.as_ref()))
+            .cloned()
+            .collect()
+    }
+
+    /// Return a filtered snapshot of the current values, retaining only objects whose labels match `selector`
+    #[must_use]
+    pub fn state_filtered(&self, selector: &Selector) -> Vec<Arc<K>>
+    where
+        K: ResourceExt,
+    {
+        self.state_with(|k| selector.matches(k.labels()))
+    }
+
     /// Return the number of elements in the store
     #[must_use]
     pub fn len(&self) -> usize {
@@ -378,6 +405,78 @@ mod tests {
         store_w.apply_watcher_event(&watcher::Event::Apply(cm.clone()));
         let store = store_w.as_reader();
         assert_eq!(store.get(&ObjectRef::from_obj(&nsed_cm)).as_deref(), Some(&cm));
+    }
+
+    #[test]
+    fn state_with_filters_by_predicate() {
+        let (reader, mut writer) = store::<ConfigMap>();
+
+        let cm1 = ConfigMap {
+            metadata: ObjectMeta {
+                name: Some("cm1".to_string()),
+                namespace: Some("ns".to_string()),
+                labels: Some([("app".to_string(), "nginx".to_string())].into()),
+                ..ObjectMeta::default()
+            },
+            ..ConfigMap::default()
+        };
+        let cm2 = ConfigMap {
+            metadata: ObjectMeta {
+                name: Some("cm2".to_string()),
+                namespace: Some("ns".to_string()),
+                labels: Some([("app".to_string(), "postgres".to_string())].into()),
+                ..ObjectMeta::default()
+            },
+            ..ConfigMap::default()
+        };
+
+        writer.apply_watcher_event(&watcher::Event::Apply(cm1.clone()));
+        writer.apply_watcher_event(&watcher::Event::Apply(cm2));
+
+        let result = reader.state_with(|k| {
+            k.metadata
+                .labels
+                .as_ref()
+                .and_then(|l| l.get("app"))
+                .map(|v| v == "nginx")
+                .unwrap_or(false)
+        });
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].as_ref(), &cm1);
+    }
+
+    #[test]
+    fn state_filtered_filters_by_label_selector() {
+        use kube_client::core::{Expression, Selector};
+
+        let (reader, mut writer) = store::<ConfigMap>();
+
+        let cm1 = ConfigMap {
+            metadata: ObjectMeta {
+                name: Some("cm1".to_string()),
+                namespace: Some("ns".to_string()),
+                labels: Some([("app".to_string(), "nginx".to_string())].into()),
+                ..ObjectMeta::default()
+            },
+            ..ConfigMap::default()
+        };
+        let cm2 = ConfigMap {
+            metadata: ObjectMeta {
+                name: Some("cm2".to_string()),
+                namespace: Some("ns".to_string()),
+                labels: Some([("app".to_string(), "postgres".to_string())].into()),
+                ..ObjectMeta::default()
+            },
+            ..ConfigMap::default()
+        };
+
+        writer.apply_watcher_event(&watcher::Event::Apply(cm1.clone()));
+        writer.apply_watcher_event(&watcher::Event::Apply(cm2));
+
+        let selector: Selector = Expression::Equal("app".into(), "nginx".into()).into();
+        let result = reader.state_filtered(&selector);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].as_ref(), &cm1);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

When using a `Store<K>` as a local cache, there is no way to query it with a label selector short of calling `state()` 
and filtering the returned `Vec` manually — or maintaining multiple stores for different selectors. Issue #970 asks for 
a way to evaluate selector syntax against the store contents directly.

## Solution

Add two methods to `Store<K>`:

- `state_with(predicate)` — generic filtering by an arbitrary `Fn(&K) -> bool` predicate
- `state_filtered(selector)` — convenience wrapper that matches objects by label using `kube_core::Selector`

`state_with` is the lower-level primitive; `state_filtered` builds on top of it using `ResourceExt::labels()` and 
`SelectorExt::matches()`.

Field selector evaluation is intentionally out of scope: unlike label selectors, Kubernetes field selectors are 
resource-type-specific and cannot be evaluated generically on the client side.

Closes #970