### PR TITLE
Allow PredicateFilter to work with dynamic objects

### DIFF
--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -461,4 +461,60 @@ pub(crate) mod tests {
         let second = filtered.next().now_or_never().unwrap().unwrap().unwrap();
         assert_eq!(second.meta().generation, Some(1));
     }
+
+    #[tokio::test]
+    async fn predicate_filter_compiles_with_dynamic_resource() {
+        use kube::api::DynamicObject;
+
+        let obj: DynamicObject = serde_json::from_value(json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "blog",
+                "generation": Some(1),
+            },
+        }))
+        .unwrap();
+        let data = stream::iter([Ok(obj)]);
+        let mut rx = pin!(PredicateFilter::new(
+            data,
+            predicates::generation,
+            Config::default()
+        ));
+
+        let first = rx.next().now_or_never().unwrap().unwrap().unwrap();
+        assert_eq!(first.meta().generation, Some(1));
+
+        // Mostly, this check is ensuring that predicate filters compile with
+        // `DynamicObject`, not testing any behaviour.
+    }
+
+    #[tokio::test]
+    async fn predicate_filter_compiles_with_custom_type() {
+        use kube::api::Object;
+        use kube_client::api::NotUsed;
+
+        let obj: Object<NotUsed, NotUsed> = serde_json::from_value(json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "blog",
+                "generation": Some(1),
+            },
+            "spec": {},
+        }))
+        .unwrap();
+        let data = stream::iter([Ok(obj)]);
+        let mut rx = pin!(PredicateFilter::new(
+            data,
+            predicates::generation,
+            Config::default()
+        ));
+
+        let first = rx.next().now_or_never().unwrap().unwrap().unwrap();
+        assert_eq!(first.meta().generation, Some(1));
+
+        // Mostly, this check is ensuring that predicate filters compile with
+        // `DynamicObject`, not testing any behaviour.
+    }
 }

--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -488,33 +488,4 @@ pub(crate) mod tests {
         // Mostly, this check is ensuring that predicate filters compile with
         // `DynamicObject`, not testing any behaviour.
     }
-
-    #[tokio::test]
-    async fn predicate_filter_compiles_with_custom_type() {
-        use kube::api::Object;
-        use kube_client::api::NotUsed;
-
-        let obj: Object<NotUsed, NotUsed> = serde_json::from_value(json!({
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {
-                "name": "blog",
-                "generation": Some(1),
-            },
-            "spec": {},
-        }))
-        .unwrap();
-        let data = stream::iter([Ok(obj)]);
-        let mut rx = pin!(PredicateFilter::new(
-            data,
-            predicates::generation,
-            Config::default()
-        ));
-
-        let first = rx.next().now_or_never().unwrap().unwrap().unwrap();
-        assert_eq!(first.meta().generation, Some(1));
-
-        // Mostly, this check is ensuring that predicate filters compile with
-        // `DynamicObject`, not testing any behaviour.
-    }
 }

--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -190,7 +190,6 @@ impl<St, K, P> Stream for PredicateFilter<St, K, P>
 where
     St: Stream<Item = Result<K, Error>>,
     K: Resource,
-    K::DynamicType: Eq + Hash,
     P: Predicate<K>,
 {
     type Item = Result<K, Error>;

--- a/kube-runtime/src/utils/predicate.rs
+++ b/kube-runtime/src/utils/predicate.rs
@@ -190,7 +190,7 @@ impl<St, K, P> Stream for PredicateFilter<St, K, P>
 where
     St: Stream<Item = Result<K, Error>>,
     K: Resource,
-    K::DynamicType: Default + Eq + Hash,
+    K::DynamicType: Eq + Hash,
     P: Predicate<K>,
 {
     type Item = Result<K, Error>;


### PR DESCRIPTION
## Motivation

Closes #2053.

## Solution

Remove the no longer necessary `Default` bound. I think this was previously necessary due to the construction by `ObjectRef::from_obj`, which was removed in #1836.