### PR TITLE
Avoid deep-cloning ObjectMeta per event in trigger_owners

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -252,8 +252,10 @@ where
     KOwner: Resource,
     KOwner::DynamicType: Clone,
 {
-    let mapper = move |obj: S::Ok| {
-        let meta = obj.meta().clone();
+    let mapper = move |mut obj: S::Ok| {
+        // `obj` is owned here, so take the metadata instead of deep-cloning the whole
+        // ObjectMeta (labels/annotations/managedFields) just to read two fields.
+        let meta = std::mem::take(obj.meta_mut());
         let ns = meta.namespace;
         let owner_type = owner_type.clone();
         meta.owner_references


### PR DESCRIPTION
## Motivation

`trigger_owners` (behind `Controller::owns(...)`) runs once per owned-child event, and cloned the entire `ObjectMeta` of every event just to read `namespace` and `owner_references`. Labels, annotations, and `managedFields` were deep-cloned and then dropped immediately.

## Solution

The object is owned by the mapper closure, so take the metadata with `std::mem::take(obj.meta_mut())` instead of cloning it. `trigger_owners_shared` takes `Arc<K>` and cannot take, so it is left unchanged.

**Measurement.** dhat, same style as `kube-runtime/benches/memory.rs`: ran the mapper over 10,000 ConfigMaps carrying two `managedFields` entries and a `last-applied-configuration` annotation (a realistic server-side-apply object).

| mapper | total allocated | allocations |
|---|---|---|
| `.clone()` | 56.8 MB | 410,000 |
| `mem::take` | 0 | 0 |

So ~5.7 KB and 41 heap allocations per event, eliminated. Objects with lean metadata save proportionally less.
