### PR TITLE
client: fall back to OS-native cert store via rustls-platform-verifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,8 @@ proc-macro2 = "1.0.93"
 quote = "1.0.38"
 rand = "0.10.0"
 runtime-macros = "1.1.1"
-rustls = { version = "0.23.16", default-features = false }
+rustls = { version = "0.23.27", default-features = false }
+rustls-platform-verifier = "0.7.0"
 schemars = "1.0.0"
 secrecy = "0.10.2"
 serde = "1.0.221"

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,9 @@ exceptions = [
     # Pulled in via hyper-rustls when using the webpki-roots feature,
     # which is off by default.
     { allow = ["CDLA-Permissive-2.0", "MPL-2.0"], crate = "webpki-roots" },
+    # Bundled CA roots pulled in via rustls-platform-verifier (used as the
+    # default no-CA trust source on the rustls-tls stack).
+    { allow = ["CDLA-Permissive-2.0"], crate = "webpki-root-certs" },
 ]
 
 [sources]

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["web-programming::http-client", "network-programming", "api-bindin
 default = ["client", "ring"]
 rustls-tls = ["rustls", "hyper-rustls"]
 webpki-roots = ["hyper-rustls/webpki-roots"]
+rustls-platform-verifier = ["rustls-tls", "dep:rustls-platform-verifier"]
 aws-lc-rs = ["hyper-rustls?/aws-lc-rs"]
 ring = ["hyper-rustls?/ring"]
 openssl-tls = ["openssl", "hyper-openssl"]
@@ -36,7 +37,7 @@ unstable-client = []
 __non_core = ["tracing", "serde-saphyr", "base64"]
 
 [package.metadata.docs.rs]
-features = ["client", "rustls-tls", "openssl-tls", "ws", "oauth", "oidc", "jsonpatch", "admission", "k8s-openapi/latest", "socks5", "unstable-client", "http-proxy"]
+features = ["client", "rustls-tls", "rustls-platform-verifier", "openssl-tls", "ws", "oauth", "oidc", "jsonpatch", "admission", "k8s-openapi/latest", "socks5", "unstable-client", "http-proxy"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -58,6 +59,7 @@ jiff = { workspace = true, optional = true, features = ["std", "serde"] }
 pem = { workspace = true, optional = true }
 openssl = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
+rustls-platform-verifier = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["time", "signal", "sync", "rt"], optional = true }
 kube-core = { path = "../kube-core", version = "=4.0.0" }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -13,9 +13,8 @@ categories = ["web-programming::http-client", "network-programming", "api-bindin
 
 [features]
 default = ["client", "ring"]
-rustls-tls = ["rustls", "hyper-rustls"]
+rustls-tls = ["rustls", "hyper-rustls", "dep:rustls-platform-verifier"]
 webpki-roots = ["hyper-rustls/webpki-roots"]
-rustls-platform-verifier = ["rustls-tls", "dep:rustls-platform-verifier"]
 aws-lc-rs = ["hyper-rustls?/aws-lc-rs"]
 ring = ["hyper-rustls?/ring"]
 openssl-tls = ["openssl", "hyper-openssl"]
@@ -37,7 +36,7 @@ unstable-client = []
 __non_core = ["tracing", "serde-saphyr", "base64"]
 
 [package.metadata.docs.rs]
-features = ["client", "rustls-tls", "rustls-platform-verifier", "openssl-tls", "ws", "oauth", "oidc", "jsonpatch", "admission", "k8s-openapi/latest", "socks5", "unstable-client", "http-proxy"]
+features = ["client", "rustls-tls", "openssl-tls", "ws", "oauth", "oidc", "jsonpatch", "admission", "k8s-openapi/latest", "socks5", "unstable-client", "http-proxy"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -6,8 +6,8 @@ pub mod rustls_tls {
         time::{Duration, Instant},
     };
 
-    // Only the webpki/native-root fallbacks use this; the platform-verifier path does not.
-    #[cfg(not(feature = "rustls-platform-verifier"))]
+    // Only the webpki-roots fallback uses this; the default platform-verifier path does not.
+    #[cfg(feature = "webpki-roots")]
     use hyper_rustls::ConfigBuilderExt;
     use rustls::{
         self, ClientConfig, DigitallySignedStruct, RootCertStore,
@@ -47,12 +47,7 @@ pub mod rustls_tls {
         #[error("failed to add a root certificate: {0}")]
         AddRootCertificate(#[source] Box<dyn std::error::Error + Send + Sync>),
 
-        /// No valid native root CA certificates found
-        #[error("no valid native root CA certificates found: {0}")]
-        NoValidNativeRootCA(#[source] std::io::Error),
-
         /// Failed to initialise the platform certificate verifier
-        #[cfg(feature = "rustls-platform-verifier")]
         #[error("failed to initialise the platform certificate verifier: {0}")]
         PlatformVerifier(#[source] rustls::Error),
 
@@ -71,30 +66,22 @@ pub mod rustls_tls {
             ClientConfig::builder().with_root_certificates(root_store(certs)?)
         } else {
             // No CA was configured (e.g. the kubeconfig has no `certificate-authority`),
-            // so fall back to the platform/system trust store, mirroring how client-go
-            // leaves `RootCAs` nil to defer to the OS roots.
-            #[cfg(feature = "rustls-platform-verifier")]
+            // so defer to the trust store, mirroring how client-go leaves `RootCAs`
+            // nil to use the OS roots.
+            #[cfg(feature = "webpki-roots")]
             {
-                // Delegate to the OS-native verifier (macOS Security framework,
-                // Windows CryptoAPI, native roots on Linux). Takes precedence over
-                // `webpki-roots`/`with_native_roots` because it honours OS trust
-                // policies such as per-certificate trust settings.
+                // Opt-in override: use the bundled WebPKI (Mozilla) roots.
+                ClientConfig::builder().with_webpki_roots()
+            }
+            #[cfg(not(feature = "webpki-roots"))]
+            {
+                // Default: delegate to the OS-native verifier (macOS Security
+                // framework, Windows CryptoAPI, native roots on Linux/Android/iOS),
+                // honouring OS trust policies such as per-certificate trust settings.
                 use rustls_platform_verifier::BuilderVerifierExt;
                 ClientConfig::builder()
                     .with_platform_verifier()
                     .map_err(Error::PlatformVerifier)?
-            }
-            #[cfg(all(not(feature = "rustls-platform-verifier"), feature = "webpki-roots"))]
-            {
-                // Use WebPKI roots.
-                ClientConfig::builder().with_webpki_roots()
-            }
-            #[cfg(all(not(feature = "rustls-platform-verifier"), not(feature = "webpki-roots")))]
-            {
-                // Use native roots. This will panic on Android and iOS.
-                ClientConfig::builder()
-                    .with_native_roots()
-                    .map_err(Error::NoValidNativeRootCA)?
             }
         };
 
@@ -289,7 +276,7 @@ FRU=
         }
     }
 
-    #[cfg(all(test, feature = "rustls-platform-verifier"))]
+    #[cfg(all(test, not(feature = "webpki-roots")))]
     mod platform_verifier_tests {
         use super::*;
 

--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -6,6 +6,8 @@ pub mod rustls_tls {
         time::{Duration, Instant},
     };
 
+    // Only the webpki/native-root fallbacks use this; the platform-verifier path does not.
+    #[cfg(not(feature = "rustls-platform-verifier"))]
     use hyper_rustls::ConfigBuilderExt;
     use rustls::{
         self, ClientConfig, DigitallySignedStruct, RootCertStore,
@@ -49,6 +51,11 @@ pub mod rustls_tls {
         #[error("no valid native root CA certificates found: {0}")]
         NoValidNativeRootCA(#[source] std::io::Error),
 
+        /// Failed to initialise the platform certificate verifier
+        #[cfg(feature = "rustls-platform-verifier")]
+        #[error("failed to initialise the platform certificate verifier: {0}")]
+        PlatformVerifier(#[source] rustls::Error),
+
         /// Invalid server name
         #[error("invalid server name: {0}")]
         InvalidServerName(#[source] InvalidDnsNameError),
@@ -63,12 +70,26 @@ pub mod rustls_tls {
         let config_builder = if let Some(certs) = root_certs {
             ClientConfig::builder().with_root_certificates(root_store(certs)?)
         } else {
-            #[cfg(feature = "webpki-roots")]
+            // No CA was configured (e.g. the kubeconfig has no `certificate-authority`),
+            // so fall back to the platform/system trust store, mirroring how client-go
+            // leaves `RootCAs` nil to defer to the OS roots.
+            #[cfg(feature = "rustls-platform-verifier")]
+            {
+                // Delegate to the OS-native verifier (macOS Security framework,
+                // Windows CryptoAPI, native roots on Linux). Takes precedence over
+                // `webpki-roots`/`with_native_roots` because it honours OS trust
+                // policies such as per-certificate trust settings.
+                use rustls_platform_verifier::BuilderVerifierExt;
+                ClientConfig::builder()
+                    .with_platform_verifier()
+                    .map_err(Error::PlatformVerifier)?
+            }
+            #[cfg(all(not(feature = "rustls-platform-verifier"), feature = "webpki-roots"))]
             {
                 // Use WebPKI roots.
                 ClientConfig::builder().with_webpki_roots()
             }
-            #[cfg(not(feature = "webpki-roots"))]
+            #[cfg(all(not(feature = "rustls-platform-verifier"), not(feature = "webpki-roots")))]
             {
                 // Use native roots. This will panic on Android and iOS.
                 ClientConfig::builder()
@@ -265,6 +286,21 @@ FRU=
             drop(file);
             expire(&verifier);
             assert!(Arc::ptr_eq(&verifier.current(), &second));
+        }
+    }
+
+    #[cfg(all(test, feature = "rustls-platform-verifier"))]
+    mod platform_verifier_tests {
+        use super::*;
+
+        // With no kubeconfig CA, the client config must fall back to the OS-native
+        // verifier instead of producing an empty (reject-everything) trust store.
+        #[test]
+        fn no_ca_falls_back_to_platform_verifier() {
+            #[cfg(feature = "aws-lc-rs")]
+            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+            rustls_client_config(None, None, false).expect("platform verifier config should build");
         }
     }
 

--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -47,9 +47,9 @@ pub mod rustls_tls {
         #[error("failed to add a root certificate: {0}")]
         AddRootCertificate(#[source] Box<dyn std::error::Error + Send + Sync>),
 
-        /// Failed to initialise the platform certificate verifier
-        #[error("failed to initialise the platform certificate verifier: {0}")]
-        PlatformVerifier(#[source] rustls::Error),
+        /// No valid native root CA certificates found
+        #[error("no valid native root CA certificates found: {0}")]
+        NoValidNativeRootCA(#[source] std::io::Error),
 
         /// Invalid server name
         #[error("invalid server name: {0}")]
@@ -81,7 +81,9 @@ pub mod rustls_tls {
                 use rustls_platform_verifier::BuilderVerifierExt;
                 ClientConfig::builder()
                     .with_platform_verifier()
-                    .map_err(Error::PlatformVerifier)?
+                    // Reuse the type-erased trust-setup error variant to keep the
+                    // public `Error` enum stable.
+                    .map_err(|e| Error::AddRootCertificate(Box::new(e)))?
             }
         };
 

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -30,10 +30,8 @@ hyper-util-tracing = ["kube-client/hyper-util-tracing", "client"]
 aws-lc-rs = ["kube-client?/aws-lc-rs"]
 ## ring rustls provider
 ring = ["kube-client?/ring"]
-## enable webpki roots in rustls
+## enable webpki roots in rustls (otherwise the OS-native trust store is used when no CA is configured)
 webpki-roots = ["kube-client/webpki-roots", "client"]
-## verify server certs against the OS-native trust store via rustls-platform-verifier (used when no CA is configured)
-rustls-platform-verifier = ["kube-client/rustls-platform-verifier", "rustls-tls"]
 
 ## enable kube-derive and proc macros
 derive = ["kube-derive", "kube-core/schema"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -32,6 +32,8 @@ aws-lc-rs = ["kube-client?/aws-lc-rs"]
 ring = ["kube-client?/ring"]
 ## enable webpki roots in rustls
 webpki-roots = ["kube-client/webpki-roots", "client"]
+## verify server certs against the OS-native trust store via rustls-platform-verifier (used when no CA is configured)
+rustls-platform-verifier = ["kube-client/rustls-platform-verifier", "rustls-tls"]
 
 ## enable kube-derive and proc macros
 derive = ["kube-derive", "kube-core/schema"]


### PR DESCRIPTION
## Motivation

Closes #2028.

When a kubeconfig has no `certificate-authority`/`-data`, client-go leaves `RootCAs` nil and defers TLS verification to the platform trust store (macOS keychain, Linux `/etc/ssl/certs`, Windows cert store). kube-rs's rustls backend instead fell back to `with_native_roots()`, which only loads roots as trust anchors and verifies via webpki — it doesn't honour OS trust policies (per-certificate trust settings, AIA intermediate fetching, etc.), and panics on Android/iOS.

## Solution

Use [`rustls-platform-verifier`](https://github.com/rustls/rustls-platform-verifier) as the **default** no-CA trust source for the `rustls-tls` stack. It delegates to the OS-native verifier (macOS Security framework, Windows CryptoAPI, native roots on Linux/Android/iOS), matching client-go's "defer to the OS" behaviour and superseding `with_native_roots()` (incl. removing the Android/iOS panic).

- `rustls-platform-verifier` is now pulled in by the `rustls-tls` feature and used whenever no CA is configured — no opt-in needed.
- `webpki-roots` remains an explicit override for the bundled Mozilla roots.
- When a CA **is** configured it stays the sole trust anchor (matching client-go); the platform verifier only engages on the no-CA path.

## Changes

- `kube-client`: `rustls-tls` now enables `dep:rustls-platform-verifier`; the no-CA branch uses `ClientConfig::builder().with_platform_verifier()`. The `with_native_roots()` call is dropped, but the **public `rustls_tls::Error` enum is unchanged** — the verifier's `rustls::Error` is mapped into the existing type-erased `AddRootCertificate` variant, and `NoValidNativeRootCA` is retained. Unit test added for the no-CA path.
- `kube`: doc note on `webpki-roots`; no new feature needed.
- workspace: add `rustls-platform-verifier = \"0.7.0\"`; bump `rustls` floor `0.23.16` → `0.23.27` (the verifier's minimum; already resolving to 0.23.40).

> Note: this leaves the separate OAuth/OIDC token-endpoint clients (`auth/oauth.rs`, `auth/oidc.rs`) on `with_native_roots()` — those talk to public IdPs, out of scope here.

## Verification

- Compiles across the cfg matrix: default rustls (platform verifier) / `webpki-roots` override / all-features (incl. openssl) / provider-less.
- `cargo +nightly fmt --check` clean, clippy `--all-targets` clean, tls unit tests pass.