### PR TITLE
kube-core: add generic owner-reference and finalizer helpers

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -89,6 +89,10 @@ name = "configmapgen_controller"
 path = "configmapgen_controller.rs"
 
 [[example]]
+name = "owner_finalizer_demo"
+path = "owner_finalizer_demo.rs"
+
+[[example]]
 name = "shared_stream_controllers"
 path = "shared_stream_controllers.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,15 @@ cargo run --example dynamic_jsonpath
 cargo run --example log_stream -- kafka-manager-7d4f4bd8dc-f6c44
 ```
 
+There's also an example exercising the generic owner-reference and finalizer helpers from
+`kube-core` (`set_controller_reference`, `ResourceExt::{has_finalizer,add_finalizer,remove_finalizer}`)
+against a real cluster, covering owner-reference conflicts, garbage-collector cascade delete, and
+finalizer-blocked deletion:
+
+```sh
+cargo run --example owner_finalizer_demo
+```
+
 ## kubectl light example
 
 The `kubectl` light example supports `get`, `delete`, and `watch` on arbitrary resources:

--- a/examples/owner_finalizer_demo.rs
+++ b/examples/owner_finalizer_demo.rs
@@ -1,0 +1,120 @@
+//! Exercises the generic owner-reference and finalizer helpers from `kube-core`
+//! (see <https://github.com/kube-rs/kube/issues/428>) against a real apiserver.
+//!
+//! Demonstrates:
+//! - `set_controller_reference` / `set_owner_reference` and the `AlreadyOwnedError` conflict check
+//! - the apiserver's garbage collector cascading a delete via the controller owner reference
+//! - `ResourceExt::{has_finalizer, add_finalizer, remove_finalizer}` blocking and then unblocking a delete
+use k8s_openapi::api::core::v1::ConfigMap;
+use kube::{
+    Client, Resource,
+    api::{Api, DeleteParams, Patch, PatchParams, PostParams, ResourceExt},
+    core::{AlreadyOwnedError, has_owner_reference, set_controller_reference},
+};
+use tracing::info;
+
+async fn create_configmap(api: &Api<ConfigMap>, name: &str) -> anyhow::Result<ConfigMap> {
+    let cm = serde_json::from_value(serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": { "name": name },
+    }))?;
+    Ok(api.create(&PostParams::default(), &cm).await?)
+}
+
+async fn patch_owner_references(api: &Api<ConfigMap>, cm: &ConfigMap) -> anyhow::Result<ConfigMap> {
+    let patch = serde_json::json!({ "metadata": { "ownerReferences": cm.owner_references() } });
+    Ok(api
+        .patch(&cm.name_any(), &PatchParams::default(), &Patch::Merge(patch))
+        .await?)
+}
+
+async fn patch_finalizers(api: &Api<ConfigMap>, cm: &ConfigMap) -> anyhow::Result<ConfigMap> {
+    let patch = serde_json::json!({ "metadata": { "finalizers": cm.finalizers() } });
+    Ok(api
+        .patch(&cm.name_any(), &PatchParams::default(), &Patch::Merge(patch))
+        .await?)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let client = Client::try_default().await?;
+    let cms: Api<ConfigMap> = Api::default_namespaced(client);
+
+    // --- owner reference / garbage collection demo ---
+    info!("Creating owner and child ConfigMaps");
+    let owner = create_configmap(&cms, "owner-finalizer-demo-owner").await?;
+    let mut child = create_configmap(&cms, "owner-finalizer-demo-child").await?;
+
+    set_controller_reference(&owner, &(), &mut child)?;
+    let child = patch_owner_references(&cms, &child).await?;
+    let owner_uid = owner.uid().expect("created object has a uid");
+    assert!(has_owner_reference(&child, &owner_uid));
+    info!(
+        "Child now has a controller owner reference pointing at owner uid {}",
+        owner_uid
+    );
+
+    info!("Verifying a conflicting controller is rejected");
+    let other_owner = create_configmap(&cms, "owner-finalizer-demo-other-owner").await?;
+    let mut child_copy = child.clone();
+    let err: AlreadyOwnedError = set_controller_reference(&other_owner, &(), &mut child_copy).unwrap_err();
+    assert_eq!(err.existing_uid, owner_uid);
+    assert_eq!(err.new_uid, other_owner.uid().expect("created object has a uid"));
+    info!("Got expected conflict error: {err}");
+    cms.delete("owner-finalizer-demo-other-owner", &DeleteParams::default())
+        .await?;
+
+    info!("Deleting owner and waiting for the garbage collector to cascade-delete the child");
+    cms.delete("owner-finalizer-demo-owner", &DeleteParams::background())
+        .await?;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
+    loop {
+        if cms.get_opt("owner-finalizer-demo-child").await?.is_none() {
+            info!("Child was garbage collected");
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            anyhow::bail!("timed out waiting for garbage collector to delete the child");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+
+    // --- finalizer demo ---
+    info!("Creating a ConfigMap with a finalizer");
+    let mut protected = create_configmap(&cms, "owner-finalizer-demo-protected").await?;
+    assert!(!protected.has_finalizer("owner-finalizer-demo.kube.rs/cleanup"));
+    assert!(protected.add_finalizer("owner-finalizer-demo.kube.rs/cleanup"));
+    patch_finalizers(&cms, &protected).await?;
+
+    info!("Deleting it: the apiserver should keep it around until the finalizer is removed");
+    cms.delete("owner-finalizer-demo-protected", &DeleteParams::default())
+        .await?;
+    let still_there = cms
+        .get("owner-finalizer-demo-protected")
+        .await
+        .expect("object with an outstanding finalizer must not be gone yet");
+    assert!(still_there.meta().deletion_timestamp.is_some());
+    assert!(still_there.has_finalizer("owner-finalizer-demo.kube.rs/cleanup"));
+    info!("Confirmed: object is terminating but still present because of the finalizer");
+
+    let mut protected = still_there;
+    assert!(protected.remove_finalizer("owner-finalizer-demo.kube.rs/cleanup"));
+    patch_finalizers(&cms, &protected).await?;
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        if cms.get_opt("owner-finalizer-demo-protected").await?.is_none() {
+            info!("Object was deleted once the finalizer was removed");
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            anyhow::bail!("timed out waiting for the object to be deleted after removing the finalizer");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+
+    info!("All checks passed");
+    Ok(())
+}

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -44,6 +44,9 @@ pub mod labels;
 pub mod object;
 pub use object::{NotUsed, Object, ObjectList};
 
+pub mod owner_ref;
+pub use owner_ref::{AlreadyOwnedError, has_owner_reference, set_controller_reference, set_owner_reference};
+
 pub mod params;
 
 pub mod request;

--- a/kube-core/src/owner_ref.rs
+++ b/kube-core/src/owner_ref.rs
@@ -1,0 +1,176 @@
+//! Generic helpers for managing owner references between resources.
+use crate::resource::{Resource, ResourceExt};
+
+/// Error returned by [`set_controller_reference`] when `controlled` is already
+/// controlled by a different owner.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "object already has a different controller (uid {existing_uid:?}), cannot set controller (uid {new_uid:?})"
+)]
+pub struct AlreadyOwnedError {
+    /// The `uid` of the owner reference already marked as controller on the object
+    pub existing_uid: String,
+    /// The `uid` of the new owner that was requested to become the controller
+    pub new_uid: String,
+}
+
+/// Returns whether `controlled` has an owner reference with the given `uid`
+///
+/// ```
+/// use k8s_openapi::api::core::v1::{ConfigMap, Pod};
+/// use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+/// use kube_core::{has_owner_reference, set_owner_reference};
+///
+/// let pod = Pod {
+///     metadata: ObjectMeta {
+///         name: Some("my-pod".to_string()),
+///         uid: Some("pod-uid".to_string()),
+///         ..Default::default()
+///     },
+///     ..Default::default()
+/// };
+/// let mut cm = ConfigMap::default();
+/// assert!(!has_owner_reference(&cm, "pod-uid"));
+/// set_owner_reference(&pod, &(), &mut cm);
+/// assert!(has_owner_reference(&cm, "pod-uid"));
+/// ```
+pub fn has_owner_reference<K: Resource>(controlled: &K, uid: &str) -> bool {
+    controlled.owner_references().iter().any(|o| o.uid == uid)
+}
+
+/// Sets `owner` as a (non-controlling) owner reference on `controlled`
+///
+/// If `controlled` already has an owner reference with the same `uid`, it is replaced in place;
+/// otherwise the new owner reference is appended.
+///
+/// Returns `None` if `owner` does not have a `.metadata.name`/`.metadata.uid` set yet (see
+/// [`Resource::owner_ref`]), in which case `controlled` is left unchanged.
+pub fn set_owner_reference<Owner: Resource, K: Resource>(
+    owner: &Owner,
+    dt: &Owner::DynamicType,
+    controlled: &mut K,
+) -> Option<()> {
+    let new_ref = owner.owner_ref(dt)?;
+    upsert_owner_reference(controlled, new_ref);
+    Some(())
+}
+
+/// Sets `owner` as the controller reference on `controlled`
+///
+/// Errors with [`AlreadyOwnedError`] if `controlled` already has a controller reference pointing
+/// at a *different* owner. Idempotent (a no-op returning `Ok(())`) if the existing controller
+/// reference already points at `owner`.
+///
+/// Returns `Ok(())` without changes if `owner` does not have a `.metadata.name`/`.metadata.uid` set yet.
+pub fn set_controller_reference<Owner: Resource, K: Resource>(
+    owner: &Owner,
+    dt: &Owner::DynamicType,
+    controlled: &mut K,
+) -> Result<(), AlreadyOwnedError> {
+    let Some(new_ref) = owner.controller_owner_ref(dt) else {
+        return Ok(());
+    };
+    if let Some(existing) = controlled
+        .owner_references()
+        .iter()
+        .find(|o| o.controller == Some(true))
+        && existing.uid != new_ref.uid
+    {
+        return Err(AlreadyOwnedError {
+            existing_uid: existing.uid.clone(),
+            new_uid: new_ref.uid,
+        });
+    }
+    upsert_owner_reference(controlled, new_ref);
+    Ok(())
+}
+
+fn upsert_owner_reference<K: Resource>(
+    controlled: &mut K,
+    new_ref: k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference,
+) {
+    let refs = controlled.owner_references_mut();
+    if let Some(existing) = refs.iter_mut().find(|o| o.uid == new_ref.uid) {
+        *existing = new_ref;
+    } else {
+        refs.push(new_ref);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{has_owner_reference, set_controller_reference, set_owner_reference};
+    use crate::resource::ResourceExt;
+    use k8s_openapi::{
+        api::core::v1::{ConfigMap, Pod},
+        apimachinery::pkg::apis::meta::v1::ObjectMeta,
+    };
+
+    fn pod(name: &str, uid: &str) -> Pod {
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                uid: Some(uid.to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn set_owner_reference_appends_and_replaces() {
+        let owner = pod("owner", "owner-uid");
+        let mut cm = ConfigMap::default();
+
+        set_owner_reference(&owner, &(), &mut cm).unwrap();
+        assert!(has_owner_reference(&cm, "owner-uid"));
+        assert_eq!(cm.owner_references().len(), 1);
+
+        // Setting again with the same uid replaces in place rather than duplicating
+        set_owner_reference(&owner, &(), &mut cm).unwrap();
+        assert_eq!(cm.owner_references().len(), 1);
+    }
+
+    #[test]
+    fn set_controller_reference_is_idempotent() {
+        let owner = pod("owner", "owner-uid");
+        let mut cm = ConfigMap::default();
+
+        set_controller_reference(&owner, &(), &mut cm).unwrap();
+        assert!(cm.owner_references()[0].controller == Some(true));
+
+        // Re-setting the same controller is a no-op success
+        set_controller_reference(&owner, &(), &mut cm).unwrap();
+        assert_eq!(cm.owner_references().len(), 1);
+    }
+
+    #[test]
+    fn set_controller_reference_rejects_conflicting_owner() {
+        let owner = pod("owner", "owner-uid");
+        let other = pod("other", "other-uid");
+        let mut cm = ConfigMap::default();
+
+        set_controller_reference(&owner, &(), &mut cm).unwrap();
+        let err = set_controller_reference(&other, &(), &mut cm).unwrap_err();
+        assert_eq!(err.existing_uid, "owner-uid");
+        assert_eq!(err.new_uid, "other-uid");
+    }
+
+    #[test]
+    fn set_controller_reference_is_noop_for_unnamed_owner() {
+        let owner = Pod::default(); // no name/uid set yet
+        let mut cm = ConfigMap::default();
+
+        set_controller_reference(&owner, &(), &mut cm).unwrap();
+        assert!(cm.owner_references().is_empty());
+    }
+
+    #[test]
+    fn set_owner_reference_is_noop_for_unnamed_owner() {
+        let owner = Pod::default(); // no name/uid set yet
+        let mut cm = ConfigMap::default();
+
+        assert!(set_owner_reference(&owner, &(), &mut cm).is_none());
+        assert!(cm.owner_references().is_empty());
+    }
+}

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -282,6 +282,16 @@ pub trait ResourceExt: Resource {
     fn finalizers(&self) -> &[String];
     /// Provides mutable access to the finalizers
     fn finalizers_mut(&mut self) -> &mut Vec<String>;
+    /// Returns whether the given finalizer is present
+    fn has_finalizer(&self, name: &str) -> bool;
+    /// Adds a finalizer if it is not already present
+    ///
+    /// Returns `true` if the finalizer was added, `false` if it was already present.
+    fn add_finalizer(&mut self, name: &str) -> bool;
+    /// Removes a finalizer if present
+    ///
+    /// Returns `true` if the finalizer was removed, `false` if it was not present.
+    fn remove_finalizer(&mut self, name: &str) -> bool;
     /// Returns managed fields
     fn managed_fields(&self) -> &[ManagedFieldsEntry];
     /// Provides mutable access to managed fields
@@ -351,11 +361,57 @@ impl<K: Resource> ResourceExt for K {
         self.meta_mut().finalizers.get_or_insert_with(Vec::new)
     }
 
+    fn has_finalizer(&self, name: &str) -> bool {
+        self.finalizers().iter().any(|f| f == name)
+    }
+
+    fn add_finalizer(&mut self, name: &str) -> bool {
+        if self.has_finalizer(name) {
+            return false;
+        }
+        self.finalizers_mut().push(name.to_string());
+        true
+    }
+
+    fn remove_finalizer(&mut self, name: &str) -> bool {
+        let finalizers = self.finalizers_mut();
+        let len_before = finalizers.len();
+        finalizers.retain(|f| f != name);
+        finalizers.len() != len_before
+    }
+
     fn managed_fields(&self) -> &[ManagedFieldsEntry] {
         self.meta().managed_fields.as_deref().unwrap_or_default()
     }
 
     fn managed_fields_mut(&mut self) -> &mut Vec<ManagedFieldsEntry> {
         self.meta_mut().managed_fields.get_or_insert_with(Vec::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ResourceExt;
+    use k8s_openapi::api::core::v1::Pod;
+
+    #[test]
+    fn finalizer_add_is_idempotent() {
+        let mut pod = Pod::default();
+        assert!(!pod.has_finalizer("my.finalizer"));
+        assert!(pod.add_finalizer("my.finalizer"));
+        assert!(pod.has_finalizer("my.finalizer"));
+        // Adding again is a no-op
+        assert!(!pod.add_finalizer("my.finalizer"));
+        assert_eq!(pod.finalizers(), &["my.finalizer".to_string()]);
+    }
+
+    #[test]
+    fn finalizer_remove_reports_whether_anything_changed() {
+        let mut pod = Pod::default();
+        pod.add_finalizer("my.finalizer");
+        assert!(pod.remove_finalizer("my.finalizer"));
+        assert!(!pod.has_finalizer("my.finalizer"));
+        // Removing again is a no-op
+        assert!(!pod.remove_finalizer("my.finalizer"));
     }
 }


### PR DESCRIPTION
## Motivation

#428 asks for generic controller-authoring helpers in `kube-core`, mirroring
controller-runtime's `controllerutil`. Today `ResourceExt` only exposes raw
accessors (`finalizers_mut()`, `owner_references_mut()`), so every reconciler
hand-rolls the same scan-and-mutate logic to add a finalizer or attach an
owner reference.

## Solution

- `ResourceExt::{has_finalizer, add_finalizer, remove_finalizer}` — idempotent
  helpers on the existing accessors.
- `set_owner_reference` / `set_controller_reference` / `has_owner_reference` +
  `AlreadyOwnedError` — free functions (owner and child are different resource
  types) built on the existing `Resource::owner_ref`/`controller_owner_ref`.
  `set_controller_reference` rejects overwriting a *different* existing
  controller, and is a no-op if reapplied with the same one.

## Verification

Unit/doc tests in `kube-core`, plus `examples/owner_finalizer_demo.rs` exercising
both against a real cluster (kind): conflicting-controller rejection, garbage
collector cascade-delete via the owner reference, and finalizer-blocked deletion.

Fixes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)