### PR TITLE
Enable `RetryPolicy::server_retry` by default for `Client`

### DIFF
--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -210,7 +210,7 @@ where
 
     let service = ServiceBuilder::new()
         .layer(stack)
-        .option_layer(config.with_retry.then_some(RetryLayer::new(RetryPolicy::server_retry())))
+        .option_layer(config.default_retry.then_some(RetryLayer::new(RetryPolicy::server_retry())))
         .option_layer(auth_layer)
         .layer(config.extra_headers_layer()?)
         .layer(

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -13,12 +13,12 @@ use hyper_util::{
 
 use jiff::Timestamp;
 use std::time::Duration;
-use tower::{BoxError, Layer, Service, ServiceBuilder, ServiceExt as _, util::BoxService};
+use tower::{BoxError, Layer, Service, ServiceBuilder, ServiceExt as _, retry::RetryLayer, util::BoxService};
 use tower_http::{ServiceExt as _, classify::ServerErrorsFailureClass, trace::TraceLayer};
 use tracing::Span;
 
 use super::body::Body;
-use crate::{Client, Config, Error, Result, client::ConfigExt};
+use crate::{Client, Config, Error, Result, client::{ConfigExt, retry::RetryPolicy}};
 
 /// HTTP body of a dynamic backing type.
 ///
@@ -210,6 +210,7 @@ where
 
     let service = ServiceBuilder::new()
         .layer(stack)
+        .option_layer(config.with_retry.then_some(RetryLayer::new(RetryPolicy::server_retry())))
         .option_layer(auth_layer)
         .layer(config.extra_headers_layer()?)
         .layer(

--- a/kube-client/src/client/retry.rs
+++ b/kube-client/src/client/retry.rs
@@ -30,7 +30,7 @@
 //! # }
 //! ```
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use http::{Request, Response, StatusCode};
 use tower::{
@@ -61,6 +61,7 @@ pub struct RetryPolicy {
     backoff: ExponentialBackoff,
     current_attempt: u32,
     max_retries: u32,
+    server_aware: bool,
 }
 
 impl RetryPolicy {
@@ -71,11 +72,17 @@ impl RetryPolicy {
     /// * `min_delay` - Initial delay between retries
     /// * `max_delay` - Maximum delay between retries (cap for exponential growth)
     /// * `max_retries` - Maximum number of retry attempts
+    /// * `server_retry` - Whether to respect server-provided `Retry-After` header for retry timing
     ///
     /// # Errors
     ///
     /// Returns [`InvalidBackoff`] if the backoff parameters are invalid.
-    pub fn new(min_delay: Duration, max_delay: Duration, max_retries: u32) -> Result<Self, InvalidBackoff> {
+    pub fn new(
+        min_delay: Duration,
+        max_delay: Duration,
+        max_retries: u32,
+        server_retry: bool,
+    ) -> Result<Self, InvalidBackoff> {
         let backoff =
             ExponentialBackoffMaker::new(min_delay, max_delay, 2.0, HasherRng::new())?.make_backoff();
 
@@ -83,7 +90,24 @@ impl RetryPolicy {
             backoff,
             current_attempt: 0,
             max_retries,
+            server_aware: server_retry,
         })
+    }
+
+    /// Create a new server-aware retry policy with parameters optimized for typical controller API usage.
+    ///
+    /// Default parameters:
+    /// - `min_delay`: 5ms
+    /// - `max_delay`: 1000s
+    /// - `max_retries`: 15
+    /// - `server_retry`: true (respects server-provided `Retry-After` header for retry timing)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidBackoff`] if the backoff parameters are invalid.
+    pub fn server_retry() -> Self {
+        Self::new(Duration::from_millis(5), Duration::from_secs(1000), 15, true)
+            .expect("default server RetryPolicy parameters are valid")
     }
 
     /// Check if the status code is retryable.
@@ -103,7 +127,7 @@ impl Default for RetryPolicy {
     /// - `max_delay`: 5s
     /// - `max_retries`: 3
     fn default() -> Self {
-        Self::new(Duration::from_millis(500), Duration::from_secs(5), 3)
+        Self::new(Duration::from_millis(500), Duration::from_secs(5), 3, false)
             .expect("default RetryPolicy parameters are valid")
     }
 }
@@ -122,7 +146,20 @@ impl<Res> Policy<Request<Body>, Response<Res>, BoxError> for RetryPolicy {
                     && self.current_attempt < self.max_retries =>
             {
                 self.current_attempt += 1;
-                Some(self.backoff.next_backoff())
+                // Tick the backoff retry anyways
+                let backoff = self.backoff.next_backoff();
+                if self.server_aware
+                    && let Some(retry_after) = response.headers().get("Retry-After")
+                    && let Some(retry_after) = retry_after.to_str().ok()
+                    && let Some(retry_after) = retry_after.parse::<u64>().ok()
+                {
+                    let server_delay = Duration::from_secs(retry_after);
+                    let retry_after = Instant::now() + server_delay;
+                    if backoff.deadline().le(&retry_after.into()) {
+                        return Some(tokio::time::sleep(server_delay));
+                    }
+                }
+                Some(backoff)
             }
             _ => None,
         }
@@ -176,7 +213,14 @@ mod tests {
 
     #[test]
     fn test_invalid_backoff() {
-        let result = RetryPolicy::new(Duration::from_secs(10), Duration::from_secs(1), 3);
+        let result = RetryPolicy::new(Duration::from_secs(10), Duration::from_secs(1), 3, false);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_compile_server_retry() {
+        let policy = RetryPolicy::server_retry();
+        assert!(policy.server_aware);
+        assert_eq!(policy.max_retries, 15);
     }
 }

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -172,7 +172,7 @@ pub struct Config {
     /// Headers to pass with every request.
     pub headers: Vec<(HeaderName, HeaderValue)>,
     /// Whether to enable default retrying requests on transient failures (429, 503, 504).
-    pub with_retry: bool,
+    pub default_retry: bool,
 }
 
 impl Config {
@@ -196,7 +196,7 @@ impl Config {
             proxy_url: None,
             tls_server_name: None,
             headers: Vec::new(),
-            with_retry: true,
+            default_retry: true,
         }
     }
 
@@ -281,7 +281,7 @@ impl Config {
             proxy_url: None,
             tls_server_name: None,
             headers: Vec::new(),
-            with_retry: true,
+            default_retry: true,
         })
     }
 
@@ -344,7 +344,7 @@ impl Config {
             auth_info: loader.user,
             tls_server_name: loader.cluster.tls_server_name,
             headers: Vec::new(),
-            with_retry: true,
+            default_retry: true,
         })
     }
 

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -171,6 +171,8 @@ pub struct Config {
     pub tls_server_name: Option<String>,
     /// Headers to pass with every request.
     pub headers: Vec<(HeaderName, HeaderValue)>,
+    /// Whether to enable default retrying requests on transient failures (429, 503, 504).
+    pub with_retry: bool,
 }
 
 impl Config {
@@ -194,6 +196,7 @@ impl Config {
             proxy_url: None,
             tls_server_name: None,
             headers: Vec::new(),
+            with_retry: true,
         }
     }
 
@@ -278,6 +281,7 @@ impl Config {
             proxy_url: None,
             tls_server_name: None,
             headers: Vec::new(),
+            with_retry: true,
         })
     }
 
@@ -340,6 +344,7 @@ impl Config {
             auth_info: loader.user,
             tls_server_name: loader.cluster.tls_server_name,
             headers: Vec::new(),
+            with_retry: true,
         })
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

`client-go` performs a default retry policy based on `Retry-After` response from the server, falling back on default retry policy for the client. In controller scenarios, the default is set to exponential backoff.

This `Retry-After` behaviour is non-configurable and is used across the board in `client-go` and `controller-runtime` as a basic retry mechanism for all API server requests, with `10` default retry attempts at the lowest level.

Such default allows to ignore some of the temporary API server errors with minimal delay, which may occur on some server load, or `CRD` cache initialisation in API server.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Add a similar implementation for `kube`, following current k8s defaults for `DefaultTypedControllerRateLimiter`, allowing to leverage recommended defaults within the tower layers for any default client setup users, and retain ability to disable the default and provide overrides with custom `RetryPolicy`, in cases where it is necessary.

Fixes #1986 

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
