### PR TITLE
deps: bump kube-cel to 0.6.1 (validation surface flattened)

### DIFF
--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -38,7 +38,7 @@ schemars = { workspace = true, optional = true }
 k8s-openapi.workspace = true
 serde-value.workspace = true
 derive_more = { workspace = true, features = ["from"] }
-kube-cel = { version = "0.5.1", optional = true, features = ["validation"] }
+kube-cel = { version = "0.6.1", optional = true, features = ["validation"] }
 
 [dev-dependencies]
 k8s-openapi = { workspace = true, features = ["latest"] }

--- a/kube-core/src/admission.rs
+++ b/kube-core/src/admission.rs
@@ -203,7 +203,7 @@ pub enum Operation {
 #[cfg(feature = "cel")]
 #[cfg_attr(docsrs, doc(cfg(feature = "cel")))]
 impl<T: Resource> AdmissionRequest<T> {
-    /// Project this request into the [`kube_cel::vap::AdmissionRequest`] used to
+    /// Project this request into the [`kube_cel::AdmissionRequest`] used to
     /// bind the `request` variable for ValidatingAdmissionPolicy CEL evaluation.
     ///
     /// This is a lossy view: only the fields exposed to VAP's `request` variable
@@ -212,8 +212,8 @@ impl<T: Resource> AdmissionRequest<T> {
     /// such as `object`, `oldObject`, `requestKind`, `subResource`, and `options`
     /// are dropped. The carried `uid` is the *user* uid (`userInfo.uid`), matching
     /// the VAP `request.userInfo.uid` variable, not the request round-trip uid.
-    pub fn to_cel_request(&self) -> kube_cel::vap::AdmissionRequest {
-        kube_cel::vap::AdmissionRequest {
+    pub fn to_cel_request(&self) -> kube_cel::AdmissionRequest {
+        kube_cel::AdmissionRequest {
             operation: match self.operation {
                 Operation::Create => "CREATE",
                 Operation::Update => "UPDATE",
@@ -227,12 +227,12 @@ impl<T: Resource> AdmissionRequest<T> {
             name: self.name.clone(),
             namespace: self.namespace.clone().unwrap_or_default(),
             dry_run: self.dry_run,
-            kind: kube_cel::vap::GroupVersionKind {
+            kind: kube_cel::GroupVersionKind {
                 group: self.kind.group.clone(),
                 version: self.kind.version.clone(),
                 kind: self.kind.kind.clone(),
             },
-            resource: kube_cel::vap::GroupVersionResource {
+            resource: kube_cel::GroupVersionResource {
                 group: self.resource.group.clone(),
                 version: self.resource.version.clone(),
                 resource: self.resource.resource.clone(),


### PR DESCRIPTION
## Motivation

`kube-core`'s optional `kube-cel` dependency is pinned at `0.5.1`. kube-cel `0.6` flattened its validation surface (the `vap` module became private and its types are re-exported flat at the crate root), which broke the path `kube-core` hard-codes in `AdmissionRequest::to_cel_request`. This bumps the dependency to the published `0.6.1` and fixes that path so the `cel` feature compiles again.

`0.6.1` is pinned (not `0.6`) so resolution can never pick `0.6.0`, whose docs.rs page is permanently broken (the library itself builds fine; this is cleanliness only).

## Solution

- `kube-core/Cargo.toml`: `kube-cel` `0.5.1` -> `0.6.1` (keeps `optional = true, features = ["validation"]`; feature set is unchanged across 0.5.1/0.6.1, so the dependency closure is identical).
- `kube-core/src/admission.rs`: rewrite the 5 `kube_cel::vap::*` references in `to_cel_request` (rustdoc link, return type, and the `AdmissionRequest` / `GroupVersionKind` / `GroupVersionResource` struct literals) to the flat `kube_cel::*` paths. The types are still not `#[non_exhaustive]` and their fields are unchanged, so only the `vap::` path segment is dropped.

**Breaking change** (`kube-core`'s `cel` surface): `to_cel_request` now returns `kube_cel::AdmissionRequest` instead of `kube_cel::vap::AdmissionRequest`, and the module-qualified paths `kube::core::cel::vap::*` / `...::compilation::*` are gone in 0.6. The flat type names re-exported through `kube_core::cel` keep working.

### Verification

- `cargo +nightly fmt --all --check` clean
- `cargo +nightly clippy --all-features` (no new warnings from this change)
- `cargo test --workspace --lib --all-features --exclude kube-examples --exclude e2e` pass
- `cargo test --workspace --doc --all-features --exclude kube-examples --exclude e2e` pass
- `cargo doc --no-deps --all-features` builds

### Note for maintainers

`kube-core/src/cel/mod.rs` still uses `pub use kube_cel::*`. 0.6 newly re-exports `kube_cel::Rule` at the crate root, which now overlaps under the glob with kube-core's own local `pub struct Rule`. Rust shadows the glob import in favour of the explicit local definition, so it compiles and `kube_core::cel::Rule` stays the local type (confirmed by the build above). Happy to replace the glob with an explicit `pub use kube_cel::{...}` list if you'd prefer the re-export surface be deliberate rather than widening implicitly. Just flagging, fine either way.
