### PR TITLE
ignore multiple versions of syn

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -70,3 +70,7 @@ name = "r-efi"
 [[bans.skip]]
 # tungstenite needs to bump rand
 name = "rand_core"
+
+[[bans.skip]]
+# need some time to get the whole ecosystem to syn 3
+name = "syn"


### PR DESCRIPTION
monthly deny fix. syn has a version 3 now, and a lot of deps use syn.