### PR TITLE
config: resolve relative exec plugin command paths

### DIFF
--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -1182,9 +1182,14 @@ users:
         // Regression for kdash-rs/kdash#541.
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("config");
+        // Build the relative command with the platform separator so it contains
+        // `MAIN_SEPARATOR` on every OS (the guard uses `MAIN_SEPARATOR`, which is
+        // `\` on Windows), keeping the test separator-agnostic.
+        let rel_cmd = format!("auth{}token.sh", std::path::MAIN_SEPARATOR);
         std::fs::write(
             &path,
-            r#"
+            format!(
+                r#"
 apiVersion: v1
 kind: Config
 current-context: ctx
@@ -1202,20 +1207,21 @@ users:
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
-      command: auth/token.sh
+      command: {rel_cmd}
 - name: path-user
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
       command: aws
-"#,
+"#
+            ),
         )
         .unwrap();
 
         let cfg = Kubeconfig::read_from(&path).unwrap();
 
         // Relative command containing a separator is made absolute.
-        let expected = to_absolute(dir.path(), "auth/token.sh");
+        let expected = to_absolute(dir.path(), &rel_cmd);
         assert_eq!(
             cfg.auth_infos[0]
                 .auth_info

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -471,6 +471,17 @@ impl Kubeconfig {
                         {
                             auth_info.token_file = Some(abs_path);
                         }
+                        // Exec plugin commands can also be relative paths. Match
+                        // client-go (`GetAuthInfoFileReferences`) and only resolve
+                        // them when they contain a path separator, so bare `PATH`
+                        // lookups like `aws` are left untouched.
+                        if let Some(exec) = &mut auth_info.exec
+                            && let Some(command) = &exec.command
+                            && command.contains(std::path::MAIN_SEPARATOR)
+                            && let Some(abs_path) = to_absolute(dir, command)
+                        {
+                            exec.command = Some(abs_path);
+                        }
                     }
                 }
             }
@@ -1162,6 +1173,67 @@ users:
             assert_eq!(cfg.contexts[0].name, "k3d-promstack");
             assert_eq!(cfg.auth_infos[0].name, "admin@k3d-k3s-default");
         }
+    }
+
+    #[test]
+    fn read_from_resolves_relative_exec_command() {
+        // Relative exec plugin commands are resolved against the kubeconfig
+        // directory (like client-go), while bare PATH commands are left as-is.
+        // Regression for kdash-rs/kdash#541.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config");
+        std::fs::write(
+            &path,
+            r#"
+apiVersion: v1
+kind: Config
+current-context: ctx
+clusters:
+- name: cluster
+  cluster:
+    server: https://localhost:6443
+contexts:
+- name: ctx
+  context:
+    cluster: cluster
+    user: relative-user
+users:
+- name: relative-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: auth/token.sh
+- name: path-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: aws
+"#,
+        )
+        .unwrap();
+
+        let cfg = Kubeconfig::read_from(&path).unwrap();
+
+        // Relative command containing a separator is made absolute.
+        let expected = to_absolute(dir.path(), "auth/token.sh");
+        assert_eq!(
+            cfg.auth_infos[0]
+                .auth_info
+                .as_ref()
+                .and_then(|a| a.exec.as_ref())
+                .and_then(|e| e.command.clone()),
+            expected
+        );
+
+        // Bare PATH command is untouched.
+        assert_eq!(
+            cfg.auth_infos[1]
+                .auth_info
+                .as_ref()
+                .and_then(|a| a.exec.as_ref())
+                .and_then(|e| e.command.as_deref()),
+            Some("aws")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Relative paths for an exec credential plugin `command` in a kubeconfig do not work today. `Kubeconfig::read_from` already remaps relative `certificate-authority`, `client-certificate`, `client-key`, and `tokenFile` paths to absolute against the kubeconfig directory, but it leaves `users[].user.exec.command` as-is. `auth_exec` then runs `Command::new(command)`, which resolves a relative command against the process working directory rather than the kubeconfig directory.

kubectl/client-go does resolve it. `GetAuthInfoFileReferences` in `clientcmd/loader.go` includes the exec command in the set of paths it makes absolute relative to the kubeconfig file, guarded by a path-separator check:

```go
if authInfo.Exec != nil && strings.ContainsRune(authInfo.Exec.Command, filepath.Separator) {
    s = append(s, &authInfo.Exec.Command)
}
```

So a kubeconfig that authenticates fine with kubectl (for example an EKS setup with `command: ../cache-eks-token/cached-aws-eks-token.sh`) fails with kube-rs whenever the app is launched from a directory other than the one holding the kubeconfig. Reported downstream in kdash: https://github.com/kdash-rs/kdash/issues/541

## Solution

Resolve a relative exec `command` against the kubeconfig directory in `read_from`, next to the existing cert/key/tokenFile handling. The resolution is guarded on the command containing a path separator, matching client-go, so bare `PATH` lookups like `aws` or `gke-gcloud-auth-plugin` are left untouched.

Added a regression test (`read_from_resolves_relative_exec_command`) covering both cases: a relative command becomes absolute, and a bare command stays as-is.

---

Note: this change was prepared with AI assistance and reviewed by me before opening.
