### PR TITLE
feat: Impl ExactSizeIterator for ObjectList

### DIFF
--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -114,6 +114,8 @@ impl<T: Clone> IntoIterator for ObjectList<T> {
     }
 }
 
+impl<T> ExactSizeIterator for ObjectList<T> {}
+
 impl<'a, T: Clone> IntoIterator for &'a ObjectList<T> {
     type IntoIter = ::std::slice::Iter<'a, T>;
     type Item = &'a T;
@@ -123,6 +125,8 @@ impl<'a, T: Clone> IntoIterator for &'a ObjectList<T> {
     }
 }
 
+impl<'a, T> ExactSizeIterator for &'a ObjectList<T> {}
+
 impl<'a, T: Clone> IntoIterator for &'a mut ObjectList<T> {
     type IntoIter = ::std::slice::IterMut<'a, T>;
     type Item = &'a mut T;
@@ -131,6 +135,8 @@ impl<'a, T: Clone> IntoIterator for &'a mut ObjectList<T> {
         self.items.iter_mut()
     }
 }
+
+impl<'a, T> ExactSizeIterator for &'a mut ObjectList<T> {}
 
 /// A trait to access the `spec` of a Kubernetes resource.
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

I recently wanted to check if the `ObjectList` is empty and was surprised that `ExactSizeIterator` wasn't implemented.

## Solution

Implement `ExactSizeIterator` for `ObjectList`, which is rather straight forward, as all default implementations can be used.
