### PR TITLE
Amortize PredicateFilter cache eviction across polls

### DIFF
--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -7,7 +7,10 @@ use futures::Stream;
 use kube_client::{Resource, api::ObjectMeta};
 use pin_project::pin_project;
 use std::{
-    collections::{HashMap, hash_map::DefaultHasher},
+    collections::{
+        HashMap,
+        hash_map::{DefaultHasher, Entry},
+    },
     hash::{Hash, Hasher},
     marker::PhantomData,
     time::{Duration, Instant},
@@ -162,6 +165,7 @@ pub struct PredicateFilter<St, K: Resource, P: Predicate<K>> {
     predicate: P,
     cache: HashMap<PredicateCacheKey, CacheEntry>,
     config: Config,
+    last_evicted: Instant,
     // K: Resource necessary to get .meta() of an object during polling
     _phantom: PhantomData<K>,
 }
@@ -177,6 +181,7 @@ where
             predicate,
             cache: HashMap::new(),
             config,
+            last_evicted: Instant::now(),
             _phantom: PhantomData,
         }
     }
@@ -193,27 +198,44 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut me = self.project();
 
-        // Evict expired entries before processing new events
         let now = Instant::now();
         let ttl = me.config.ttl;
-        me.cache
-            .retain(|_, entry| now.duration_since(entry.last_seen) < ttl);
+        // Reclaim expired entries periodically instead of on every poll. Per-entry
+        // freshness is enforced below, so this scan is only memory hygiene and does
+        // not affect which events are emitted.
+        if now.duration_since(*me.last_evicted) >= ttl {
+            me.cache
+                .retain(|_, entry| now.duration_since(entry.last_seen) < ttl);
+            *me.last_evicted = now;
+        }
 
         Poll::Ready(loop {
             break match ready!(me.stream.as_mut().poll_next(cx)) {
                 Some(Ok(obj)) => {
                     if let Some(val) = me.predicate.hash_property(&obj) {
                         let key = PredicateCacheKey::from(obj.meta());
-                        let now = Instant::now();
 
-                        // Check if the predicate value changed or entry doesn't exist
-                        let changed = me.cache.get(&key).map(|entry| entry.hash) != Some(val);
-
-                        // Upsert the cache entry with new hash and timestamp
-                        me.cache.insert(key, CacheEntry {
-                            hash: val,
-                            last_seen: now,
-                        });
+                        // Upsert in a single lookup. An entry older than the TTL is
+                        // treated as absent, matching the evict-before-every-poll
+                        // semantics now that eviction is amortized.
+                        let changed = match me.cache.entry(key) {
+                            Entry::Occupied(mut e) => {
+                                let stale = now.duration_since(e.get().last_seen) >= ttl;
+                                let changed = stale || e.get().hash != val;
+                                e.insert(CacheEntry {
+                                    hash: val,
+                                    last_seen: now,
+                                });
+                                changed
+                            }
+                            Entry::Vacant(e) => {
+                                e.insert(CacheEntry {
+                                    hash: val,
+                                    last_seen: now,
+                                });
+                                true
+                            }
+                        };
 
                         if changed {
                             Some(Ok(obj))


### PR DESCRIPTION
## Motivation

`PredicateFilter::poll_next` ran `cache.retain(...)` on every poll, including polls where the inner stream returns `Pending`, so a controller filtering N objects paid an O(N) scan on every wakeup.

## Solution

Run `retain` at most once per TTL, and enforce per-entry freshness at lookup instead: an entry older than the TTL is treated as absent, so the set of emitted events is unchanged. The `get` + `insert` pair also collapses into a single `entry()` probe. Existing predicate tests (including the TTL-eviction test) pass unchanged.

**Measurement.** Timing over a 10,000-entry cache, 1,000 idle polls (nothing expires), mirroring the eviction loop:

| eviction | time |
|---|---|
| retain-every-poll | 25.2 ms |
| amortized | 17 µs |

The saving scales with cache size times the number of no-op polls.

<details><summary>repro harness</summary>

```rust
use std::{collections::HashMap, hint::black_box, time::{Duration, Instant}};

fn main() {
    const N: usize = 10_000;
    const POLLS: usize = 1_000;
    let ttl = Duration::from_secs(3600);
    let start = Instant::now();
    let cache0: HashMap<String, (u64, Instant)> =
        (0..N).map(|i| (format!("key-{i}"), (i as u64, start))).collect();

    // OLD: full O(n) retain on every poll (nothing expired -> scans, removes nothing)
    let mut c = cache0.clone();
    let t = Instant::now();
    for _ in 0..POLLS {
        let now = Instant::now();
        c.retain(|_, (_, ls)| now.duration_since(*ls) < ttl);
        black_box(&c);
    }
    println!("OLD retain-every-poll: {:?}", t.elapsed());

    // NEW: amortized -> skip retain until ttl elapses
    let mut c = cache0.clone();
    let mut last_evicted = Instant::now();
    let t = Instant::now();
    for _ in 0..POLLS {
        let now = Instant::now();
        if now.duration_since(last_evicted) >= ttl {
            c.retain(|_, (_, ls)| now.duration_since(*ls) < ttl);
            last_evicted = now;
        }
        black_box(&c);
    }
    println!("NEW amortized: {:?}", t.elapsed());
}
```
</details>
