### PR TITLE
Include error sources in Display messages at client, core, runtime

### DIFF
--- a/kube-client/src/api/remote_command.rs
+++ b/kube-client/src/api/remote_command.rs
@@ -84,7 +84,7 @@ pub enum Error {
     SerializeTerminalSize(#[source] serde_json::Error),
 
     /// Fail to send terminal size message
-    #[error("failed to send terminal size message")]
+    #[error("failed to send terminal size message: {0}")]
     SendTerminalSize(#[source] ws::Error),
 
     /// Failed to set terminal size, tty need to be true to resize the terminal

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -79,7 +79,7 @@ pub enum Error {
     ReadTokenFile(#[source] std::io::Error, PathBuf),
 
     /// Failed to parse token-key
-    #[error("failed to parse token-key")]
+    #[error("failed to parse token-key: {0}")]
     ParseTokenKey(#[source] serde_json::Error),
 
     /// command was missing from exec config
@@ -103,7 +103,7 @@ pub enum Error {
     ExecMissingClusterInfo,
 
     /// No valid native root CA certificates found
-    #[error("No valid native root CA certificates found")]
+    #[error("No valid native root CA certificates found: {0}")]
     NoValidNativeRootCA(#[source] std::io::Error),
 }
 

--- a/kube-client/src/client/auth/oauth.rs
+++ b/kube-client/src/client/auth/oauth.rs
@@ -56,7 +56,7 @@ pub enum Error {
     BuildRequest(#[source] http::Error),
 
     /// No valid native root CA certificates found
-    #[error("No valid native root CA certificates found")]
+    #[error("No valid native root CA certificates found: {0}")]
     NoValidNativeRootCA(#[source] std::io::Error),
 
     /// OAuth failed with unknown reason

--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -46,7 +46,7 @@ pub mod rustls_tls {
         AddRootCertificate(#[source] Box<dyn std::error::Error + Send + Sync>),
 
         /// No valid native root CA certificates found
-        #[error("no valid native root CA certificates found")]
+        #[error("no valid native root CA certificates found: {0}")]
         NoValidNativeRootCA(#[source] std::io::Error),
 
         /// Invalid server name

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -78,15 +78,15 @@ pub enum KubeconfigError {
     ParseProxyUrl(#[source] http::uri::InvalidUri),
 
     /// Failed to load certificate authority
-    #[error("failed to load certificate authority")]
+    #[error("failed to load certificate authority: {0}")]
     LoadCertificateAuthority(#[source] LoadDataError),
 
     /// Failed to load client certificate
-    #[error("failed to load client certificate")]
+    #[error("failed to load client certificate: {0}")]
     LoadClientCertificate(#[source] LoadDataError),
 
     /// Failed to load client key
-    #[error("failed to load client key")]
+    #[error("failed to load client key: {0}")]
     LoadClientKey(#[source] LoadDataError),
 
     /// Failed to parse PEM-encoded certificates

--- a/kube-core/src/admission.rs
+++ b/kube-core/src/admission.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-#[error("failed to serialize patch")]
+#[error("failed to serialize patch: {0}")]
 /// Failed to serialize patch.
 pub struct SerializePatchError(#[source] serde_json::Error);
 

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -70,15 +70,15 @@ pub enum Error<ReconcilerErr: 'static, QueueErr: 'static> {
     ObjectNotFound(Box<ObjectRef<DynamicObject>>),
 
     /// User's reconcile fn failed for the object
-    #[error("reconciler for object {1} failed")]
+    #[error("reconciler for object {1} failed: {0}")]
     ReconcilerFailed(#[source] ReconcilerErr, Box<ObjectRef<DynamicObject>>),
 
     /// The queue stream contained an error
-    #[error("event queue error")]
+    #[error("event queue error: {0}")]
     QueueError(#[source] QueueErr),
 
     /// The internal runner returned an error
-    #[error("runner error")]
+    #[error("runner error: {0}")]
     RunnerError(#[source] RunnerError),
 }
 

--- a/kube-runtime/src/controller/runner.rs
+++ b/kube-runtime/src/controller/runner.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error<ReadyErr> {
-    #[error("readiness gate failed to become ready")]
+    #[error("readiness gate failed to become ready: {0}")]
     Readiness(#[source] ReadyErr),
 }
 


### PR DESCRIPTION
## Motivation

Follow-up to #2020, which surfaced the underlying cause in `CommitError`'s `Display` output. The same gap exists in a number of other error types across the workspace: a `#[source]`/`#[from]` field is present, but the `#[error(...)]` message never interpolates it, so the cause is dropped from plain `Display`/log output and only visible by walking `.source()`. Several are inconsistent within the same enum (e.g. `KubeconfigError::ParseCertificates` already appends `: {0}` while its sibling `Load*` variants don't), which makes these look like oversights rather than deliberate.

## Solution

Append `: {0}` to the affected messages, matching the convention the top-level `kube::Error` already follows. `#[source]`/`#[from]` stays in place, so the `.source()` chain is preserved.

Covered:
- **kube-client** — config (`LoadCertificateAuthority`, `LoadClientCertificate`, `LoadClientKey`), auth (`ParseTokenKey`, `NoValidNativeRootCA`), oauth (`NoValidNativeRootCA`), tls (`NoValidNativeRootCA`), remote_command (`SendTerminalSize`)
- **kube-runtime** — controller (`ReconcilerFailed`, `QueueError`, `RunnerError`) and runner (`Readiness`)
- **kube-core** — admission (`SerializePatchError`)

## Note

`controller::Error` and `runner::Error` now require `Display` on their generic error params for the generated `Display` impl. This is already implied by the existing `#[source]` bound (`std::error::Error: Display`), so it shouldn't affect real downstreams, but flagging it since it touches a public generic type's trait impl.
