### PR TITLE
chore: group cel into the just hack feature-powerset

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,7 +54,7 @@ hack:
   time cargo hack check --feature-powerset --no-private -p kube \
     --skip=oauth,oidc \
     --group-features=socks5,http-proxy,gzip,ws \
-    --group-features=admission,jsonpatch,derive \
+    --group-features=admission,jsonpatch,derive,cel \
     --group-features=rustls-tls,aws-lc-rs
   # Test groups features with minimal overlap that are grouped to reduce combinations.
   # Without any grouping this test takes an hour and has to test >11k combinations.


### PR DESCRIPTION
## Motivation

The `cel` feature is currently ungrouped in the `just hack` feature-powerset (`justfile`), so it expands independently and **doubles** the number of `cargo hack` check invocations: 2352 -> 4704 (measured via `cargo hack check ... --print-command-list | grep -c "cargo check"`). Since `features.yml` runs `just hack` on every push to `main`, that post-merge job became ~2x heavier once `cel` landed (#1954).

## Solution

Fold `cel` into the existing `admission,jsonpatch,derive` group, as suggested by @clux in #2005. This brings the powerset back to **2352** while still compiling `cel` in combinations (it appears in 1176 of them), so feature coverage is retained, the toggle is just no longer independent.

No code change, justfile-only.