### PR TITLE
Construct typed CustomResourceDefinition in derived crd()

### DIFF
--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -112,7 +112,6 @@ fn verify_crd() {
           "plural": "fooz",
           "shortNames": ["f"],
           "singular": "foo",
-          "categories": []
         },
         "scope": "Namespaced",
         "versions": [

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -794,11 +794,6 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         let printers: Vec<_> = printcolumns.iter().map(|p| p.to_tokens(&k8s_openapi)).collect();
         quote! { vec![ #(#printers),* ] }
     };
-    let fields: Vec<String> = selectable
-        .iter()
-        .map(|s| format!(r#"{{ "jsonPath": "{s}" }}"#))
-        .collect();
-    let fields = format!("[ {} ]", fields.join(","));
     let scale = scale.map_or_else(
         || quote! { None },
         |s| {
@@ -823,20 +818,33 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         quote! { &[#names] }
     };
 
-    let categories_json = serde_json::to_string(&categories).unwrap();
-    let short_json = serde_json::to_string(&shortnames).unwrap();
+    // Unset attributes must be absent from the CRD, not explicit empty collections (#1680)
+    let opt = |unset: bool, value: TokenStream| {
+        if unset {
+            quote! { None }
+        } else {
+            quote! { Some(#value) }
+        }
+    };
+    let categories = opt(categories.is_empty(), quote! { vec![#(#categories.into()),*] });
+    let short_names = opt(shortnames.is_empty(), quote! { vec![#(#shortnames.into()),*] });
+    let printer_columns = opt(printcolumns.is_empty(), printers);
+    let fields = selectable
+        .iter()
+        .map(|path| quote! { #apiext::SelectableField { json_path: #path.into() } });
+    let selectable_fields = opt(selectable.is_empty(), quote! { vec![#(#fields),*] });
+    let subresources = opt(!has_status, quote! {
+        #apiext::CustomResourceSubresources {
+            scale: #scale,
+            status: Some(#apiext::CustomResourceSubresourceStatus(#serde_json::json!({}))),
+        }
+    });
+    let (deprecated, deprecation_warning) = match deprecated {
+        None => (quote! { None }, quote! { None }),
+        Some(Override::Inherit) => (quote! { Some(true) }, quote! { None }),
+        Some(Override::Explicit(warning)) => (quote! { Some(true) }, quote! { Some(#warning.into()) }),
+    };
     let crd_meta_name = format!("{plural}.{group}");
-
-    let mut crd_meta = TokenStream::new();
-    crd_meta.extend(quote! { "name": #crd_meta_name });
-
-    if !annotations.is_empty() {
-        crd_meta.extend(quote! { , "annotations": #meta_annotations });
-    }
-
-    if !labels.is_empty() {
-        crd_meta.extend(quote! { , "labels": #meta_labels });
-    }
 
     let schemagen = if schema_mode.use_in_crd() {
         quote! {
@@ -851,7 +859,10 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
                 .with_transform(#kube_core::schema::OptionalEnum)
                 .with_transform(#kube_core::schema::OptionalIntOrString)
                 .into_generator();
-            let schema = generate.into_root_schema_for::<Self>();
+            let schema = #serde_json::to_value(generate.into_root_schema_for::<Self>())
+                .and_then(#serde_json::from_value)
+                .map(Some)
+                .expect("valid JSONSchemaProps from schemars schema");
         }
     } else {
         // we could issue a compile time warning for this, but it would hit EVERY compile, which would be noisy
@@ -862,86 +873,51 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         }
     };
 
-    let selectable = if !selectable.is_empty() {
-        quote! { "selectableFields": fields, }
-    } else {
-        quote! {}
-    };
-
-    let deprecation = if let Some(deprecation) = deprecated {
-        match deprecation {
-            Override::Inherit => quote! { "deprecated": true, },
-            Override::Explicit(warning) => quote! {
-                "deprecated": true,
-                "deprecationWarning": #warning,
-            },
-        }
-    } else {
-        quote! {}
-    };
-
     // Known constraints that are hard to enforce elsewhere
     let compile_constraints = quote! {}; // all modern features rolled out atm.
-
-    let jsondata = quote! {
-        #schemagen
-
-        let jsondata = #serde_json::json!({
-            "metadata": {
-                #crd_meta
-            },
-            "spec": {
-                "group": #group,
-                "scope": #scope,
-                "names": {
-                    "categories": categories,
-                    "plural": #plural,
-                    "singular": #name,
-                    "kind": #kind,
-                    "shortNames": shorts
-                },
-                "versions": [{
-                    "name": #version,
-                    "served": #served,
-                    "storage": #storage,
-                    #deprecation
-                    "schema": {
-                        "openAPIV3Schema": schema,
-                    },
-                    "additionalPrinterColumns": columns,
-                    #selectable
-                    "subresources": subres,
-                }],
-            }
-        });
-    };
 
     // Implement the CustomResourceExt trait to allow users writing generic logic on top of them
     let impl_crd = quote! {
         impl #extver::CustomResourceExt for #rootident {
 
             fn crd() -> #apiext::CustomResourceDefinition {
-                let columns : Vec<#apiext::CustomResourceColumnDefinition> = #printers;
-                let fields : Vec<#apiext::SelectableField> = #serde_json::from_str(#fields).expect("valid selectableField column json");
-                let scale: Option<#apiext::CustomResourceSubresourceScale> = #scale;
-                let categories: Vec<String> = #serde_json::from_str(#categories_json).expect("valid categories");
-                let shorts : Vec<String> = #serde_json::from_str(#short_json).expect("valid shortnames");
-                let subres = if #has_status {
-                    if let Some(s) = &scale {
-                        #serde_json::json!({
-                            "status": {},
-                            "scale": scale
-                        })
-                    } else {
-                        #serde_json::json!({"status": {} })
-                    }
-                } else {
-                    #serde_json::json!({})
-                };
+                #schemagen
 
-                #jsondata
-                #serde_json::from_value(jsondata)
-                    .expect("valid custom resource from #[kube(attrs..)]")
+                #apiext::CustomResourceDefinition {
+                    metadata: #k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                        annotations: #meta_annotations,
+                        labels: #meta_labels,
+                        name: Some(#crd_meta_name.into()),
+                        ..Default::default()
+                    },
+                    spec: #apiext::CustomResourceDefinitionSpec {
+                        group: #group.into(),
+                        names: #apiext::CustomResourceDefinitionNames {
+                            categories: #categories,
+                            kind: #kind.into(),
+                            plural: #plural.into(),
+                            short_names: #short_names,
+                            singular: Some(#name.into()),
+                            ..Default::default()
+                        },
+                        scope: #scope.into(),
+                        versions: vec![#apiext::CustomResourceDefinitionVersion {
+                            additional_printer_columns: #printer_columns,
+                            deprecated: #deprecated,
+                            deprecation_warning: #deprecation_warning,
+                            name: #version.into(),
+                            schema: Some(#apiext::CustomResourceValidation {
+                                open_api_v3_schema: schema,
+                            }),
+                            selectable_fields: #selectable_fields,
+                            served: #served,
+                            storage: #storage,
+                            subresources: #subresources,
+                        }],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }
             }
 
             fn crd_name() -> &'static str {

--- a/kube-derive/tests/crd_complex_enum_test.rs
+++ b/kube-derive/tests/crd_complex_enum_test.rs
@@ -130,16 +130,13 @@ fn complex_enum() {
             "spec": {
               "group": "clux.dev",
               "names": {
-                "categories": [],
                 "kind": "ComplexEnumTest",
                 "plural": "complexenumtests",
-                "shortNames": [],
                 "singular": "complexenumtest"
               },
               "scope": "Cluster",
               "versions": [
                 {
-                  "additionalPrinterColumns": [],
                   "name": "v1",
                   "schema": {
                     "openAPIV3Schema": {
@@ -224,7 +221,6 @@ fn complex_enum() {
                   },
                   "served": true,
                   "storage": true,
-                  "subresources": {}
                 }
               ]
             }
@@ -247,16 +243,13 @@ fn normal_enum() {
             "spec": {
               "group": "clux.dev",
               "names": {
-                "categories": [],
                 "kind": "NormalEnumTest",
                 "plural": "normalenumtests",
-                "shortNames": [],
                 "singular": "normalenumtest"
               },
               "scope": "Cluster",
               "versions": [
                 {
-                  "additionalPrinterColumns": [],
                   "name": "v1",
                   "schema": {
                     "openAPIV3Schema": {
@@ -290,7 +283,6 @@ fn normal_enum() {
                   },
                   "served": true,
                   "storage": true,
-                  "subresources": {}
                 }
               ]
             }
@@ -313,16 +305,13 @@ fn optional_enum() {
             "spec": {
               "group": "clux.dev",
               "names": {
-                "categories": [],
                 "kind": "OptionalEnumTest",
                 "plural": "optionalenumtests",
-                "shortNames": [],
                 "singular": "optionalenumtest"
               },
               "scope": "Cluster",
               "versions": [
                 {
-                  "additionalPrinterColumns": [],
                   "name": "v1",
                   "schema": {
                     "openAPIV3Schema": {
@@ -354,7 +343,6 @@ fn optional_enum() {
                   },
                   "served": true,
                   "storage": true,
-                  "subresources": {}
                 }
               ]
             }
@@ -377,16 +365,13 @@ fn normal_enum_without_descriptions() {
               "spec": {
                 "group": "clux.dev",
                 "names": {
-                  "categories": [],
                   "kind": "NormalEnumWithoutDescriptionsTest",
                   "plural": "normalenumwithoutdescriptionstests",
-                  "shortNames": [],
                   "singular": "normalenumwithoutdescriptionstest"
                 },
                 "scope": "Cluster",
                 "versions": [
                   {
-                    "additionalPrinterColumns": [],
                     "name": "v1",
                     "schema": {
                       "openAPIV3Schema": {
@@ -419,7 +404,6 @@ fn normal_enum_without_descriptions() {
                     },
                     "served": true,
                     "storage": true,
-                    "subresources": {}
                   }
                 ]
               }
@@ -441,15 +425,12 @@ fn optional_complex_enum() {
             "spec": {
                 "group": "clux.dev",
                 "names": {
-                    "categories": [],
                     "kind": "OptionalComplexEnumTest",
                     "plural": "optionalcomplexenumtests",
-                    "shortNames": [],
                     "singular": "optionalcomplexenumtest"
                 },
                 "scope": "Cluster",
                 "versions": [{
-                    "additionalPrinterColumns": [],
                     "name": "v1",
                     "schema": {
                         "openAPIV3Schema": {
@@ -507,7 +488,6 @@ fn optional_complex_enum() {
                     },
                     "served": true,
                     "storage": true,
-                    "subresources": {}
                 }]
             }
         })
@@ -528,16 +508,13 @@ fn flattened_untagged_enum() {
             "spec": {
               "group": "clux.dev",
               "names": {
-                "categories": [],
                 "kind": "FlattenedUntaggedEnumTest",
                 "plural": "flatteneduntaggedenumtests",
-                "shortNames": [],
                 "singular": "flatteneduntaggedenumtest"
               },
               "scope": "Cluster",
               "versions": [
                 {
-                  "additionalPrinterColumns": [],
                   "name": "v1",
                   "schema": {
                     "openAPIV3Schema": {
@@ -597,7 +574,6 @@ fn flattened_untagged_enum() {
                   },
                   "served": true,
                   "storage": true,
-                  "subresources": {}
                 }
               ]
             }

--- a/kube-derive/tests/crd_enum_test.rs
+++ b/kube-derive/tests/crd_enum_test.rs
@@ -70,16 +70,13 @@ fn test_crd_schema_matches_expected() {
           "spec": {
             "group": "clux.dev",
             "names": {
-              "categories": [],
               "kind": "FooEnum",
               "plural": "fooenums",
-              "shortNames": [],
               "singular": "fooenum"
             },
             "scope": "Cluster",
             "versions": [
               {
-                "additionalPrinterColumns": [],
                 "name": "v1",
                 "schema": {
                   "openAPIV3Schema": {
@@ -146,7 +143,6 @@ fn test_crd_schema_matches_expected() {
                 },
                 "served": true,
                 "storage": true,
-                "subresources": {}
               }
             ]
           }

--- a/kube-derive/tests/crd_mixed_enum_test.rs
+++ b/kube-derive/tests/crd_mixed_enum_test.rs
@@ -113,16 +113,13 @@ fn valid_enum_3() {
             "spec": {
               "group": "clux.dev",
               "names": {
-                "categories": [],
                 "kind": "ValidEnum3",
                 "plural": "validenum3s",
-                "shortNames": [],
                 "singular": "validenum3"
               },
               "scope": "Cluster",
               "versions": [
                 {
-                  "additionalPrinterColumns": [],
                   "name": "v1",
                   "schema": {
                     "openAPIV3Schema": {
@@ -166,7 +163,6 @@ fn valid_enum_3() {
                   },
                   "served": true,
                   "storage": true,
-                  "subresources": {}
                 }
               ]
             }
@@ -189,16 +185,13 @@ fn valid_enum_4() {
             "spec": {
               "group": "clux.dev",
               "names": {
-                "categories": [],
                 "kind": "ValidEnum4",
                 "plural": "validenum4s",
-                "shortNames": [],
                 "singular": "validenum4"
               },
               "scope": "Cluster",
               "versions": [
                 {
-                  "additionalPrinterColumns": [],
                   "name": "v1",
                   "schema": {
                     "openAPIV3Schema": {
@@ -247,7 +240,6 @@ fn valid_enum_4() {
                   },
                   "served": true,
                   "storage": true,
-                  "subresources": {}
                 }
               ]
             }
@@ -276,16 +268,13 @@ fn valid_enum_6() {
               "spec": {
                 "group": "clux.dev",
                 "names": {
-                  "categories": [],
                   "kind": "ValidEnum6",
                   "plural": "validenum6s",
-                  "shortNames": [],
                   "singular": "validenum6"
                 },
                 "scope": "Cluster",
                 "versions": [
                   {
-                    "additionalPrinterColumns": [],
                     "name": "v1",
                     "schema": {
                       "openAPIV3Schema": {
@@ -330,7 +319,6 @@ fn valid_enum_6() {
                     },
                     "served": true,
                     "storage": true,
-                    "subresources": {}
                   }
                 ]
               }


### PR DESCRIPTION
## Motivation

`#[derive(CustomResource)]` builds the CRD by assembling an untyped `serde_json::json!` blob and deserializing it back into `CustomResourceDefinition`. Optional list properties were therefore always emitted: unset `categories`, `shortNames` and `additionalPrinterColumns` attributes became explicit empty lists, and status-less CRDs got an empty `subresources` object.

The apiserver drops empty lists on apply (Go `omitempty`), so the live object never matches the applied manifest, and GitOps tools that diff desired against live report perpetual drift. Reported for Argo CD in #1678 / #1680, worked around downstream with manual pruning (stackabletech/hdfs-operator#626, restatedev/restate-operator#15, PortSwigger/randomsecret#18), and also reported for Pulumi in #1751.

## Fix

Construct the typed `CustomResourceDefinition` directly instead of the json round-trip:

- unset attributes are now a plain `None`, absent from the serialized CRD
- the runtime json blob build, the three `from_str` round-trips and the whole-CRD `from_value().expect()` panic path disappear; the only remaining runtime conversion is `schemars::Schema` into `JSONSchemaProps` (there is no direct conversion between the two crates)
- typos in the construction are now compile errors instead of silently ignored json keys

## Behavior changes

Only for attributes that were not set: `crd().spec.names.categories` / `short_names` / `versions[0].additional_printer_columns` are now `None` instead of `Some(vec![])`, and `versions[0].subresources` is `None` instead of `Some` of an empty object for status-less CRDs. Code unwrapping these fields needs adjusting. Set attributes serialize exactly as before, and the exact-output tests only lose the empty keys.

## Verification

Beyond the test suite, verified against a real apiserver (kind) and a full Argo CD loop (k3d + gitea + auto-sync application):

- **old output**: applying and reading back shows the server dropping exactly the three empty lists, so the application stays **OutOfSync** forever even though every sync succeeds
- **new output**: manifest and live spec are byte-identical, and the same application reports **Synced**

The Argo CD side has no fix coming for this class of diff (argoproj/argo-cd#12686 is an `ignoreDifferences` convenience proposal, leaning towards closure), so emitting only what was set is the fix that works for every consumer.

<img width="1402" height="840" alt="1-outofsync-before" src="https://github.com/user-attachments/assets/a6649d48-0836-4eb4-b2d2-d3fe81954352" />
<img width="1402" height="840" alt="2-diff-empty-defaults" src="https://github.com/user-attachments/assets/45733c8d-c18c-4c51-a214-dadeaf9f9bce" />
<img width="1402" height="840" alt="3-synced-after" src="https://github.com/user-attachments/assets/a407c105-df15-40bc-aff0-cbcba00aae15" />



Fixes #1680
Supersedes #1751

