### PR TITLE
derive: Run integration tests locally and in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Run workspace unit tests (all features)
         if: matrix.os != 'windows-latest'
         run: cargo test --workspace --lib --all-features --exclude kube-examples --exclude e2e -j6
+      # kube-derive integration (UI) tests
+      - name: Run kube-derive integration tests
+        run: cargo test -p kube-derive --tests -j6
+        if: matrix.os == 'ubuntu-latest'
       # Workspace documentation (all features only)
       - name: Run workspace doc tests
         run: cargo test --workspace --doc --all-features --exclude kube-examples --exclude e2e -j6
@@ -145,8 +149,8 @@ jobs:
       matrix:
         # Run these tests against older clusters as well
         k8s:
-        - "v1.32" # MK8SV
-        - "latest"
+          - "v1.32" # MK8SV
+          - "latest"
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable

--- a/justfile
+++ b/justfile
@@ -39,6 +39,8 @@ test:
   cargo test --workspace --doc --all-features --exclude kube-examples --exclude e2e
   cargo test -p kube-examples --examples
   cargo test -p kube-examples --examples --all-features
+  # --lib misses integration tests; kube-derive is the only member with tests/
+  cargo test -p kube-derive --tests
 
 # Integration tests (will modify your current context's cluster)
 test-integration:

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -321,7 +321,7 @@ where
 mod tests {
     #[cfg(feature = "gzip")] use super::*;
 
-    #[cfg(feature = "gzip")]
+    #[cfg(all(feature = "gzip", feature = "rustls-tls"))]
     #[tokio::test]
     async fn test_no_accept_encoding_header_sent_when_compression_disabled()
     -> Result<(), Box<dyn std::error::Error>> {

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -329,6 +329,10 @@ mod tests {
         use std::net::SocketAddr;
         use tokio::net::{TcpListener, TcpStream};
 
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .expect("to install the aws_lc_rs crypto provider");
+
         // setup a server that echoes back any encoding header value
         let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
         let listener = TcpListener::bind(addr).await?;

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -328,11 +328,7 @@ mod tests {
         use http::Uri;
         use std::net::SocketAddr;
         use tokio::net::{TcpListener, TcpStream};
-
-        rustls::crypto::aws_lc_rs::default_provider()
-            .install_default()
-            .expect("to install the aws_lc_rs crypto provider");
-
+        
         // setup a server that echoes back any encoding header value
         let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
         let listener = TcpListener::bind(addr).await?;


### PR DESCRIPTION
Discovered in https://github.com/kube-rs/kube/pull/2050 and discussed in https://github.com/kube-rs/kube/issues/2051.

With this PR, the integration tests for `kube-derive` are now run when executing `just test` and when CI runs them via the `ci.yml` workflow.