### PR TITLE
client: include sources in `CommitError`'s error message

### DIFF
--- a/kube-client/src/api/entry.rs
+++ b/kube-client/src/api/entry.rs
@@ -249,10 +249,10 @@ impl<K> OccupiedEntry<'_, K> {
 /// Commit errors
 pub enum CommitError {
     /// Pre-commit validation failed
-    #[error("failed to validate object for saving")]
+    #[error("failed to validate object for saving: {0}")]
     Validate(#[from] CommitValidationError),
     /// Failed to submit the new object to the Kubernetes API
-    #[error("failed to save object")]
+    #[error("failed to save object: {0}")]
     Save(#[source] Error),
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

A user report left us with logs that essentially boiled down to a `CommitError` message:

> failed to save object

That made the failure look generic and sent me down a couple-hour long debug session.

The actual cause was pretty simple, and once I eventually managed to reproduce it I saw that the inner `kube::Error` contained a pretty clear message for the actual problem and I thought "Damn, having that information would've made this so much easier" - so this change is to help future me :)

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

This PR just appends the existing error messages with `: {0}`, which is a pattern already present in other places such as the top-level `kube::Error` type.
