### PR TITLE
runtime: add `wait::conditions::is_created` helper

### DIFF
--- a/kube-runtime/src/wait.rs
+++ b/kube-runtime/src/wait.rs
@@ -190,6 +190,14 @@ pub mod conditions {
         }
     }
 
+    /// An await condition that returns `true` once the object has been created.
+    ///
+    /// This is the counterpart to [`is_deleted`](super::conditions::is_deleted).
+    #[must_use]
+    pub fn is_created<K: Resource>() -> impl Condition<K> {
+        |obj: Option<&K>| obj.is_some()
+    }
+
     /// An await condition for `CustomResourceDefinition` that returns `true` once it has been accepted and established
     ///
     /// Note that this condition only guarantees you that you can use `Api<CustomResourceDefinition>` when it is ready.


### PR DESCRIPTION
This is the counterpart to is_deleted.

## Motivation

I had to create this helper for testing controller functionality, but it may as well be used otherwise.
It is pretty trivial, but I think also quite common, so offer it directly. :)
