### PR TITLE
Fix multi-document YAML parsing in kubectl apply example

### DIFF
--- a/examples/kubectl.rs
+++ b/examples/kubectl.rs
@@ -170,10 +170,7 @@ impl App {
         let ssapply = PatchParams::apply("kubectl-light").force();
         let pth = self.file.clone().expect("apply needs a -f file supplied");
         let yaml = std::fs::read(&pth).with_context(|| format!("Failed to read {}", pth.display()))?;
-        let docs = serde_json::Deserializer::from_slice(&yaml)
-            .into_iter::<DynamicObject>()
-            .flatten()
-            .collect::<Vec<_>>();
+        let docs: Vec<DynamicObject> = serde_saphyr::from_slice_multiple(&yaml)?;
 
         for obj in docs {
             let namespace = obj.metadata.namespace.as_deref().or(self.namespace.as_deref());


### PR DESCRIPTION
## Motivation

The `apply` subcommand of the `kubectl` example cannot read YAML manifests. It deserializes with a `serde_json` stream parser:

```rust
let docs = serde_json::Deserializer::from_slice(&yaml)
    .into_iter::<DynamicObject>()
    .flatten()
    .collect::<Vec<_>>();
```

`serde_json` does not understand YAML (`key: value` syntax, `---` document separators), and `.flatten()` silently drops every parse error. So `kubectl apply -f manifest.yaml` applies zero documents and exits successfully with no diagnostic. Reported in #2026.

This is a regression from the serde-yaml -> serde-saphyr migration (#1975); the rest of the example (`get`, `edit`, etc.) already uses `serde_saphyr`.

## Solution

Use `serde_saphyr::from_slice_multiple`, which parses multi-document YAML straight into `Vec<DynamicObject>` and propagates errors with `?`:

```rust
let docs: Vec<DynamicObject> = serde_saphyr::from_slice_multiple(&yaml)?;
```

This deserializes `DynamicObject` directly (consistent with the `edit` path's `serde_saphyr::from_str::<DynamicObject>`), ignores empty documents like the old multidoc helper did, and surfaces parse errors instead of swallowing them. `cargo check -p kube-examples --example kubectl` passes.

Fixes #2026