### PR TITLE
bump k8s-openapi to 0.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       matrix:
         # Run these tests against older clusters as well
         k8s:
-        - "v1.31" # MK8SV
+        - "v1.32" # MK8SV
         - "latest"
     steps:
       - uses: actions/checkout@v6
@@ -213,7 +213,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: "v1.31" # MK8SV
+          version: "v1.32" # MK8SV
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
           tool: cargo-tarpaulin@0.32.8
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: "v1.31" # MK8SV
+          version: "v1.32" # MK8SV
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ hyper-util = "0.1.16"
 jiff = { version = "0.2.16", default-features = false }
 json-patch = "4"
 jsonpath-rust = "1"
-k8s-openapi = { version = "0.27.0", default-features = false }
+k8s-openapi = { version = "0.28.0", default-features = false }
 openssl = "0.10.61"
 parking_lot = "0.12.0"
 pem = "3.0.1"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
 [![Rust 1.88](https://img.shields.io/badge/MSRV-1.88-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.88.0)
-[![Tested against Kubernetes v1.31 and above](https://img.shields.io/badge/MK8SV-v1.31-326ce5.svg)](https://kube.rs/kubernetes-version)
+[![Tested against Kubernetes v1.32 and above](https://img.shields.io/badge/MK8SV-v1.32-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Select a version of `kube` along matching versions of [k8s-openapi](https://gith
 ```toml
 [dependencies]
 kube = { version = "3.1.0", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.27.0", features = ["latest", "schemars"] }
+k8s-openapi = { version = "0.28.0", features = ["latest", "schemars"] }
 schemars = { version = "1" }
 ```
 

--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ hack:
 minimal-versions:
   cargo hack --remove-dev-deps --workspace
   cargo +nightly update -Z direct-minimal-versions
-  K8S_OPENAPI_ENABLED_VERSION=v1_32 cargo check --all-features
+  K8S_OPENAPI_ENABLED_VERSION=1.32 cargo check --all-features
 
 readme:
   rustdoc README.md --test --edition=2024

--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ hack:
 minimal-versions:
   cargo hack --remove-dev-deps --workspace
   cargo +nightly update -Z direct-minimal-versions
-  K8S_OPENAPI_ENABLED_VERSION=1.31 cargo check --all-features
+  K8S_OPENAPI_ENABLED_VERSION=v1_32 cargo check --all-features
 
 readme:
   rustdoc README.md --test --edition=2024
@@ -113,6 +113,8 @@ bump-msrv msrv:
   sd "rust:.*-bullseye" "rust:{{msrv}}-bullseye" .devcontainer/Dockerfile
 
 # Sets the Kubernetes feature version from latest k8s-openapi.
+# run: cargo upgrade -p k8s-openapi -i
+# then: just bump-k8s
 bump-k8s:
   #!/usr/bin/env bash
   earliest=$(cargo info k8s-openapi --color=never 2> /dev/null |grep earliest | awk -F'[][]' '{print $2}')
@@ -126,6 +128,6 @@ bump-k8s:
   # bump mk8sv badge
   badge="[![Tested against Kubernetes ${min_dots} and above](https://img.shields.io/badge/MK8SV-${min_dots}-326ce5.svg)](https://kube.rs/kubernetes-version)"
   sd "^.+badge/MK8SV.+$" "${badge}" README.md
-  # bump K8S_OPENAPI_ENABLED_VERSION in minimal-versions recipe
+  # bump K8S_OPENAPI_ENABLED_VERSION in minimal-versions recipe (TODO: fix this)
   sd "K8S_OPENAPI_ENABLED_VERSION=\S+" "K8S_OPENAPI_ENABLED_VERSION=${min_dots}" justfile
   echo "remember to bump kubernetes-version.md in kube-rs/website"

--- a/kube-client/src/api/util/mod.rs
+++ b/kube-client/src/api/util/mod.rs
@@ -128,29 +128,36 @@ mod test {
 
         // Create TokenRequest
         let tokenrequest = serviceaccounts
-            .create_token_request(serviceaccount_name, &PostParams::default(), &TokenRequest {
-                metadata: Default::default(),
-                spec: TokenRequestSpec {
-                    audiences: audiences.clone(),
-                    bound_object_ref: None,
-                    expiration_seconds: None,
+            .create_token_request(
+                serviceaccount_name,
+                &PostParams::default(),
+                &TokenRequest {
+                    metadata: Default::default(),
+                    spec: Some(TokenRequestSpec {
+                        audiences: Some(audiences.clone()),
+                        bound_object_ref: None,
+                        expiration_seconds: None,
+                    }),
+                    status: None,
                 },
-                status: None,
-            })
+            )
             .await?;
-        let token = tokenrequest.status.unwrap().token;
+        let token = tokenrequest.status.unwrap().token.unwrap();
         assert!(!token.is_empty());
 
         // Check created token is valid with TokenReview
         let tokenreview = tokenreviews
-            .create(&PostParams::default(), &TokenReview {
-                metadata: Default::default(),
-                spec: TokenReviewSpec {
-                    audiences: Some(audiences.clone()),
-                    token: Some(token),
+            .create(
+                &PostParams::default(),
+                &TokenReview {
+                    metadata: Default::default(),
+                    spec: TokenReviewSpec {
+                        audiences: Some(audiences.clone()),
+                        token,
+                    },
+                    status: None,
                 },
-                status: None,
-            })
+            )
             .await?;
         let tokenreviewstatus = tokenreview.status.unwrap();
         assert_eq!(tokenreviewstatus.audiences, Some(audiences));


### PR DESCRIPTION
Upgrade to [k8s-openapi@0.28](https://github.com/Arnavion/k8s-openapi/releases/tag/v0.28.0) for Kubernetes `v1_36`.

some minor breaking changes found in `k8s_openapi::api::authentication::v1` (some option wrapping of the `token` has changed), guess kubernetes does not consider optionality breaking. (see e.g. [0.28-tokenreview-spec](https://docs.rs/k8s-openapi/latest/k8s_openapi/api/authentication/v1/struct.TokenReviewSpec.html) vs [0.27-tokenreview-spec](https://docs.rs/k8s-openapi/0.27.1/k8s_openapi/api/authentication/v1/struct.TokenReviewSpec.html)).