### PR TITLE
bump msrv to 1.89

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.88.0-bullseye
+FROM docker.io/rust:1.89.0-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/kube-rs/kube"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.89.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kube-rs
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
-[![Rust 1.88](https://img.shields.io/badge/MSRV-1.88-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.88.0)
+[![Rust 1.89](https://img.shields.io/badge/MSRV-1.89-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.89.0)
 [![Tested against Kubernetes v1.32 and above](https://img.shields.io/badge/MK8SV-v1.32-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)


### PR DESCRIPTION
now required as currently [failing ci](https://github.com/kube-rs/kube/actions/runs/28783302345/job/85343844760) due to some leaf dependencies;

```
      Adding educe v0.6.0 (available: v0.7.4, requires Rust 1.89)
      Adding enum-ordinalize v4.4.1 (requires Rust 1.89)
      Adding enum-ordinalize-derive v4.4.1 (requires Rust 1.89)
```