### PR TITLE
Remove extraneous Sync bound in Controller::reconcile_all_on

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -1501,7 +1501,7 @@ where
     ///
     /// If a [`Stream`] is terminated (by emitting [`None`]) then the [`Controller`] keeps running, but the [`Stream`] stops being polled.
     #[must_use]
-    pub fn reconcile_all_on(mut self, trigger: impl Stream<Item = ()> + Send + Sync + 'static) -> Self {
+    pub fn reconcile_all_on(mut self, trigger: impl Stream<Item = ()> + Send + 'static) -> Self {
         let store = self.store();
         let dyntype = self.dyntype.clone();
         self.trigger_selector.push(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

We want to use `Controller::reconcile_all_on` with a watcher configured to observe a single `ConfigMap`.
Currently, doing that requires a dance of `tokio` channels and `tokio::spawn` akin to the following (non-production-ready example, not all watcher events are updates to the config map):

```rs
let watcher_stream = watcher(...);
let (watch_tx, watch_rx) = watch::channel(());
tokio::spawn(async move {
    let mut watcher_stream = Box::pin(watcher_stream);
    while watcher_stream.next().await.is_some() {
        let send_result = watch_tx.send(());
        if send_result.is_err() {
            break;
        }
    }
});
Controller::new(...)
        .reconcile_all_on(WatchStream::new(watch_rx))
```

Instead, we would like to be able to specify the much simpler:

```rs
let watcher_stream = watcher(...);
Controller::new(...)
        .reconcile_all_on(watcher_stream.map(|_| ()))
```

But the stream returned by `watcher` is not `Sync`

## Solution

`Controller::reconcile_all_on` does not actually need the stream to be `Send + Sync`, and it works perfectly fine with a `Send` stream. So we can remove the `Sync` bound, and allow a watcher-based stream to be passed to `reconcile_all_on`.
